### PR TITLE
Removing pulseaudio socket

### DIFF
--- a/io.github.shiftey.Desktop.yaml
+++ b/io.github.shiftey.Desktop.yaml
@@ -11,7 +11,6 @@ separate-locales: false
 finish-args:
   - --share=ipc
   - --socket=x11
-  - --socket=pulseaudio
   - --socket=ssh-auth
   - --share=network
   - --device=all


### PR DESCRIPTION
This is related to the discussion in https://github.com/flathub/io.github.shiftey.Desktop/issues/4. I have tested the app without the pulseaudio socket on my system, and it works just fine. I don't really see reason why the app needs to play or record audio at all.