### PR TITLE
Add xdg-run/gnupg permission

### DIFF
--- a/io.github.shiftey.Desktop.yaml
+++ b/io.github.shiftey.Desktop.yaml
@@ -18,6 +18,7 @@ finish-args:
   - --filesystem=/opt/:ro
   - --filesystem=/xdg-data/flatpak/app:ro
   - --filesystem=xdg-run/keyring
+  - --filesystem=xdg-run/gnupg:ro
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.freedesktop.Notifications


### PR DESCRIPTION
This does not fully fix the problem where GitHub desktop cannot sign a commit if a GPG key has a passphrase, but it does fix it if said key is already unlocked by the gpg-agent. (https://github.com/shiftkey/desktop/issues/565)

If you try to make a git commit directly on the host system, type in the passphrase, then any subsequent commits made by GitHub Desktop Flatpak works fine.

Having --filesystem=host is not enough, because the gpg key could be stored in a smartcard/yubikey instead.