### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,5 @@ Known Issues
 ------------
 
 - `Show in your File Manager` does not open the file manager
+
 This happens because the default manager is not set in your environment. You need to a default file manager to your `~/.config/mimeapps.list` file. If you are using nautilus, this can be done by adding `inode/directory=org.gnome.Nautilus.desktop` to the end of the `[Default Applications]` section.

--- a/README.md
+++ b/README.md
@@ -43,3 +43,9 @@ To update `desktop` repo to its latest commit and update the dependencies, you h
 4. Make sure the patches in the `patches` directory still apply.
 
 5. Once you are sure it works, make a PR with the changes.
+
+Known Issues
+------------
+
+- `Show in your File Manager` does not open the file manager
+This happens because the default manager is not set in your environment. You need to a default file manager to your `~/.config/mimeapps.list` file. If you are using nautilus, this can be done by adding `inode/directory=org.gnome.Nautilus.desktop` to the end of the `[Default Applications]` section.

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Known Issues
 
 - `Show in your File Manager` does not open the file manager
 
-This happens because the default manager is not set in your environment. You need to a default file manager to your `~/.config/mimeapps.list` file. If you are using nautilus, this can be done by adding `inode/directory=org.gnome.Nautilus.desktop` to the end of the `[Default Applications]` section.
+    This happens because the default manager is not set in your environment. You need to a default file manager to your `~/.config/mimeapps.list` file. If you are using nautilus, this can be done by adding `inode/directory=org.gnome.Nautilus.desktop` to the end of the `[Default Applications]` section.


### PR DESCRIPTION
This is regarding flathub#4. The problem here is that on GNOME, there is no option in GNOME Control Center to set the default manager - it will default to using Nautilus out of the box. Github Desktop, however, expects the default file manager to be explicitly set, thus the user need to manually add the setting to their mimeapps.list. 

I think adding this section would help someone having the same issue and save them time looking up a solution.