### PR TITLE
Add AppMenu to finish args

### DIFF
--- a/io.github.shiftey.Desktop.yaml
+++ b/io.github.shiftey.Desktop.yaml
@@ -24,6 +24,7 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.gtk.vfs.*
+  - --talk-name=com.canonical.AppMenu.Registrar
   - --filesystem=~/.gnupg:rw
   - --filesystem=xdg-config/gnupg:rw
   - --filesystem=xdg-run/gnupg


### PR DESCRIPTION
This pull request adds a new entry to the finish args to enable Global Menu widgets from kde and xfce to recognize the GitHub's desktop global menu and integrate them.

Image 1: Example without the new finish args
![Screenshot_20220530_155012](https://user-images.githubusercontent.com/51462138/171047193-75a81f75-192a-4108-a625-5d21fd396cf5.png)

Image 2: Example with the new finish args
![Screenshot_20220530_154945](https://user-images.githubusercontent.com/51462138/171047215-d6525d84-d016-4504-9640-29f628a5fc56.png)


