### PR TITLE
Metainfo: Properly capitalize GitHub

### DIFF
--- a/io.github.shiftey.Desktop.metainfo.xml
+++ b/io.github.shiftey.Desktop.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>io.github.shiftey.Desktop</id>
-  <name>Github Desktop</name>
+  <name>GitHub Desktop</name>
   <summary>Simple collaboration from your desktop</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>


### PR DESCRIPTION
Looks like this part of #26 was accidentally reverted/undone when #27 was merged.