### PR TITLE
update to release-3.4.3-linux1

### DIFF
--- a/generated-sources.json
+++ b/generated-sources.json
@@ -1,30 +1,37 @@
 [
     {
         "type": "archive",
-        "url": "https://electronjs.org/headers/v28.3.3/node-v28.3.3-headers.tar.gz",
+        "url": "https://electronjs.org/headers/v30.0.8/node-v30.0.8-headers.tar.gz",
         "strip-components": 1,
-        "sha256": "fd12e36ec3278b99d80c422c2c1c593ccf6fabce2dea75c14d34a0e5cd3b80b4",
-        "dest": "flatpak-node/cache/node-gyp/28.3.3"
+        "sha256": "48352f6b7548ce17e61d3db8647fb6b980db023997aea5e6ed437aea49b03ace",
+        "dest": "flatpak-node/cache/node-gyp/30.0.8"
     },
     {
         "type": "archive",
-        "url": "https://www.electronjs.org/headers/v28.3.3/node-v28.3.3-headers.tar.gz",
+        "url": "https://www.electronjs.org/headers/v30.0.8/node-v30.0.8-headers.tar.gz",
         "strip-components": 1,
-        "sha256": "fd12e36ec3278b99d80c422c2c1c593ccf6fabce2dea75c14d34a0e5cd3b80b4",
-        "dest": "flatpak-node/cache/node-gyp/28.3.3"
+        "sha256": "48352f6b7548ce17e61d3db8647fb6b980db023997aea5e6ed437aea49b03ace",
+        "dest": "flatpak-node/cache/node-gyp/30.0.8"
     },
     {
         "type": "file",
-        "url": "https://codeload.github.com/desktop/desktop-trampoline/tar.gz/cbd3dbb31d0d3ea9f325067f48bfbf60b6663a57",
-        "sha256": "4888fd3b0c2a07d4ff83d5ef2a2a20f89b6fcdefaadc791ea2ecc7c7bd33906d",
-        "dest-filename": "cbd3dbb31d0d3ea9f325067f48bfbf60b6663a57",
+        "url": "https://codeload.github.com/desktop/desktop-trampoline/tar.gz/8f6ceec51d9434d4ada9022bb7d62f01f1d8f51b",
+        "sha256": "f1f9f2f2f4dccb805ebbffbc8bab69c477e8c5e641ec19cab4ca36f200d2c91c",
+        "dest-filename": "8f6ceec51d9434d4ada9022bb7d62f01f1d8f51b",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4/dugite-native-v2.43.4-f5c5df6-ubuntu-x64.tar.gz",
-        "sha256": "0e67961bfac757841ccf6888be3f0371c095a4bc8621eaf25e652a679cdc1b7b",
-        "dest-filename": "dugite-native-v2.43.4-f5c5df6-ubuntu-x64.tar.gz",
+        "url": "https://codeload.github.com/kpdecker/istanbul/tar.gz/dd1228d2f0a6e8506cbb5dba398a8297b1dbaf22",
+        "sha256": "01247fc72f596f2404b6597c56146e38b38761b79c5ee2569922dbf302ec7a8c",
+        "dest-filename": "dd1228d2f0a6e8506cbb5dba398a8297b1dbaf22",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://github.com/desktop/dugite-native/releases/download/v2.45.1/dugite-native-v2.45.1-e87d290-ubuntu-x64.tar.gz",
+        "sha256": "cdf8c4cdca273e015d95c15fcc99e2322a97316f77f0b958b6b86424ca2b12da",
+        "dest-filename": "dugite-native-v2.45.1-e87d290-ubuntu-x64.tar.gz",
         "dest": "flatpak-node/tmp",
         "only-arches": [
             "x86_64"
@@ -32,9 +39,9 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4/dugite-native-v2.43.4-f5c5df6-ubuntu-arm64.tar.gz",
-        "sha256": "eb8b9a9343d42fd185f5f1037bcc20b94aa1cef5b858e25f1a047662aefdc38f",
-        "dest-filename": "dugite-native-v2.43.4-f5c5df6-ubuntu-arm64.tar.gz",
+        "url": "https://github.com/desktop/dugite-native/releases/download/v2.45.1/dugite-native-v2.45.1-e87d290-ubuntu-arm64.tar.gz",
+        "sha256": "21cec4d32ceec81efa146a40253a2f766a1d3b34a6e7c1fed1d87c7c553b3c99",
+        "dest-filename": "dugite-native-v2.45.1-e87d290-ubuntu-arm64.tar.gz",
         "dest": "flatpak-node/tmp",
         "only-arches": [
             "aarch64"
@@ -42,16 +49,16 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v28.3.3/SHASUMS256.txt",
-        "sha256": "1b50b9f98ad4572b8cc1ac9f1958ba3a09da6e21c2971809d4f64fec7fcabd8b",
-        "dest-filename": "SHASUMS256.txt-28.3.3",
+        "url": "https://github.com/electron/electron/releases/download/v30.0.8/SHASUMS256.txt",
+        "sha256": "3a9f7c715a103ae484cd70a098893207af9ec1e777d961a40fc426e0af174158",
+        "dest-filename": "SHASUMS256.txt-30.0.8",
         "dest": "flatpak-node/cache/electron"
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v28.3.3/electron-v28.3.3-linux-arm64.zip",
-        "sha256": "f77107266581a6b9880757876518df1c4bf6eeff5c193bb5de0a8f6c9902bd1f",
-        "dest-filename": "electron-v28.3.3-linux-arm64.zip",
+        "url": "https://github.com/electron/electron/releases/download/v30.0.8/electron-v30.0.8-linux-arm64.zip",
+        "sha256": "909527303de8d3479f2d62dc28939eb1aee12285377807627ffd42fe8bd4e754",
+        "dest-filename": "electron-v30.0.8-linux-arm64.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "aarch64"
@@ -59,9 +66,9 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v28.3.3/electron-v28.3.3-linux-armv7l.zip",
-        "sha256": "384d8b43f52b5350a438031ad12980418fc244b4b0aecfa5f7dcc3d6f103ebed",
-        "dest-filename": "electron-v28.3.3-linux-armv7l.zip",
+        "url": "https://github.com/electron/electron/releases/download/v30.0.8/electron-v30.0.8-linux-armv7l.zip",
+        "sha256": "eb53b9433e4f777e34e832d70c8b279a780d5dd4c373f55d8b00e3d56a8875fd",
+        "dest-filename": "electron-v30.0.8-linux-armv7l.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "arm"
@@ -69,9 +76,9 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v28.3.3/electron-v28.3.3-linux-x64.zip",
-        "sha256": "20f6be493cbd6c9924206e744b1c490af1f97f4735451b9dc19f0d305366d546",
-        "dest-filename": "electron-v28.3.3-linux-x64.zip",
+        "url": "https://github.com/electron/electron/releases/download/v30.0.8/electron-v30.0.8-linux-x64.zip",
+        "sha256": "d00ca370fb8cba0bb678c7ce116f26296416287addc81a9bdb3ce703e6d44a8e",
+        "dest-filename": "electron-v30.0.8-linux-x64.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "x86_64"
@@ -100,9 +107,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.1.0.tgz#72becdf17ee44b2d1ac5651fb12f1952c336fe23",
+        "sha512": "779472b13949ee19b0e53c38531831718de590c7bdda7f2c5c272e2cf0322001caea3f0379f0f0b469d554380e9eff919c4a2cba50c9f4d3ca40bdbb6c321dd2",
+        "dest-filename": "@ampproject-remapping-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630",
         "sha512": "945323253ac52f78fb2fdc81c7061f0aada4eaaab01f2cee525fd706789fefc3d64c96322ff75fa30407584deca7a53a673a968a22199e94cc3bdeb38648f0b6",
         "dest-filename": "@ampproject-remapping-2.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-4.0.0.tgz#8f5b45b7a0a79c6f4032de2101e0c221847efb62",
+        "sha512": "ddd8812c85413cf8778f8fa16f9968d08d43f92fcefd50c93c8e18e74d9aa41c66c04aa3c971b881348f154966e35b1265e67331aad3fc6ce8bf0f6457b027d3",
+        "dest-filename": "@ava-babel-plugin-throws-helper-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@ava/babel-preset-stage-4/-/babel-preset-stage-4-4.0.0.tgz#9be5a59ead170062e228bb6ffd2b29f0489424fd",
+        "sha512": "959115d5900dcdfcd260153a587484aeccbb8cb3db0f58888006e80123cc70aa3bc285678b9ff920a59e4f44710bcad8f34d8c164b6eaf738a130d896354efdb",
+        "dest-filename": "@ava-babel-preset-stage-4-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-6.0.0.tgz#639e8929d2cdc8863c1f16020ce644c525723cd4",
+        "sha512": "f1e2a1173669ed072ad552dfa02ef9820193f2742cf6af1f23196d538ef2081ed68bb63c41fea8a98d419b4cf4e1f21e736e2f120af410d8431c43941950ea9c",
+        "dest-filename": "@ava-babel-preset-transform-test-files-6.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -184,6 +219,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789",
+        "sha512": "8805ea527f0821e05335def6c6c16581a5c790c04cb7acb81c9a75b4868ae3ae4258b4ff7c6d5aa81ef292bf798071e69417466c579659fc81e0d249d2799e22",
+        "dest-filename": "@babel-code-frame-7.16.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e",
         "sha512": "5e4b6e856949e60fb74c95dce6ea5df4ab351eeb5202b8a4ea37f67808d817220e7f87a3dd137ed7ce1c65bcc3bdb3e7b932485213ca289137708b184e2013df",
         "dest-filename": "@babel-code-frame-7.22.13.tgz",
@@ -198,9 +240,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d",
+        "sha512": "dbb778959a28995ca8e7555e831236d3164fb921eeb2a6d06a0ff3b6b042ef07a05a84359cb4443d548a496f1bca14e5cd32b2344e227da4c0ea50a9ec98e917",
+        "dest-filename": "@babel-code-frame-7.5.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.17.0.tgz#86850b8597ea6962089770952075dcaabb8dba34",
+        "sha512": "dfdd9bc939691965ccbf815bc96c37b0067f16b5bf0ebc2a2c65e9cb499bc8d7bd4daaafd6683dc8e379fe8d1c9ebf176029054d96c2d5e57e73e2c044e82b9e",
+        "dest-filename": "@babel-compat-data-7.17.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.23.5.tgz#ffb878728bb6bdcb6f4510aa51b1be9afb8cfd98",
         "sha512": "b94dbb91f0d19617ca97ec3553abe9d7a22ebd22ed8c0c5d02b5573daf41bcb92bafb09822cc47e5a7691ce6de00663fe35facc9cb5458e675e346b646f9208f",
         "dest-filename": "@babel-compat-data-7.23.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/core/-/core-7.11.6.tgz#3a9455dc7387ff1bac45770650bc13ba04a15651",
+        "sha512": "5a972fd370069e69209bab92ea4f22c212304eb70fd26d7b4cbd67d6ccbba83d2a7a50eee1735e5b474dd261df6be19e8b6d75c8368ba047bf5656d743333806",
+        "dest-filename": "@babel-core-7.11.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/core/-/core-7.17.0.tgz#16b8772b0a567f215839f689c5ded6bb20e864d5",
+        "sha512": "c7fe446be44ee4cbc5f62cdee4379520226856b36fd0c8b646720006b644298bcf12995d5f06ae3e482f600d7b70a6ba5a95372e862f61bb84305b52345b1aac",
+        "dest-filename": "@babel-core-7.17.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -212,9 +282,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/core/-/core-7.7.4.tgz#37e864532200cb6b50ee9a4045f5f817840166ab",
+        "sha512": "f9b61bc79ea3e276019a9b16b673d4b0a5b735d9d8c5bab27eb3f6c3dc082c1b87cdd7c82b3f69ae27992b40c53f223392361551ee1092eb062f4eebe695f39d",
+        "dest-filename": "@babel-core-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/generator/-/generator-7.11.6.tgz#b868900f81b163b4d464ea24545c61cbac4dc620",
+        "sha512": "0d6b50d4f577afe70b6f24a81ebc27f5158480a3012cb99ae0e0509683d1c8362f7399ac24cf64bd32e8d589e525dd4ffd9b8a6dd962de28ebe6adc5bc0177b8",
+        "dest-filename": "@babel-generator-7.11.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.0.tgz#7bd890ba706cd86d3e2f727322346ffdbf98f65e",
+        "sha512": "2373a68afe8518e0b6f5db6566191f5ceea98249ae9094a54f6e908d5bd2d431997bf37349508f1b8d57d2d4b6d68664258968bdf8fda835a028ff829f86d7c7",
+        "dest-filename": "@babel-generator-7.17.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.5.tgz#17d0a1ea6b62f351d281350a5f80b87a810c4755",
         "sha512": "04fb2c087ac10fed18af1be239add0ce9ab084d217284b4e6b68d0ae6e05966902d9aa588119d07263d6886643946c6236d96d9d416894c7bce3dec4b2bcbe8c",
         "dest-filename": "@babel-generator-7.23.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.4.tgz#db651e2840ca9aa66f327dcec1dc5f5fa9611369",
+        "sha512": "9b9aa8d9681d3897b262780a2266e4c90ae750dd663dc79a1b9055f86d04de05ac6b897f8c24abc9625d336c7c3ae1803b287eddde695587d958288d16dca7c6",
+        "dest-filename": "@babel-generator-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz#bb3faf1e74b74bd547e867e48f551fa6b098b6ce",
+        "sha512": "d814264201022b360a14fa62c9ca05f6d95be4703896b5720262cb54ad7bec471002a8d52dc8946f6fd1fa7d5ba10f72e44355deecf666a88dc3b40c041c353a",
+        "dest-filename": "@babel-helper-annotate-as-pure-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz#06e66c5f299601e6c7da350049315e83209d551b",
+        "sha512": "986a23070216730183eab7ea8115d59556263c0bfb78ea487a6506ddd1a70dd098e0f69eef444e8a3dd799fac7e856b58756a20f29698256d9ca4b5fcf2a3f84",
+        "dest-filename": "@babel-helper-compilation-targets-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -226,9 +338,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz#6d5762359fd34f4da1500e4cff9955b5299aaf59",
+        "sha512": "32dfa304a6b12f4cdf3885ab7d0a677d808deffad2e862b1e820827eea2a55577ed7b47cccd0e5cd5626222f6ac9bdb03a4d34d8db264930f29a4232803507ec",
+        "dest-filename": "@babel-helper-create-regexp-features-plugin-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7",
+        "sha512": "48b2dbd00027e8f9147807ca24208e97d7b5479de94251807dce32e17b8c4597ea78c60b13474cd4b321a9b180946418d257f0e7fa21a185807bd575ca26d16a",
+        "dest-filename": "@babel-helper-environment-visitor-7.16.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz#96159db61d34a29dba454c959f5ae4a649ba9167",
         "sha512": "cdf79d488cc585ab7f8058567c7b605af95e7349ea07d604215ae9bb08ebb8b9577d44a703c7090749a21cac2a0e743b777d9a2a8db1b7cf3fc59a6dc316df84",
         "dest-filename": "@babel-helper-environment-visitor-7.22.20.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz#d2d3b20c59ad8c47112fa7d2a94bc09d5ef82f1a",
+        "sha512": "61d692cb3d67f20638e0498def1e38cc19fdcd0d51cb663edc64c0fb7bc7e8c8b391ed55c346960cceba14e6043f0f3ffea2a49aa39c92b1a04d86beeac71ea9",
+        "dest-filename": "@babel-helper-function-name-7.10.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz#f1ec51551fb1c8956bc8dd95f38523b6cf375f8f",
+        "sha512": "41f0df127214cb20524771edaed1840ae67a0c0c82918169ec61e5ef9bc5b539e7ea98ca78ad13d4307994b905bc179af0c75a894001c77a2c6e02f2227a1e8c",
+        "dest-filename": "@babel-helper-function-name-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -240,9 +380,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz#ab6e041e7135d436d8f0a3eca15de5b67a341a2e",
+        "sha512": "02790621d881844ba2c1da0c9ca9bb8df3dfa88b5986045a65f320d575f76d2db920d3a72cf8cf1b53e99da8e1f1eaa0b7990f2677eaad11ea16a9a328364bcd",
+        "dest-filename": "@babel-helper-function-name-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2",
+        "sha512": "12437760307e4910e0888527360726883dfad6d8be0156cbddfdc77a77fa76aa94cabe5d32ca2b9e8d2525626e2e10e1908e6c604a608facbd901f00394d48d8",
+        "dest-filename": "@babel-helper-get-function-arity-7.10.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz#ea08ac753117a669f1508ba06ebcc49156387419",
+        "sha512": "7e573e44b48e057ccdcd585c2eeeae8de1d4ac3ead00d00e539a23ad1c7f6acfad6f37fcfacb540a3efe21f451a006c466a8ff6a15c432c8e13a181e66cae74f",
+        "dest-filename": "@babel-helper-get-function-arity-7.16.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz#cb46348d2f8808e632f0ab048172130e636005f0",
+        "sha512": "41318a11d0a48e0ce07c9ddb032470178cb24f7a60faf0e06a7f034a2bead5e4b48308be286284e71f2445c6de1536ffebbde690ee523752197e609f039a3e10",
+        "dest-filename": "@babel-helper-get-function-arity-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246",
+        "sha512": "9b4e1dff43a9df81f9bfba5b670ea948a3fbc1e03a96c32f7e220031e22f918fd1e3142d05230512282ef504d9daa07ff65db6becc6d33c6be43c0b30f6e797e",
+        "dest-filename": "@babel-helper-hoist-variables-7.16.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz#c01a007dac05c085914e8fb652b339db50d823bb",
         "sha512": "c068e4f50655cef92703ac8a2145116fccd8de0ad709c399b7effb59ccbc3b6b9cb7186996650f90e76582836199d55e7b673dd895db7f5c6932d54d6dfa3147",
         "dest-filename": "@babel-helper-hoist-variables-7.22.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz#ae69c83d84ee82f4b42f96e2a09410935a8f26df",
+        "sha512": "25b165287167b51579a8ac37602d02bd09c36785ccc20cf305b95decbcb8323e1c6c5cb72b2c1c47c36d35cb514e831624e56f2c8349bf9db919deb0c15131fd",
+        "dest-filename": "@babel-helper-member-expression-to-functions-7.11.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620",
+        "sha512": "9c44091ea61abc8db5ee80fdface4c501ce4eb1d4896fa12f564cf7e01b8dc26cc11e4ad134bfeafe4ee716771f0a146a303c6bf23a40d3f7eec31de7480e757",
+        "dest-filename": "@babel-helper-module-imports-7.10.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437",
+        "sha512": "2d5b52e93aa324715cfa761e213468e952d7bdeef4c66abbc0f8564ea0c9bac2448069a4000096c0c89336bbdfa10a3a844845c00222c4d92f0748cf5c32fc5a",
+        "dest-filename": "@babel-helper-module-imports-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -254,9 +450,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz#e5a92529f8888bf319a6376abfbd1cebc491ad91",
+        "sha512": "74672b5fa2bd97cdb9f16163c832c9c2e54ac51e1765f534fef4d480e4185849d10fc9a0afea7877a7c250cabfcacd21e020adfd2e4985bbedc84ae35a8b8051",
+        "dest-filename": "@babel-helper-module-imports-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz#b16f250229e47211abdd84b34b64737c2ab2d359",
+        "sha512": "d36115bbc08e32e4d13b54c0cdd32da413db7ba690d70ffc7de3c3d988109b1654e20a4d59a2fd80adc9a7b77196452550224e4da49e03e1eb9b5051430a8886",
+        "dest-filename": "@babel-helper-module-transforms-7.11.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz#7665faeb721a01ca5327ddc6bba15a5cb34b6a41",
+        "sha512": "81aaad2c3c4910509e41b629f5a2c079f8e190a76329c761e8307b8e7888194dcfcf9d960263f6ebcccad1580fcfd85436431261e1fdefa2b6fd8eb23da7699e",
+        "dest-filename": "@babel-helper-module-transforms-7.16.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz#d7d12c3c5d30af5b3c0fcab2a6d5217773e2d0f1",
         "sha512": "edb06ce040fd3a6b3075f0f3a73e0ca56812ad5ec55e5737cc86a0bcb1634b91fe324ed29ebdb5bd0e90c2bb2808631f342e1ee0b40f76850b12de32933d1245",
         "dest-filename": "@babel-helper-module-transforms-7.23.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.7.4.tgz#8d7cdb1e1f8ea3d8c38b067345924ac4f8e0879a",
+        "sha512": "7a1181bb8997ae1b3417102a37cb5693317c19220602212e9aee0e359fe10fd33cf2e1dc0fe62edadb4a7ce0a0c33a1eb09389aed421eedac8e583db46d3269c",
+        "dest-filename": "@babel-helper-module-transforms-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz#50dc96413d594f995a77905905b05893cd779673",
+        "sha512": "9f7506298e155f05d384488aae0440a153c132a7a83e01d5aa21d939a9c02421bd9d050bda92d1422ad4ce5d22a0a7251c6a46a918083a481c20968858ba7282",
+        "dest-filename": "@babel-helper-optimise-call-expression-7.10.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250",
+        "sha512": "09800e502011c04c67122c4b741eac0e6d9d209fd880400a0ccd4c39e31e66ef4b77f6c3815a3c6a25ab5f0718ece061fb511adae51c5517312a4d0626f5bb40",
+        "dest-filename": "@babel-helper-plugin-utils-7.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -268,9 +506,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5",
+        "sha512": "420dcd93b671a6032bb28c7a1eb798d5934a741abb2bbdad0d296203a7429797f4d3b8d1e277bc883e54cee3670891f6c417f60441151abfbf38be86769ed1c4",
+        "dest-filename": "@babel-helper-plugin-utils-7.16.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz#dd7ee3735e8a313b9f7b05a773d892e88e6d7295",
         "sha512": "b8b96cd3a5152a0146f500f839e1582c41ad78c2006b99294cf7052f6f32b82208cec7fa67229932594a54e099161899e69b67c17e26b4a75608113fb93e1a9a",
         "dest-filename": "@babel-helper-plugin-utils-7.22.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.5.5.tgz#0aa6824f7100a2e0e89c1527c23936c152cab351",
+        "sha512": "0a409840b91f922ba06d10cef1e667ea546e47c9336681970a0df5e3d893939b1eee0eaaca44a9cb7fa110b4b0aae86ef938079fc9e42e20701ef357f07a1f73",
+        "dest-filename": "@babel-helper-regex-7.5.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz#c68c2407350d9af0e061ed6726afb4fff16d0234",
+        "sha512": "4a4e319ad55d33db00fe3088f347fe292f8c77e6472298eeaa660f93533b17fba91e8bb97b845e626131022bba3d57bae418493d9036098f71f64e01a84e6497",
+        "dest-filename": "@babel-helper-remap-async-to-generator-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz#d585cd9388ea06e6031e4cd44b6713cbead9e6cf",
+        "sha512": "b0fc597c55e8704ca66137552b550d9853c137e1efe662642cfb185b0181c590316967c5bbec6aa7b6faa960f4ca336e34bd9529ce8be4cd7cb4e5d43fb354d0",
+        "dest-filename": "@babel-helper-replace-supers-7.10.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz#0f5ccda2945277a2a7a2d3a821e15395edcf3461",
+        "sha512": "d1f332ef67a3fd512f17c50b997eb26f932d1c6e2e1f80db77a23f6870dbfc9560d1b6e2bf0b7d5a0fa1dee32f5fe41216dc2be4c788b6f6b36eb7388ed4405f",
+        "dest-filename": "@babel-helper-simple-access-7.10.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz#d656654b9ea08dbb9659b69d61063ccd343ff0f7",
+        "sha512": "648cc7572a1e2ccbd730dfefa24fdae0b591cbc1b6bf6d3998d3f45ceb9ff5744bc97e7fbbd0a756e954b438144da99ade54fe6dffd4aae72e663aa21ae4d2d6",
+        "dest-filename": "@babel-helper-simple-access-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -282,9 +562,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz#a169a0adb1b5f418cfc19f22586b2ebf58a9a294",
+        "sha512": "ccaed31de1177da9fb5255ac1b603a088fcbf63567239fb1c4a64e75e8f7f58d18b4360ac7dada1e4e45d84b4af4af031d14e2858c20db4003b7d4b7e8647bf0",
+        "dest-filename": "@babel-helper-simple-access-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz#f8a491244acf6a676158ac42072911ba83ad099f",
+        "sha512": "ef855e8efa7a98790613e9be939bc763ddc55f6700b6bc35cd7ad95d1946e25e35d0d9bd3f17c48954e7d4f8c33d5e529e689e8ae798e00160db1aa1345bae66",
+        "dest-filename": "@babel-helper-split-export-declaration-7.11.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz#0b648c0c42da9d3920d85ad585f2778620b8726b",
+        "sha512": "c5b5a8cbf3c5a314966b3213a13f5289ffa325396b31c9dd22c68e2af4c0eaeed0128ee2964459a637b0d7cfd6ddcee79bc7d77540d7874d955d36d9d2918337",
+        "dest-filename": "@babel-helper-split-export-declaration-7.16.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz#322c61b7310c0997fe4c323955667f18fcefb91c",
         "sha512": "02c527c6e2e1458b22b0589a270be9d5017e2372a30f914ec6eb75e2afc6ce8bd47baa2b1cb7ac5b60bb77be789119b9de1e60aabcfab0597ab31738055b44fe",
         "dest-filename": "@babel-helper-split-export-declaration-7.22.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz#57292af60443c4a3622cf74040ddc28e68336fd8",
+        "sha512": "82e020d525c5715af4e06ba4f5eab44b8feb592fbeb1b9b2aa8b09cd5b3cfb57c7e4d23e65c9a469291cedd9ad0056c716f6bac912678d6df201c1b18ee783ba",
+        "dest-filename": "@babel-helper-split-export-declaration-7.7.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -310,9 +618,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad",
+        "sha512": "86c12715e99e896e03d3c039814019c4b0535e9677f4ff9af83183b07c35cb1ab243f8f31449f17f9b93106a7eddbcc06cd3b1535a5a4e0612e04094fc881f0f",
+        "dest-filename": "@babel-helper-validator-identifier-7.16.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0",
         "sha512": "638399fb2b656ad47c008fbc2997cab8be6eacaa7ba9ecb4f216b7d4bf1bdc1c1ec0902825a993cf2bf13d1ff90fe2a47490863eaffef13ba41c1958d74157f4",
         "dest-filename": "@babel-helper-validator-identifier-7.22.20.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23",
+        "sha512": "4d1b5e9ceb91515a3da084063c2e46f4380ae3be3771dc6fb4ec34c1e40da595da4b5e920818b930d8d917cbdb6b71135118d9a536d59fb56f71fd9e030168cd",
+        "dest-filename": "@babel-helper-validator-option-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -324,9 +646,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz#37ab7fed5150e22d9d7266e830072c0cdd8baace",
+        "sha512": "56c7f366deb09aca1c39a554d0ea24c2b232b47343e79cafc93e013c1f40208830afcfb1efad7b85eb5d253b2e1b0ca0379442ea6c40f44273b538eec26da87e",
+        "dest-filename": "@babel-helper-wrap-function-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.10.4.tgz#2abeb0d721aff7c0a97376b9e1f6f65d7a475044",
+        "sha512": "2f6817fd779438d7846c8efc7574ab27319dcf8190f994c0fda6b37d4b056968d27bde64882b8e6791ec5ef922c378b017e9851d24547c953cb7a61abe871d5c",
+        "dest-filename": "@babel-helpers-7.10.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.17.0.tgz#79cdf6c66a579f3a7b5e739371bc63ca0306886b",
+        "sha512": "5deffd345c633f010b52f5b676cba470c648a7a5f03d26c8e288c5049b97e6b6a61ee544db6495719230ab3756a39b8281e4d75bca95f7b94cbd23a3abed7e9d",
+        "dest-filename": "@babel-helpers-7.17.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.5.tgz#52f522840df8f1a848d06ea6a79b79eefa72401e",
         "sha512": "a0eeeeb3c1734c4b06dd4e9a83d31f745d6203fed9e9dcfe32d16189f664f02f28e39deb1891455943f5b7e50b33d4d4200cc2f6ec571225e33a254cc9ded03e",
         "dest-filename": "@babel-helpers-7.23.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.7.4.tgz#62c215b9e6c712dadc15a9a0dcab76c92a940302",
+        "sha512": "6a4e4d199189e8b57ce50d5973d827da7f9ac973a2cebca18d25014ddbb98a1d6d9550897ae40437373822dc8256120d557bc84ff650e2685e188b1f064a6c92",
+        "dest-filename": "@babel-helpers-7.7.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -345,6 +695,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88",
+        "sha512": "e459d340b48bb30123e88920570e4abac35450563d646a9efd34459cffc12981d881f87bb5cf82ee6c22cbde7fc8d3fb0e1f71e7cd15bfcafbbbb65f4c117177",
+        "dest-filename": "@babel-highlight-7.16.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.20.tgz#4ca92b71d80554b01427815e06f2df965b9c1f54",
         "sha512": "76474c08dde9cb4fa4b028189861bc8ca78603ff1393e809c126189451b11b996685f28da00cb4d386292f1a52d56d89f26fc42b6130fb23acf69551c0ef3d9a",
         "dest-filename": "@babel-highlight-7.22.20.tgz",
@@ -359,9 +716,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540",
+        "sha512": "edd5787aef60071a0cd1d0278ff0421435bd2c5534cef4eb92ad2e80cee99c712082e38478ecf5b28d9982111dcef898cd01040f4af8100829b010a12b2d5345",
+        "dest-filename": "@babel-highlight-7.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037",
+        "sha512": "5fdac3f2aaa6ebde6f82679a4387efcffa37f9693867342f487903060a582b1a43e2a4c0526f3c64ab47915a883ac60515b210eb0418842eaaee98ea54ad04d1",
+        "dest-filename": "@babel-parser-7.11.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.7.tgz#fee7b39fe809d0e73e5b25eecaf5780ef3d73056",
         "sha512": "a16474d946e9e314cb080a8f462348b8c56034ee4089fff1a57b5a6e1cd6d875940f8ed726c001e1977f460df4f977900378ee5e2815ee196ab8e4e6c2a2e2c2",
         "dest-filename": "@babel-parser-7.12.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.0.tgz#f0ac33eddbe214e4105363bb17c3341c5ffcc43c",
+        "sha512": "54a5d2090c790fc4b4e1e8fe0eab2bd42cd8bef5a07f6d23230d83f988500ab225af651919a0ddb36dd8d3183be7fb243b1a4b091a5466f93fd44015906a033b",
+        "dest-filename": "@babel-parser-7.17.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -380,6 +758,41 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.4.tgz#75ab2d7110c2cf2fa949959afb05fa346d2231bb",
+        "sha512": "8c8c2f2ced3308bf8efcb9842508d603be4c4135b0c77737bb624e4c32b90f7ffd7a0ad6451034ff4864f575f2c189d7655569ceb0587884139a1c1469e3c8f6",
+        "dest-filename": "@babel-parser-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz#0351c5ac0a9e927845fffd5b82af476947b7ce6d",
+        "sha512": "d72a7266f1915eb898fd03faebcfacf2c16bda6aa29e19110cc3d240b360842404f8602416da7ec241d5be0dbe1dd922f20c0ff8d17324127f37505fcc208313",
+        "dest-filename": "@babel-plugin-proposal-async-generator-functions-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz#dde64a7f127691758cbfed6cf70de0fa5879d52d",
+        "sha512": "4ad1fe9c601d3baa8307597cb19e54055f000b7176556d88f157e577bdd330aca9b4c53d0d8e58b09012f14f35faf12dc5c1f763f2dad301b46ed0eb8699e18d",
+        "dest-filename": "@babel-plugin-proposal-dynamic-import-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz#ec21e8aeb09ec6711bc0a39ca49520abee1de379",
+        "sha512": "0f233b5366e7b107ab090fac7a371335987c290114b82dee7f37675674a252ffeaa06269d99de16a728bd7c28386c053e568fa6bb08c4f999dc82349b04680f7",
+        "dest-filename": "@babel-plugin-proposal-optional-catch-binding-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz#331aaf310a10c80c44a66b238b6e49132bd3c889",
+        "sha512": "2e2e3e1234a9060c5cb2678417c20571f57ffb2246c475c38ab0e4128c858ee9aec1b99f0951d4b741eea300ff88633b3a1211c97247f585f1aa21fa37cd79fa",
+        "dest-filename": "@babel-plugin-syntax-async-generators-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d",
         "sha512": "b727266719067d96b184c45b5e53d7b95169756957a62af65b800c85226044ace4fde0e52173a16f62c75a82e90c5ed3107ca5579ccd872917e8a0201c999337",
         "dest-filename": "@babel-plugin-syntax-async-generators-7.8.4.tgz",
@@ -394,9 +807,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz#6644e6a0baa55a61f9e3231f6c9eeb6ee46c124c",
+        "sha512": "18248117b89495eeab36e81f511c0d982186dd9ff6fa8a7100c2ecd67343e1b8441b93eec53220803068798612ba30252edb2ea733876094203d2de98afc1720",
+        "dest-filename": "@babel-plugin-syntax-class-properties-7.10.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz#bcb297c5366e79bebadef509549cd93b04f19978",
         "sha512": "538d00efac79813c26112cfeaa2aacb2a99e12c2af712cafb6092dae6d2ecdc01102633d2358d1db6d5fe8eabe1a61eb703f8bbd90da8355133937b67cbdd378",
         "dest-filename": "@babel-plugin-syntax-class-properties-7.12.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz#29ca3b4415abfe4a5ec381e903862ad1a54c3aec",
+        "sha512": "8c7416d2f6d11afc10360c95c700e1e32b97bb86c7d5fe7f1080892c0865d526e52ecd820e1aec98293ebf95cb744f70c6d005472c71f8ffff230f9ae4bfed4e",
+        "dest-filename": "@babel-plugin-syntax-dynamic-import-7.7.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -450,6 +877,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz#a3e38f59f4b6233867b4a92dcb0ee05b2c334aa6",
+        "sha512": "e194aecd6805c6a1d1137d4696ef9f12bfcc8ab35938c6260ffd018415b22f238e433fe04c097b4265a6da15f54311085ecaf6be4765c312334f2898442e3171",
+        "dest-filename": "@babel-plugin-syntax-optional-catch-binding-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz#6111a265bcfb020eb9efd0fdfd7d26402b9ed6c1",
         "sha512": "e953c3d0f7359694eac3468aa1e45332207e916840a13db83c0fa4b16481ac5b65e52211569665c0ddcd34f4237a103613ff75155dd18cb5a855382559c495dd",
         "dest-filename": "@babel-plugin-syntax-optional-catch-binding-7.8.3.tgz",
@@ -471,6 +905,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz#c1cfdadc35a646240001f06138247b741c34d94c",
+        "sha512": "871fbeba92efe54d6b8187f07b5c41414851994e35344be952fae9f2392b48276f1929cce7fa9d44cb72949e8f1b938590168791b4c02939dddff63211244717",
+        "dest-filename": "@babel-plugin-syntax-top-level-await-7.14.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.7.tgz#39c9b55ee153151990fb038651d58d3fd03f98f8",
+        "sha512": "6215082471c692a3e011c31890f08a4f219476818a5ada29232710ca3247f0e8ef460398b17b1a29e84b54f49c28958050b3f131ae0dd6f09eeaccd1105959ec",
+        "dest-filename": "@babel-plugin-syntax-typescript-7.16.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz#24f460c85dbbc983cd2b9c4994178bcc01df958f",
         "sha512": "f4488d8d524e33008efb8dd3aa84eb810f23330700774b16c978bd44f7c8b0b4e3e11d8c0030c341710b85f7da531fee26fd8061cc4180fc07ea3e13200e32b5",
         "dest-filename": "@babel-plugin-syntax-typescript-7.23.3.tgz",
@@ -478,9 +926,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.4.tgz#f7ccda61118c5b7a2599a72d5e3210884a021e96",
+        "sha512": "9a4d1c1f5cf231afd71de6fa2ce4d74db1bbb8827c46b8e5ceef75a54c7f292dc9a5c81a4c3c0c4bc90cf9aafc48b3af94bd8ba1f8b80860408c2a376b6c7e97",
+        "dest-filename": "@babel-plugin-transform-dotall-regex-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.3.tgz#661ae831b9577e52be57dd8356b734f9700b53b4",
         "sha512": "6954b417ae4b2ac74d3ad733e85442a44e0e82c3f63859d6e3aa8dc4d217f61df0bb368d71242c272b2e330a9289b0bdf073eb7f6bc282dc4a3704b40c096070",
         "dest-filename": "@babel-plugin-transform-modules-commonjs-7.23.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.4.tgz#bee4386e550446343dd52a571eda47851ff857a3",
+        "sha512": "93c8954bb261737ebb21c345e77282c085ed2801fb7337aff3ae9386c4e0cbc0b09578e72999dad951f00a1825ccb95e62b707cf5790108265191431079de7a8",
+        "dest-filename": "@babel-plugin-transform-modules-commonjs-7.7.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -506,9 +968,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278",
+        "sha512": "6428c3dbb706245501ea7982075127922debf8be6426f797f69ab54af0142a8202cba099f720fcc4ed3ce985dd621bcd8c17677a49b866768fe720bc0acff5b4",
+        "dest-filename": "@babel-template-7.10.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc",
         "sha512": "1a40f39874ba195ed97977c9674b4b44185970c718d3f2e76fe7846d70c17c201c6428eb64a7baa77278c1efc3db83bd63c7a7c56020d5c5b0a1fe7dc8b876a3",
         "dest-filename": "@babel-template-7.12.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155",
+        "sha512": "23c8ffc7c90752b6d84535315ebacc6df09aee3c6413bb59adedfdc77923afd86f23cd9c2b515fa8bca0a2d71637991d3c659c2dd58c1e94816afb1ee6d5b0df",
+        "dest-filename": "@babel-template-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -520,6 +996,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/template/-/template-7.7.4.tgz#428a7d9eecffe27deac0a98e23bf8e3675d2a77b",
+        "sha512": "a94ce286054f82e0335c22bb597c3ca6ab3a704c22e78b3713e1eb7a3964b963ba8af30ac7d8599776367d25e9f62e478325a68fb44a3feba56989ca338c98c7",
+        "dest-filename": "@babel-template-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.11.5.tgz#be777b93b518eb6d76ee2e1ea1d143daa11e61c3",
+        "sha512": "12388f5edfabecb88265711f46948977e8d432705de3ff4e52fecdc77fb4bbdf9e8a63302661b443df25c38ff6f3d242a31484f0ea250cc35969a17f259ebd59",
+        "dest-filename": "@babel-traverse-7.11.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.0.tgz#3143e5066796408ccc880a33ecd3184f3e75cd30",
+        "sha512": "7e91485efa83ea40bb73b3d436767467c7105e56ab08bb42529b764b50f1ecf8e846d0857dfbce9071d2a26fa6e472313199f96c80556fbd6585a6dc9a312caa",
+        "dest-filename": "@babel-traverse-7.17.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.5.tgz#f546bf9aba9ef2b042c0e00d245990c15508e7ec",
         "sha512": "733c7b5f2e5aeac6a9596471eb59b529ed516b8bdcceed66093b496a6e7345304ea277dd27e4bf07a1d898662eddf26dafc186113dec8ba221816541849fe6f3",
         "dest-filename": "@babel-traverse-7.23.5.tgz",
@@ -527,9 +1024,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.7.4.tgz#9c1e7c60fb679fe4fcfaa42500833333c2058558",
+        "sha512": "3f52f9f21432ba99fcf9ecd5036cf92819b8fd9af89420bc770282318cec6b98c5303310033681372f56e558c1f8a0260636f8d14edafc7e9aa3e5e8fbdb1a23",
+        "dest-filename": "@babel-traverse-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/types/-/types-7.11.5.tgz#d9de577d01252d77c6800cee039ee64faf75662d",
+        "sha512": "6ef33b433e9e2a72551489fed4b3ed8e50453d53798cd0dcd5798dd79bd67bb4370cf06e7d65ac2e222f52eef15bceee4c6e90a208292039d480b42f3e1794f9",
+        "dest-filename": "@babel-types-7.11.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@babel/types/-/types-7.12.7.tgz#6039ff1e242640a29452c9ae572162ec9a8f5d13",
         "sha512": "30dc88f76a99aba8eb4245efb488b292f9785ada11ad557d30f9fe65fb281043638967014376521eb9319c95a05ad2d7dd75ea5f986b490f97ebdc2499eb17b9",
         "dest-filename": "@babel-types-7.12.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b",
+        "sha512": "4e629234ee03e6bce12f96e35857151c72c44f37d0fc099b2a928f3928e53f45a81d9e8bf75d5f82838a638025a7f7a6cc6e1c1c9772378f73a6091b5c51071f",
+        "dest-filename": "@babel-types-7.17.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -548,6 +1066,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/types/-/types-7.7.4.tgz#516570d539e44ddf308c07569c258ff94fde9193",
+        "sha512": "733e498b6dca0a2e13f98204fc1a255a8b2b26e4a6a1978dd4416746d07017e28a2e2f061bf67673684e2497825cf9389b0938405bd39b0228749a305e0b6d44",
+        "dest-filename": "@babel-types-7.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39",
         "sha512": "d21610f120780dbe73bd90786b174c1c6c046908e467316342237d2d562f2050769d25075bdb58a715ab88fad60c0488c626976b1f3744470bc6e49d9c63d9b7",
         "dest-filename": "@bcoe-v8-coverage-0.2.3.tgz",
@@ -558,6 +1083,13 @@
         "url": "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9",
         "sha512": "a28582ae564fd758bc1889928d31d81cb92f1433f8f274b8fb6d389c66f54625ff59760798903620823dfded8359569b08449d5bb841004cc746a527f4e515bd",
         "dest-filename": "@colors-colors-1.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@concordance/react/-/react-2.0.0.tgz#aef913f27474c53731f4fd79cc2f54897de90fde",
+        "sha512": "86e2d2914b8cdbf3fe534bb2d96c252ae8b132c4ce0c3f29e09550048e1529ea299223740bb33737d5d855ac1be0cfb8b2937946b3bf78b864ecaa105fa9ec7c",
+        "dest-filename": "@concordance-react-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -744,6 +1276,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550",
+        "sha512": "3bc8dc8da6d76a578e1bd0d0d3e0115d66414df9cfe16340ab3ba224aee5978e009b118abff2763384cf8f18d8df39c109fbc15c5cee726d6dc1dc85c9b16a10",
+        "dest-filename": "@isaacs-cliui-8.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced",
         "sha512": "5637874a5233a6ffcdc83dcdd18b877d738f0c88b1700d6ad9957df30b0ca9c6253e6bf69f761bda560ff5730496768555783903b60b4de2eee95f38b900e399",
         "dest-filename": "@istanbuljs-load-nyc-config-1.1.0.tgz",
@@ -765,6 +1304,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@jest/console/-/console-27.5.0.tgz#82289a589ad5803555b50b64178128b7a8e45282",
+        "sha512": "594cd7e677856f420e40ecbfec0d9586219dc492a4f395e7b363aadbd25a1e6b6749e97e06c8f0c90671cc0b365f17ddda2e39d9fc1d0c6f68c7f2168bcd5b75",
+        "dest-filename": "@jest-console-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@jest/console/-/console-29.7.0.tgz#cd4822dbdb84529265c5a2bdb529a3c9cc950ffc",
         "sha512": "e4d8b8094ed71d08b7d88277f7c1043f846b07c795d3db173f644ea83e1b92c1eb9d3ade7b9d8fb31bd7f2da4bf0bbd3677a45cd7c8f6cd411792378d420213a",
         "dest-filename": "@jest-console-29.7.0.tgz",
@@ -772,9 +1318,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@jest/core/-/core-27.5.0.tgz#27b383f497ff1671cc30fd5e22eba9d9b10c3031",
+        "sha512": "0dc513919ca89fe751a334c48f2dfc060b773c8539d4675426ecf7b872a0e66686b6609a62a3d41a23375dd76a8bb788302ec4ddf4c62251ea1fd8b4a533b2e9",
+        "dest-filename": "@jest-core-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@jest/core/-/core-29.7.0.tgz#b6cccc239f30ff36609658c5a5e2291757ce448f",
         "sha512": "9fb69e5d628c9c6b43038f32f132d624f2662e6999eb8d827a8efc718584a620fb1730e098d0d5fc6095468acf0017572c967ff70cf38190251e35e3c431c6b2",
         "dest-filename": "@jest-core-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@jest/environment/-/environment-27.5.0.tgz#a473bc76261aad7dfa3a1d8e35155953a5ba3436",
+        "sha512": "960d0916c31a2ca829c33b349273a0db5678390c1a26804bbad9e66338a9e2dc8b4d73f6d55616b581a92d7831e367f0fccc34e66d560d758a83047a5a7b224f",
+        "dest-filename": "@jest-environment-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -800,6 +1360,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.5.0.tgz#f9e07b4c723a535f7c532cfb403394fa40d88c8a",
+        "sha512": "7b75ab969a921eadc7010d372458d39fc602aecca0eb8d3fb2bd6b8e4336acdbfccf5b9f8ee769bf8c6ae83bef4c9601e85b94adf83483eedb48a3deb7941f09",
+        "dest-filename": "@jest-fake-timers-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.7.0.tgz#fd91bf1fffb16d7d0d24a426ab1a47a49881a565",
         "sha512": "ab80c7d476b84d314f7712eca835cad5ddfe8a848bef22f9a023096600d89ba8bee82ca05b9139c55aff0f51ddb06c63b7565649f500b3d3b1481fc135e956ad",
         "dest-filename": "@jest-fake-timers-29.7.0.tgz",
@@ -807,9 +1374,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@jest/globals/-/globals-27.5.0.tgz#16271323f79e3b0fe0842e9588241d202a6c2aff",
+        "sha512": "c16a4c9d3891eb9438243edfaf606a37e6436e2f7d9a620b9c433abbb01a5f881e01210856f42c881e110afc19ac85f96190ac023be225056af4261d74b00192",
+        "dest-filename": "@jest-globals-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@jest/globals/-/globals-29.7.0.tgz#8d9290f9ec47ff772607fa864ca1d5a2efae1d4d",
         "sha512": "9a98b3dddbad2db916d8c345b9b50650454b9131a2a96eb22d54c0f896cfe9f23a27988bf58d0d960f24f79a5c17c72d2b0092ed6571b5e06cdbd8617c0a2dcd",
         "dest-filename": "@jest-globals-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.5.0.tgz#e7602e12656b5051bf4e784cbdd82d4ec1299e33",
+        "sha512": "0c6f819954b1dae6894932b3e73d5e49c8074d0ebf719e4208a4a99a9af8b1740fc15d95e5a50c3810f05d7d4c9ea351847eff46af4af7bca79e872f868e5a30",
+        "dest-filename": "@jest-reporters-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -835,6 +1416,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@jest/source-map/-/source-map-27.5.0.tgz#f22a7e759b8807491f84719c01acf433b917c7a0",
+        "sha512": "d31afb559f8934246b942c9131886ab949bc794de435d1836885b8b372fadb96cd8e4dbbdeff598409b761ccc8bb3273607d299e34fe4120a26507a058a8dea3",
+        "dest-filename": "@jest-source-map-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@jest/source-map/-/source-map-29.6.3.tgz#d90ba772095cf37a34a5eb9413f1b562a08554c4",
         "sha512": "3078d3f7942e8a970fae92ccfbc24c4b3171e9e1e9e419bee177850c9970b2f5418e628d88802f6ac18ad9fc73d966c64659efa9e8456e1d3b30c6bb9f76099f",
         "dest-filename": "@jest-source-map-29.6.3.tgz",
@@ -849,6 +1437,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.5.0.tgz#29e0ace33570c9dcbd47c67e954f77a7d7fff98e",
+        "sha512": "2f179cbf1e6637a5887b29c8c96d1d583426f143c6307bd3c3150f2be3ac65aa810cc19a343499b70e77568564ec7c93e807116e5311fe97dad17b9c987e211b",
+        "dest-filename": "@jest-test-result-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@jest/test-result/-/test-result-29.7.0.tgz#8db9a80aa1a097bb2262572686734baed9b1657c",
         "sha512": "15dc7eb6feb1d7396424f7165e6303006d87067691f573d277968359056c7eb6662d54f7954d5cc32c4b81199747dcabab8341a049bd04cb1f805cd34006c960",
         "dest-filename": "@jest-test-result-29.7.0.tgz",
@@ -856,9 +1451,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.5.0.tgz#68beceb3de818dcb34fb3ea59be3c22c890bb6e5",
+        "sha512": "5b38dc0df96a6e959ef929c93c2bc1da007a85a19fae4cc083363a3dbd5aabe10fa15023da6c0168a37444e588e07f3b692b250a3ab633e054405349f15a670c",
+        "dest-filename": "@jest-test-sequencer-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz#6cef977ce1d39834a3aea887a1726628a6f072ce",
         "sha512": "190c09e56655aca9ce26e898880179d94354257813671d4d1e3152101d2a10c99264a02474ca08cf0fc28fac7a345e00bd5db7014a83a45cd090dfde602613c7",
         "dest-filename": "@jest-test-sequencer-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@jest/transform/-/transform-27.5.0.tgz#a4941e69ac51e8aa9a255ff4855b564c228c400b",
+        "sha512": "c97532fe23b74c7d62b7127d045ecb2e3b97b7c4ed82d8c09743c141b51a0af45af8bd32601a1beae6b25bd745457fc20d0c1ea2e2e1be65e1e38cd189a07ec8",
+        "dest-filename": "@jest-transform-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -873,6 +1482,13 @@
         "url": "https://registry.yarnpkg.com/@jest/types/-/types-24.8.0.tgz#f31e25948c58f0abd8c845ae26fcea1491dea7ad",
         "sha512": "835ed4c55af661f06d68c5319fdbbfe3eb221b5a6d83d206600630be9c27eb59c183befd4579e313f9bb0b161c23312dd006c765900748464d8641365b151156",
         "dest-filename": "@jest-types-24.8.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@jest/types/-/types-27.5.0.tgz#6ad04a5c5355fd9f46e5cf761850e0edb3c209dd",
+        "sha512": "a031c4a7b8304a003cd9167aa7350bdee80cda78cffe5541d4cb3145934e064f82a0dbe1f52a47d65422c4f15cfe40e5579d2fe7d72c896e072e2c569a19a03d",
+        "dest-filename": "@jest-types-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -894,6 +1510,13 @@
         "url": "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098",
         "sha512": "1cb85258e2d18bcef9ce38cc1bfafe36fd28096f2e9866f4060121c97ddd0d7dde83066d07c3ea2e78f3df279db7c4794ad06bcdc838681a6787c500f43d41a1",
         "dest-filename": "@jridgewell-gen-mapping-0.3.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz#b876e3feefb9c8d3aa84014da28b5e52a0640d72",
+        "sha512": "733f071633857d406dbcdf8d5d848530761177164c6849745f2a55ae1cf106069d2885e122445df1a31e1e1985e7a4a5ed2b92f0e9d4a50ef7fe4f4b1385672e",
+        "dest-filename": "@jridgewell-resolve-uri-3.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -926,6 +1549,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.10.tgz#baf57b4e2a690d4f38560171f91783656b7f8186",
+        "sha512": "1edf30216e6fd7ae5ab485f5a7e26f291e4e37353217801cf03648439919b3dceb6fa33c489357a71d739f4e2b9fae558c1332811a0c5dcc98c0d2b47d3edb12",
+        "dest-filename": "@jridgewell-sourcemap-codec-1.4.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24",
         "sha512": "5cf4891d69a2dfde1fb94bb30e71b3d7088aa967e8d725de70740c45fda5ea1ced4cefa73ebbbae7c0320e781a05eee2b08c44911b0f47715987eb3b8956b853",
         "dest-filename": "@jridgewell-sourcemap-codec-1.4.14.tgz",
@@ -954,6 +1584,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.2.tgz#e051581782a770c30ba219634f2019241c5d3cde",
+        "sha512": "f4acf31f890c8c0d979814477ea1b6fd5b65eecf7697ab8d0ddd305bb7eb0c4f8452f4051aa357856a745062634a4b77bf60188f33999f540ef5769334922dd5",
+        "dest-filename": "@jridgewell-trace-mapping-0.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz#72e45707cf240fa6b081d0366f8265b0cd10197f",
         "sha512": "47c2dc3de599a25db347c9a61f725e290e9044215bed7814855f599468472c6ca0e30a4f88f64d40e396845661c4ac3cbbfff24db346238d81c7fde9697110f9",
         "dest-filename": "@jridgewell-trace-mapping-0.3.20.tgz",
@@ -975,9 +1612,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde",
+        "sha512": "6cf1e9e898bc6f8d6ccd339c68feb75659db6cee4dcba7700004ed63a2538e1e4dd8e2eb6f9424fd38797119114219160adf8426c62b341d0c88bf86a67e9ede",
+        "dest-filename": "@mrmlnc-readdir-enhanced-2.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b",
+        "sha512": "7869b06109f7831a38afb8dd42792bacde9b638efc0b73fe6bfcbbd8826e905f0b8c1e991de07773e12169c8f7b187929945c696703aeff3e66ccf425702fb0f",
+        "dest-filename": "@nodelib-fs.scandir-2.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5",
         "sha512": "beadb806adf29b91c4426d8d282af7c970f08dceef4ec1138510e7929d832bda75baa2d1f831eeae6fcd393a34286ec760753b7a9a4a663dcccaa62e3017fada",
         "dest-filename": "@nodelib-fs.scandir-2.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b",
+        "sha512": "b210260f26900b81fdd803c5a086950c70b1e5b4ad228720bdbc10cb13d1adb518db45751184db48372159bbb094c1b7575edca6b66103afbbf097c1fb70d33f",
+        "dest-filename": "@nodelib-fs.stat-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3",
+        "sha512": "6d0045aee4764c0c287af04477f356328000b4d1b34d181daea9d809cedd8737e836fa8fccbcaa944427cd9de456736b4a9db98b2c44d34ff78767ea180180ac",
+        "dest-filename": "@nodelib-fs.stat-2.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -989,6 +1654,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976",
+        "sha512": "d55f57398e2b0d6d2b7a1cdbadca809879f3f1eed22af5f6ee087c1add96801d3ea5dcdd88b57cde9ef69193d4fa3bcc6d2d6a53999ab8fda23af3bcae19aead",
+        "dest-filename": "@nodelib-fs.walk-1.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a",
         "sha512": "a0607e53196059c810920c28f067041b07a6a1316ddc520ef5a6da6c199a1b05c8a01299f864f2d293f5f396de1a0ecb96287f3521d25765c0b35967ce7a1c4a",
         "dest-filename": "@nodelib-fs.walk-1.2.8.tgz",
@@ -996,9 +1668,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@npmcli/agent/-/agent-2.2.2.tgz#967604918e62f620a648c7975461c9c9e74fc5d5",
+        "sha512": "3ab70d3d77694a5f545fba8f55159b996302497adc0dad8cf43beb6ce4e3edaa354b83e5a95158bfdff22ca324ac9299fd5e40fe40c10baf74a2bdf4ee2dba3a",
+        "dest-filename": "@npmcli-agent-2.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@npmcli/fs/-/fs-3.1.1.tgz#59cdaa5adca95d135fc00f2bb53f5771575ce726",
+        "sha512": "abd0915a3a4708c221e6c57279fa03d5c03b3e4bc82ea099b2748e114522bce44b8f108efc8ae6b9ed83a6b11388d804aa4b4305968cd418be8eb6abc755dd0a",
+        "dest-filename": "@npmcli-fs-3.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.4.1.tgz#ff22eb2e5d476fbc2450a196e40dd243cc20c28f",
         "sha512": "3b6c9125c7b518e73a3c0cb743114ce0dcc5896cef49c0c2d7fe6285804be8150455dab45cc58dd35b29a44f87e9b0576da1588a98f014b1162e0e4f69239384",
         "dest-filename": "@opentelemetry-api-1.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33",
+        "sha512": "fb55648dd0f44012cfa1d1ab2547aa6ab1fc54022f40e0c86f087d5e93f94b28ac7fb628420b0928f345a2aa8b425bbe550fed552b21311ea5a0f327f14f9d3e",
+        "dest-filename": "@pkgjs-parseargs-0.11.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1031,9 +1724,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea",
+        "sha512": "f4d113f75d0335a20f9e06272cb3de83e3a0ceab22f6e3389926e8539cbaa7c4b90f3313544b0966b6b08be0680cd51505ad83849a9061416f3037e0534eb62d",
+        "dest-filename": "@sindresorhus-is-0.14.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f",
         "sha512": "b74f6f48ddcc75fb32087a057134421ff894b46ece2740ac8f307c72302629cfef6bf90881e0c8fd3c6c8a0767704ff86deef7e26d1cbc863035a5788b65ea03",
         "dest-filename": "@sindresorhus-is-4.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217",
+        "sha512": "f3dd8afa4594522ddc97e2e5a845880eb86f2e074befdb440a2f09654caae88be22b2fc3361bb309195b1d48f12bcf5fe32a4f30c6859c5b91f487ba0e820cb3",
+        "dest-filename": "@sinonjs-commons-1.8.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1052,9 +1759,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz#3fdc2b6cb58935b21bfb8d1625eb1300484316e7",
+        "sha512": "3803c9500b6078836187f4c0954203e104ece773639bbc7375d695944b3f497c20b620f5b56db6cc007f5b5c1da9fae99a292069643d170e96b3e86c8919b956",
+        "dest-filename": "@sinonjs-fake-timers-8.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421",
+        "sha512": "5c80765dbcc74cdea27888df20c57d86555c7cf536eacdaf69f61641c6475971cec62691658103284c1d975dbd672839d3e7e8615da30a0b6ba9203aa8db8d48",
+        "dest-filename": "@szmarczak-http-timer-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807",
         "sha512": "e0101f7f29183a03bee67cc1598c04dd6f74b0180b26850f45659c2fcc25ca233c201f22a49cf750c27d29741dd512905e92a9f13bad9fcd0766d5acbb6bbbeb",
         "dest-filename": "@szmarczak-http-timer-4.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82",
+        "sha512": "45bcc9be5373991ab97373b4f548a97ae5e7a38b40d4513a8a43a3c592b4b6ec55bf7e35da5eb8979b755b9a63e3eac9abdbe9926fe4c22474eda6579ec28fc7",
+        "dest-filename": "@tootallnate-once-1.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1066,9 +1794,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.10.tgz#ca58fc195dd9734e77e57c6f2df565623636ab40",
+        "sha512": "c7c38cf17cc84c83328b0979566a36075711d52d48a64cafe267656c98cc6b5966b8abca63d16b05b10034868c9675a7e517fbb8efab0bf56061a6cd904d7b1f",
+        "dest-filename": "@types-babel__core-7.1.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.18.tgz#1a29abcc411a9c05e2094c98f9a1b7da6cdf49f8",
+        "sha512": "4bbba70e39bf0bbcf603647d3737ca08ad48f810002c3b71126b09070941dc4ccd7dbf76f729232fefb508af4b3bef84229d9f42b0bc3be0708cabf3e94783c9",
+        "dest-filename": "@types-babel__core-7.1.18.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017",
         "sha512": "aa8429ad9bf3e70405270303a9eb1e4575afdeba8cbe18296d715f5725a16f1f57e3b3ce200ea2ffe75779f12664aa0080e69375a22035232a30853ad72472cc",
         "dest-filename": "@types-babel__core-7.20.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.1.tgz#4901767b397e8711aeb99df8d396d7ba7b7f0e04",
+        "sha512": "6c12a6fb654f25c311570361c4abbc5bee7fcd3ee9c0d12a7a89053a66ef552a86cc59de37161c101ae8f4073bfcdf6d96c68f62764b2bc2752d62a432c2c07b",
+        "dest-filename": "@types-babel__generator-7.6.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1080,6 +1829,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.0.3.tgz#b8aaeba0a45caca7b56a5de9459872dde3727214",
+        "sha512": "b82a339c83c39a789c9048ba0f4bf5d520695b43ae56a1c909aeecc97a901f2e6e92d482ade225b748a096c0a79afcfcc826f7f2119c59eb1e03c716252c2fe5",
+        "dest-filename": "@types-babel__template-7.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.0.tgz#0c888dd70b3ee9eebb6e4f200e809da0076262be",
         "sha512": "3533c4af1e3f1623c2192707edfa0fcabfbfd439339278beac78981c7a138efc28bbb010cc990d783eb403d097472f9910dd81d5b8209a44cc0836fe32fe64f8",
         "dest-filename": "@types-babel__template-7.4.0.tgz",
@@ -1087,9 +1843,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.14.tgz#e99da8c075d4fb098c774ba65dabf7dc9954bd13",
+        "sha512": "f30f6ccf32acd7866d055b8fe969fb9cc2d12740fa75f074544044c91831ad9fcb9f8f5a34cca4ae084cd8568d9f8149473369a4249ad11bfda4144ce57737c2",
+        "dest-filename": "@types-babel__traverse-7.0.14.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.16.tgz#0bbbf70c7bc4193210dd27e252c51260a37cd6a7",
         "sha512": "4badc3b780993a4b939a92c6196b53fe641d54e4493a9c7a49958655a3f9e9d75aff4371e6711ef362bbfcb026f3362be927ccabed4dd8eade20eac7031eb9eb",
         "dest-filename": "@types-babel__traverse-7.0.16.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.14.2.tgz#ffcd470bbb3f8bf30481678fb5502278ca833a43",
+        "sha512": "2b6c1a5dd5c18b6df4d9751d707711d6309e5342cbe130fd1d1b3f824d0dd97beb86df86fc17c96b840e6c14197e131dc620a957708e97935fab8b8a4de4e724",
+        "dest-filename": "@types-babel__traverse-7.14.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1213,6 +1983,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7",
+        "sha512": "11a39bab022f6b22396bc742ce116b8cacd5c0a2f18e81bd4fa3e9779084a34ecb44a7d0f18a24c39e2be7e5aaec568143ec9746f40060fac7c326b5fd416df6",
+        "dest-filename": "@types-events-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.11.0.tgz#aaaf472777191c3e56ec7aa160034c6b55ebdd59",
         "sha512": "84e8b540d6fee06f948c3b7a08427a3235c7cbe5dc798ec0c486b6f14f47809f340bede021b8fb879749371388ecf5370ced4b22118fe41b38ec36dfe65f3e30",
         "dest-filename": "@types-express-serve-static-core-4.11.0.tgz",
@@ -1262,9 +2039,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575",
+        "sha512": "d41874e9c6d62541cc0bdeda72e0fa50c1b6f6732dd00ab3d6f17782e2df1be9071c9872dc0ca8859145c589367fb43549022b370be7731004d0dffdb3bd05db",
+        "dest-filename": "@types-glob-7.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb",
         "sha512": "654c5bcca97421f2482d34bab7b8a9e5f41033f2774c962e6c39b79cc6e0b9b34d612eb6797794a682d40bcffb7c93621581d3ac63d09fb86ca435332075f750",
         "dest-filename": "@types-glob-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.3.tgz#039af35fe26bec35003e8d86d2ee9c586354348f",
+        "sha512": "0221d1684079d0b420d296669bae7dbcd05bf5fe12274aab027b5ebb385278051c24ac68620127a6b83ff37929a429dcdb3bed08a6dd66bcb56b9a5563794e4d",
+        "dest-filename": "@types-graceful-fs-4.1.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1307,6 +2098,13 @@
         "url": "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#e5471e7fa33c61358dd38426189c037a58433b8c",
         "sha512": "dc1513c8ccdb65ad83b43236064111342ea3270d8caf6634a0623b991c583413f1a696ed10ad45ebabb76cac14da0fb0c70588ecf028469267398d60ac9ab31e",
         "dest-filename": "@types-istanbul-lib-report-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#c14c24f18ea8190c118ee7562b7ff99a36552686",
+        "sha512": "a651a05c03df54a16861f6bd369603024b1e1be83a26bdbde11a9ea9ca838b149b537e0c6552518bf3feed8f060e9ce41302da19964ea4a20499e55936d2acae",
+        "dest-filename": "@types-istanbul-lib-report-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1444,6 +2242,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/node/-/node-12.12.12.tgz#529bc3e73dbb35dd9e90b0a1c83606a9d3264bdb",
+        "sha512": "306baf609acf5341d4c2a17b2eabc88f9d116545f6dd9fa6e7cdca07280a61464b959f3c9fac36f1744d251260b07ba42c49cbcfac3a4afc59a0b81baf9c0ba9",
+        "dest-filename": "@types-node-12.12.12.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@types/node/-/node-12.12.24.tgz#d4606afd8cf6c609036b854360367d1b2c78931f",
         "sha512": "d428aabfda6ac15b56e85b0850a499341f361390aed48d9b0538f5c6e2075cb7bfd7360b977f79e8d6e18363334981d57e5f7fae66a78db4086fb2e26df0a7ba",
         "dest-filename": "@types-node-12.12.24.tgz",
@@ -1451,16 +2256,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/node/-/node-18.16.20.tgz#b27be1ceb267bfb47d8bac024ff6379998f62207",
-        "sha512": "9cbe7855f0e34e174fd945c95d96a8e70a7be820e20f0e334913bc7784e4ed4803a8d286295110074fedded8badcd4be60d3642100efc04005d3804ef9662eed",
-        "dest-filename": "@types-node-18.16.20.tgz",
+        "url": "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256",
+        "sha512": "8e2137408c49f092cd71bd4fb3aac36f2b0384de316bc0c926fb82f69aebeb0fb5b4887e4006d8c8d177b7289934b0c122e0427f8284715d94bd09bf57ad317c",
+        "dest-filename": "@types-node-14.11.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/node/-/node-18.16.3.tgz#6bda7819aae6ea0b386ebc5b24bdf602f1b42b01",
-        "sha512": "38fb395a79d3d71902062b90ad9038f98015e071097a39879decab6886b1b1b7afe72084afa28cc0834d14ff7041e148c3c1567284ea177bd0b1ae420da23ef1",
-        "dest-filename": "@types-node-18.16.3.tgz",
+        "url": "https://registry.yarnpkg.com/@types/node/-/node-20.11.1.tgz#6a93f94abeda166f688d3d2aca18012afbe5f850",
+        "sha512": "0ec5e88c95044b633e144f02a69b494caa60fabe789a857d6449dc3ecb678b55871664dc0b37852e73057f2842552f1734ecbf3901bef2557144b46b547995e4",
+        "dest-filename": "@types-node-20.11.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/node/-/node-20.12.12.tgz#7cbecdf902085cec634fdb362172dfe12b8f2050",
+        "sha512": "7962c3185fc53923ed02f12a791010e02f0b480eccd48ee2d24cb523c53b903d49e484f25b702c46142b295a167f9a45299da420bb0418986c23dafddcf6273b",
+        "dest-filename": "@types-node-20.12.12.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1475,6 +2287,13 @@
         "url": "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.1.tgz#b6e98083f13faa1e5231bfa3bdb1b0feff536b6d",
         "sha512": "6e8cb8c4f344b62c3a37769b461062fdeee136fcb74edf04f5944042bc001b3a021994bfd708e8f4a63b2478677e712c1b9c128c36f2982a3350cf5adde6bb39",
         "dest-filename": "@types-prettier-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.3.tgz#a3c65525b91fca7da00ab1a3ac2b5a2a4afbffbf",
+        "sha512": "4334ae64c06e1b9bbc1ea633d35aad31d83f25f72d967be3d73fe56272035ecfe0a25c70d1fc6d4401ddf4aaf38d1ed8c73d6a55e234d28d2488edcf995749f7",
+        "dest-filename": "@types-prettier-2.4.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1633,6 +2452,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c",
+        "sha512": "1e5db5f7f053e5f2c06b3e8d0e44ae8736accb8f5dc104bf0d276ee0c76080507ccdc5efeef7e5048df1a7b1449a499d0e40542366cf50d78cb6da7692761dc7",
+        "dest-filename": "@types-stack-utils-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@types/strip-ansi/-/strip-ansi-3.0.0.tgz#9b63d453a6b54aa849182207711a08be8eea48ae",
         "sha1": "9b63d453a6b54aa849182207711a08be8eea48ae",
         "dest-filename": "@types-strip-ansi-3.0.0.tgz",
@@ -1776,6 +2602,13 @@
         "url": "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916",
         "sha512": "48e86e538c0d0718614c7c586a21b9358e070610c80e7245eb4194fb62ea1c074a29eafcebffdee3283af5a10d0ad434e27d28bf3fadab660f304e6de72a78a7",
         "dest-filename": "@types-yargs-12.0.12.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977",
+        "sha512": "4fc61cf70b7fe4b6c9c8268b8873d17896b4900a5c22027b067ef7e468c8b547e1d3c675a49beef1066a6fdb3e98cbca57a59441157b2b6478e986e33174d327",
+        "dest-filename": "@types-yargs-16.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2081,6 +2914,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a",
+        "sha512": "f482bd11a76c6c7a3a8cb588a71a51ea92f4b1acd35d5ebe490bf6e5907e17b063f6624d68e7389c245a6f077933f2709946bc89dcfa11c8ba78a7c9af23ece9",
+        "dest-filename": "abab-2.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291",
         "sha512": "8f669f4ac68810dbc764dd81f063a9179ebabd9e56564e68a4088c4ef5a06904fc0e46ceaac4dfbcd02f1e8446536cf33fc70fa2acacfb11d3443596f0bfbf04",
         "dest-filename": "abab-2.0.6.tgz",
@@ -2088,9 +2928,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135",
+        "sha256": "1530f0905843355725f720a8ad36c87d78ac3faf87e79ec4d6524b1979bd7e6c",
+        "dest-filename": "abbrev-1.0.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8",
+        "sha256": "0cc19d22a5f9a54ff45f64509c56c7aedb358215a41be9a9c7c0be8c8673ba6d",
+        "dest-filename": "abbrev-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf",
+        "sha512": "ebf9a1d44daed98804b021dd634631e685beeb581953ed6f5daa221c7ae929eb9134d805bd2fbf8ebc07890841e5aa407f9a01ed407b135f689764762ca1fc85",
+        "dest-filename": "abbrev-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/accepts/-/accepts-1.3.3.tgz#c3ca7434938648c3e0d9c1e328dd68b622c284ca",
+        "sha256": "f677b48165bc953b770708fc9884d7f84ff8ed759359322bc53991328a150809",
+        "dest-filename": "accepts-1.3.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2",
+        "sha256": "b8349c513112bec18ea7b7124b5609f30c6fa21e0c2cdf9e4ecfe551072a4b6b",
+        "dest-filename": "accepts-1.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e",
         "sha512": "3d802d8536b69b654ac6ebd20f70cf0bf1b2f94fac380d4b02e4fc9a4991bafc3e34009269e5c443e34771517bace365eaa71ac55dd4b9e9b06b093eefe4892f",
         "dest-filename": "accepts-1.3.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45",
+        "sha512": "65097b2ce59a17978faaa717e212eebff6cb5d840d7cd5b0d9cd3fc97fd3b0f44a6a6cc77131909e50a31d3dd3b2690e51510f4b772b0b188f7ddcc4fd3ae586",
+        "dest-filename": "acorn-globals-6.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2109,9 +2991,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b",
+        "sha256": "64abdf9797ca21d15e3815a16e0d7f402cc27b109a0a5180c9b0f0f19e5e6efe",
+        "dest-filename": "acorn-jsx-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384",
+        "sha512": "b4c52ac0159f2c56c96e2cd198471648bc3a1e71737dd26cdac38910ec30b553cca07ff4032f84ef4de8673efc5525d98a20dc66b4395ca8cf214422c619a057",
+        "dest-filename": "acorn-jsx-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937",
         "sha512": "aeaf6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781",
         "dest-filename": "acorn-jsx-5.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc",
+        "sha512": "38f74217a1ac3083fe033f9a59f000384b76ffe8950ca13ba32ea5274f7c6a87b9f680262bbeaa57a1b0eb449b67c8c7b86db01f4e7c185e292c56d86a662b54",
+        "dest-filename": "acorn-walk-7.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2130,9 +3033,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a",
+        "sha256": "c46e46efbf37f24f13a395609f358bf17b0d46b2629d296215cfe1da3416ff0e",
+        "dest-filename": "acorn-3.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d",
+        "sha256": "60fe1f0b744325f605e3d784f5cabf51e76ec65ffc00b22e1566e0c0b9f0eb56",
+        "dest-filename": "acorn-5.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c",
+        "sha512": "90be42ba85c0fdd8319416d5adf96c7e5cd0dcf01ab3b458641e7634e9bfebcdfd89560980a309ddc4090feb768b9faa15af21dcc0e910e2624bae04f092e749",
+        "dest-filename": "acorn-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c",
+        "sha512": "f86ecff23266087afe4be70b7d0c7281b5a15f2fbc613546cc092911b70ba3698ba0beed8a3fd51b8d5048700249fe50818461319607b8d73a76b25a3b40dafb",
+        "dest-filename": "acorn-7.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b",
         "sha512": "9dcd00c73a7fd0520b2c456c9b87cdc0b0b032db6f844236eb742d54f41c6e97d9677b6cd212ec6463a913a73336589dec227d325c87f2b797929b1fdd8518e3",
         "dest-filename": "acorn-8.11.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf",
+        "sha512": "57f2c6af500fcbe3d723029e6c45ab9193f0a1ea05fb0d6388e0549aec6e89421a387b686fc41cf414eb628ed5b88e5f47cb6ab32f9bb80d96168a11e6896abd",
+        "dest-filename": "acorn-8.7.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2144,9 +3082,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.7.tgz#8606c2cbf1c426ce8c8ec00174447fd49b6eafc1",
+        "sha256": "22a32b4ae153f106d00a1150f75cda89e118fae1370f47ba2d0b8cbabe36ffaf",
+        "dest-filename": "adm-zip-0.4.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f",
+        "sha1": "fedb394f9f0e02aa9768e702bda23b505fae7e1f",
+        "dest-filename": "after-0.8.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f",
+        "sha256": "424c7e0f727f614f7956e38fe8870f473905b8f2c92f099dd639504dda8eb09b",
+        "dest-filename": "after-0.8.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/agent-base/-/agent-base-2.1.1.tgz#d6de10d5af6132d5bd692427d46fc538539094c7",
+        "sha256": "6b08f51fc6bf384d4e01a50e9d0138246f815eec86503021c59d8524e3fe6293",
+        "dest-filename": "agent-base-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee",
+        "sha512": "b1a95c1a78a75749cfaf0a46367e154d705bd523ae5d0062a9bacd5e87a2cc9b07aec2fa11114cd8d7b725448159113a69e34923644e3ff5841080d48837b772",
+        "dest-filename": "agent-base-4.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77",
         "sha512": "45937035c945efe312ffc6c383bd1a9a0df6772799199c620ee42667128b025423af78c6c8bc7ee0a924e7c50eec3d90760148402a2fb92b991129dee911ba5d",
         "dest-filename": "agent-base-6.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.1.tgz#bdbded7dfb096b751a2a087eeeb9664725b2e317",
+        "sha512": "1f44d2c8534332898c3494019fcc05579602ff6789f955c40b039a759253e79e313fa70e0d91cf5f71fd40c4040b1beb82248e3f5a478f2d6c31641560939438",
+        "dest-filename": "agent-base-7.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a",
+        "sha512": "e08ed3774d6ab96fd1a6871f35ac85745564d6a4aea21d04ec9adb449d7a9c7d351e128543cf0836af5277e9ddef6cea4724a5afd0660c0f3194427abc932b60",
+        "dest-filename": "aggregate-error-3.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2172,6 +3159,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c",
+        "sha256": "8e9e6f40527df1d26da80977bdd2ed8bb3acd678fd0eeca83649398d5765d7a4",
+        "dest-filename": "ajv-keywords-1.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d",
         "sha512": "e69e964cdd03753195424e958dc123bb5f4881a1ee75a95c7da6c3ef284319e03a6dc42798bf82a6f78b26aff786f7f07756a87fa2f7f3a3ae824c7a45fc8c21",
         "dest-filename": "ajv-keywords-3.5.2.tgz",
@@ -2186,6 +3180,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv/-/ajv-4.11.7.tgz#8655a5d86d0824985cc471a1d913fb6729a0ec48",
+        "sha256": "f307cc5dcb78e52319295dd46a194cdf67fec8b4d83aedae15dde20b17edc38c",
+        "dest-filename": "ajv-4.11.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536",
         "sha1": "82ffb02b29e662ae53bdc20af15947706739c536",
         "dest-filename": "ajv-4.11.8.tgz",
@@ -2193,9 +3194,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536",
+        "sha256": "5e645008a327dfa21293ea60d2e2b9aaa383b44553da1b4126a7dc5a2034fcb7",
+        "dest-filename": "ajv-4.11.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965",
+        "sha256": "0caf0ce6ce6c773345b1ea3d34f67280ea6f16f883a4552f63c04a9eb2f0902f",
+        "dest-filename": "ajv-5.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52",
+        "sha512": "4d7b54504607b9a4c46cb65620a52be69981ba10cbcbef0a62d3d875c57ca82fa93992fe34aa98c2f59246b5571e7f99991440bbcbc94c0ce71fb39a83a45547",
+        "dest-filename": "ajv-6.10.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706",
         "sha512": "e0ad1c2b72f586caa4f7121bdb3f6fb3f5d4f8f18967d3cda494434bd60bce635d5fa8e654f7da98bbd326bd1a0c0bac9c7c821cee8c8f396402c82daa9f6d78",
         "dest-filename": "ajv-6.12.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da",
+        "sha512": "95117c44e45c863a4a1b9d3f5857fcc6683bb2008b16260d367a9d29f964eb7c213107164799e01a38925e42fd6e3c72e81da7a4e2b61d230de3d8c404c4a46a",
+        "dest-filename": "ajv-6.12.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2210,6 +3239,55 @@
         "url": "https://registry.yarnpkg.com/ajv/-/ajv-8.10.0.tgz#e573f719bd3af069017e3b66538ab968d040e54d",
         "sha512": "6f3a801193a392b50c97669f1fc7649ebab92849364abc1d051391faf1f510a5504ea6946c954f75cfe011d8204cc33449efacf896b88eee1394d712b4a9761f",
         "dest-filename": "ajv-8.10.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117",
+        "sha256": "050f54a2d7e5cbcf6fce522d3890845637a0d3f8f2b10bb54655d1e4257c5c0b",
+        "dest-filename": "align-text-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5",
+        "sha256": "6c7ec6ea1fdb80e0b8a55e9945490b9803e0ae8a4e45e62efb0e3f0409c97922",
+        "dest-filename": "amdefine-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f",
+        "sha1": "c36aeccba563b89ceb556f3690f0b1d9e3547f7f",
+        "dest-filename": "ansi-align-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb",
+        "sha512": "6690a554aa973774460662a26dd7d6cea098e259e312ea0dcd4e53d28105a5f77fcf9a891d56abba4ae2743e23b8b3b6157322c14431afd5aa42d6986bc5d163",
+        "dest-filename": "ansi-align-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e",
+        "sha256": "a27dc82e666b53b10a9e2ee58b79169b5498de0a77476fd6d87c79979d041aec",
+        "dest-filename": "ansi-escapes-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b",
+        "sha1": "5bae52be424878dd9783e8910e3fc2922e83c81b",
+        "dest-filename": "ansi-escapes-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.0.tgz#a4ce2b33d6b214b7950d8595c212f12ac9cc569d",
+        "sha512": "122621c28d2fdb9e4750be9e0f2b8bad71244e2ed6c1508b030f9278e43b33ba9dba7d73d69ba6e03126fe7baa2156cfbe2f513cf73d93d2dbc81bfa1f40f056",
+        "dest-filename": "ansi-escapes-4.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2242,8 +3320,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
+        "sha256": "52b8ab148865eeaf538e630a937fa153d5af21232f014a5d4e38491937be8037",
+        "dest-filename": "ansi-regex-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998",
         "sha1": "ed0317c322064f79466c02966bddb605ab37d998",
+        "dest-filename": "ansi-regex-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998",
+        "sha256": "bdadb0d036d35d54a71c47d94b2abfedb595775f41b8137bec044dc5efe43d35",
         "dest-filename": "ansi-regex-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -2270,8 +3362,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a",
+        "sha512": "9f933ce797ca6f64ac7cc222145a15ac0047242f10b47c15c7e98758fdd0704a811d889e9e3e5d1d28236f1b42d161195d8b78c1c0faceb4049433e116e6607c",
+        "dest-filename": "ansi-regex-6.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe",
         "sha1": "b432dd3358b634cf75e1e4664368240533c1ddbe",
+        "dest-filename": "ansi-styles-2.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe",
+        "sha256": "8d603cbfa5e38e5302fe9ed0d50d968853ff3f144522c6d291b7f9f17413121f",
         "dest-filename": "ansi-styles-2.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -2285,8 +3391,22 @@
     {
         "type": "file",
         "url": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d",
+        "sha256": "7318625e1aa6768258ca472572b254711de4ac35f1ee49c4c1a9044c1f020df3",
+        "dest-filename": "ansi-styles-3.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d",
         "sha512": "553d1923a91945d4e1f18c89c3748c6d89bfbbe36a7ec03112958ed0f7fdb2af3f7bde16c713a93cac7d151d459720ad3950cd390fbc9ed96a17189173eaf9a8",
         "dest-filename": "ansi-styles-3.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.0.tgz#5681f0dcf7ae5880a7841d8831c4724ed9cc0172",
+        "sha512": "ee415082711a31d46dc1feae49f52756bf604860bb7dabab9fe27f32ff74fd6fa24ed374e34e7f9cb768a5f316c1c872c616c6625e930b849c727f5352418082",
+        "dest-filename": "ansi-styles-4.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2308,6 +3428,27 @@
         "url": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b",
         "sha512": "0b1c29b7649f4f34ed5dc7ce97318479ef0ef9cf8c994806acd8817179ee5b1b852477ba6b91f3eeac21c1ee4e81a498234209be42ea597d40486f9c24e90488",
         "dest-filename": "ansi-styles-5.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5",
+        "sha512": "6cdefdf2015f417faf8b0dd1ef2ac6591aa7acdda84641245238e5e09367e04f06c716e3b46dc56eb108218de5f3f86bc14c0878266f8b842e3933f8304ad5ba",
+        "dest-filename": "ansi-styles-6.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi/-/ansi-0.3.1.tgz#0c42d4fb17160d5a9af1e484bace1c66922c1b21",
+        "sha1": "0c42d4fb17160d5a9af1e484bace1c66922c1b21",
+        "dest-filename": "ansi-0.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a",
+        "sha256": "ba3b290dcc7371467420b97639b42db92cc05fd548e2b86c17341b11276029d3",
+        "dest-filename": "anymatch-1.3.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2340,9 +3481,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991",
+        "sha256": "a23b5a4b3a0e1b6e01384a027eff16ee970f6ca97b559e6ad09e62efb44489f4",
+        "dest-filename": "append-transform-0.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab",
+        "sha512": "3f4d3da1891e1f253be36892649cd9672c23e104497674d67df68ab8940b69b942675bb3ebf716e3269181c0daa10faec0ec719edd204547307ec34fdab8b483",
+        "dest-filename": "append-transform-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a",
+        "sha256": "5af368c71e05db3f69f4f7f892156ceaecaf5ae2eaf464cf6ae37809f0e8e09d",
+        "dest-filename": "aproba-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a",
         "sha512": "63d27a6635eda1887c4675d508c394fedb439a4d5a063ba7abdbced2d6b9c7ce560d08907d417db083c121375b8a2215701a34dc78b78ccc62801b6c75d95747",
         "dest-filename": "aproba-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc",
+        "sha512": "9587b81b1ed04fe30a19b0ec03e67e85efd6b5e7f4062c033a52bf5e406b75fb21f49fe33cf5db5f4b44f71f5c976ed39aee608374146d4ad061aff2f8a3873d",
+        "dest-filename": "aproba-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/archiver/-/archiver-0.14.4.tgz#5b9ddb9f5ee1ceef21cb8f3b020e6240ecb4315c",
+        "sha256": "ce0c84640671529ab5a217447bd09324ba8748e0c923104e5e59d47332f90817",
+        "dest-filename": "archiver-0.14.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40",
+        "sha1": "f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40",
+        "dest-filename": "archy-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40",
+        "sha256": "1659a980f11d9df11cd89bfda2e21db3a7e1ed821c96a0d88d4ff0fad5370c26",
+        "dest-filename": "archy-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2354,9 +3544,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz#bb5dca382bb94f05e15194373d16fd3ba1ca110d",
+        "sha256": "4d3a5082ace75e092f6fcf705b50280f88a73525483e445abdcd15e0ee816527",
+        "dest-filename": "are-we-there-yet-1.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21",
+        "sha256": "c5c1b6012946bf0d4074ba07f5ead07266f87835f25a6616ee95779dc6a962c5",
+        "dest-filename": "are-we-there-yet-1.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21",
         "sha512": "e6161d024665706f2d38bba35434e0093fae3d7d159e9007dbc816b0b7f3a57626ef03fa9a9e50fe063247b610d1c29525c5c99e5de3da4a416a7d773ed41feb",
         "dest-filename": "are-we-there-yet-1.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz#679df222b278c64f2cdba1175cdc00b0d96164bd",
+        "sha512": "4195b8103986c2562eaf46327ff6f6b86b9c1d031af1a1543fb7aef5d751ef7bef845cade15d159774073dc4cd27c97aa9838177181776705742b1e295f45006",
+        "dest-filename": "are-we-there-yet-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-4.0.2.tgz#aed25dd0eae514660d49ac2b2366b175c614785a",
+        "sha512": "9dc49601ac0584a3090d376801e395fa3c96d5508c8f940803050b20157449247b07f44b3cf1108a49ca720fd1208665510af110ba6cc4c893528010e2c214ca",
+        "dest-filename": "are-we-there-yet-4.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/argparse/-/argparse-0.1.16.tgz#cfd01e0fbba3d6caed049fbd758d40f65196f57c",
+        "sha256": "d4f2af1da22e410042986800a932d29103ac364aee864958c8643015b4640c3c",
+        "dest-filename": "argparse-0.1.16.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911",
+        "sha256": "7faa149cd7811b7e11fc8353dc6e4e9c4de68a02f8221aa8f7dc22108315ac0d",
+        "dest-filename": "argparse-1.0.10.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2368,9 +3600,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86",
+        "sha256": "9909912e4f3ab3c8aadaea0421d4c6110b386a83c38e2077df6f62ea68d95131",
+        "dest-filename": "argparse-1.0.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38",
         "sha512": "f3ef56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd",
         "dest-filename": "argparse-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab",
+        "sha1": "ecbd16f8949b157183711b1bda334f37840185ab",
+        "dest-filename": "argv-0.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2382,9 +3628,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf",
+        "sha256": "ed72c1065bb45dd8320bba7172d5136e5f8f6fe38dc4124e7e1e63f1bfa80ea0",
+        "dest-filename": "arr-diff-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520",
         "sha1": "d6461074febfec71e7e15235761a329a5dc7c520",
         "dest-filename": "arr-diff-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.3.tgz#a274ed85ac08849b6bd7847c4580745dc51adfb1",
+        "sha256": "d5a9b7a5e35a9457d97992d95c9c00831690ad80dfd9ba86afbfa94881d5adc2",
+        "dest-filename": "arr-flatten-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1",
+        "sha256": "5e6d678d5ba687bd199b8ce1a1a51293976411f46945d672221279e303c0b62a",
+        "dest-filename": "arr-flatten-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2410,8 +3677,36 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031",
+        "sha256": "afe8d25feb1466435d9af1e4af3170acff5e3bc4a040a4610ae954b20c022b1e",
+        "dest-filename": "array-differ-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1",
+        "sha1": "df010aa1287e164bbda6f9723b0a96a1ec4187a1",
+        "dest-filename": "array-find-index-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1",
+        "sha256": "05ea6cb80af8863ab910004a81179301357956f96a1f78151f348a4b19213bc6",
+        "dest-filename": "array-find-index-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2",
         "sha1": "9a5f699051b1e7073328f2a008968b64ea2955d2",
+        "dest-filename": "array-flatten-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2",
+        "sha256": "1aca1277ec265d578b3ff517a8a7a07dbab5e6edd349775830ef38c38d6426ed",
         "dest-filename": "array-flatten-1.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -2445,9 +3740,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/array-index/-/array-index-1.0.0.tgz#ec56a749ee103e4e08c790b9c353df16055b97f9",
+        "sha1": "ec56a749ee103e4e08c790b9c353df16055b97f9",
+        "dest-filename": "array-index-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-slice/-/array-slice-0.2.3.tgz#dd3cfb80ed7973a75117cdac69b0b99ec86186f5",
+        "sha256": "2321e37c9e0819f3fcaf36c049f365254295d676c8b4f0f5b6370449d9000d95",
+        "dest-filename": "array-slice-0.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39",
+        "sha1": "9a34410e4f4e3da23dea375be5be70f24778ec39",
+        "dest-filename": "array-union-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39",
+        "sha256": "88a3fa706bd874b0ca7055ba0681ce4b9fd1bd6ad073cbb06e1010d9b83f7947",
+        "dest-filename": "array-union-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d",
         "sha512": "1c6cb1a0e4d853208ceacb547ba1098277781287b0008ef331d7ea3be9068e79599810f3fdc479a5ff2bfdc4785aaeb4b0bfe9d0891c8d41043f04b7185ac8cb",
         "dest-filename": "array-union-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6",
+        "sha1": "af6ac877a25cc7f74e058894753858dfdb24fdb6",
+        "dest-filename": "array-uniq-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6",
+        "sha256": "cf5abcde307565a37870bf4d4d39af56bc033902b9aac5f66704007e8d6f72e4",
+        "dest-filename": "array-uniq-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-uniq/-/array-uniq-2.1.0.tgz#46603d5e28e79bfd02b046fcc1d77c6820bd8e98",
+        "sha512": "6dd1f1b5ebfb14debe3172356055b443c990f1d4c97364bc00c7e3bbe651efba5b836c80755c8397091a508ec76abd0bc8e31114f1eb27d9587728d966cc1d95",
+        "dest-filename": "array-uniq-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53",
+        "sha256": "7e4f36d75b071730d7da025eec05d0f4a4fce80712b7fe8dbc1d7022f024478a",
+        "dest-filename": "array-unique-0.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2508,9 +3859,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca",
+        "sha256": "3d1c1ab972ea0614b7a3331cdd773f60dcf743d8bd04a9fe2ea42e402be4b4e7",
+        "dest-filename": "arraybuffer.slice-0.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d",
         "sha1": "898508da2226f380df904728456849c1501a4b0d",
         "dest-filename": "arrify-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d",
+        "sha256": "97aedd9df226f1c9415ee5670d31fa1178cc671e192d004b03cf7d5e85828937",
+        "dest-filename": "arrify-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa",
+        "sha512": "dddb84c2d8bcf34c6a8b878030df00c91e1ad01c93f74ce861d2e57af7ebbd4e37bdbd186706557f13a0c56acb5d75e9cae80bd2135973d1ba0620790779d4ba",
+        "dest-filename": "arrify-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2536,9 +3908,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/asn1/-/asn1-0.1.11.tgz#559be18376d08a4ec4dbe80877d27818639b2df7",
+        "sha256": "7206eadc8a9344e484bcce979e22a12c9fa64c1395aa0544b8b767808b268f43",
+        "dest-filename": "asn1-0.1.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86",
+        "sha256": "45ab08e7614dfe11caeda2b869602a5cd7fc777a01968ac101f239db0c9ea19c",
+        "dest-filename": "asn1-0.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136",
+        "sha256": "e1a444974c38e516e8a0cd7a87b62d5fa6df78d41a02f5fc246f9e566793d53b",
+        "dest-filename": "asn1-0.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.1.5.tgz#ee74009413002d84cec7219c6ac811812e723160",
+        "sha256": "be8817ac92dd8a0dc9e0d2e79c1420a0399be89313c9585d05226ec7aef54fc9",
+        "dest-filename": "assert-plus-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234",
+        "sha256": "73031b3f39d0f0785e6a39f896067abf50d4283dcde4527835e5eacdf3bbc2fd",
+        "dest-filename": "assert-plus-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525",
+        "sha256": "47ab5c4571504bdee569f03e3423af5b51aa17d6a94866ddcae353ed2d9033eb",
+        "dest-filename": "assert-plus-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525",
         "sha512": "35f27853304271018b0e542aee71f11feb6fde4c99d211d0a85e413ba27bb4d25e3f9768d6594fafc759f331e89df840bb43c701d3244a8fbca34c3183d9595b",
         "dest-filename": "assert-plus-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91",
+        "sha256": "4461a8144d59d9233822c361d83363d5c74ffb406c59a9a8f6053e18a5e6a405",
+        "dest-filename": "assert-1.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b",
+        "sha256": "e23e003f80c55c20352da6534d117fa881f72aeb1133cafb3f674caf79d45692",
+        "dest-filename": "assertion-error-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2557,6 +3985,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9",
+        "sha512": "f91c9fea0dc12a845cee37e9eda77cb4ce13b4c89a5af6c5ff5fec41c64f9244bb6a0dc3e6730109ed947ce4ce36d024686d2d3b48a3dc2e4bc267f5122ca31e",
+        "dest-filename": "astral-regex-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31",
         "sha512": "67bb4cc35cad4d7b798ea31c38ff8e42d794d55b8d2bd634daeb89b4a4354afebd8d740a2a0e5c89b2f0189a30f32cd93fe780735f0498b18f6a5d1ba77eabbd",
         "dest-filename": "astral-regex-2.0.0.tgz",
@@ -2564,9 +3999,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d",
+        "sha256": "d70f0b86048f27952ab79ee00e4b240e0fb260773bd3f140d4a59d4f4e739bc0",
+        "dest-filename": "async-each-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3",
         "sha512": "356d9c5fc9b543b28f03b6b933650b41e676c11e6a2393c06f0e4bd1438cc5d8a8564f4f319d21d539b264490f62b0af6230e51480aeb0ebb576510a00079707",
         "dest-filename": "async-exit-hook-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/async/-/async-0.1.22.tgz#0fc1aaa088a0e3ef0ebe2d8831bab0dcf8845061",
+        "sha256": "6fd2750cd519a754b0e32ef3423e64768055129e00a95d9297005bda29fdef18",
+        "dest-filename": "async-0.1.22.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1",
+        "sha256": "46869f9efcfc4045217c7730f65a81f85b518a0765d14f931ddb70581afb644c",
+        "dest-filename": "async-0.2.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d",
+        "sha256": "8215cab4b997a502912679742c9a7051c854ccf02271b972eb977398554e78af",
+        "dest-filename": "async-0.9.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9",
+        "sha256": "77bad328b45ff24ff6792373e44cb47d41ee5764661ab14a1945c2bb4f428ce7",
+        "dest-filename": "async-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/async/-/async-1.4.0.tgz#35f86f83c59e0421d099cd9a91d8278fb578c00d",
+        "sha256": "44e3ea456f681acf6f7ae1838e5e457d2b1e9431a3ea1c23b95d5fad09a0e843",
+        "dest-filename": "async-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a",
+        "sha256": "df1f8e1ab87b78beeefcd5ff69d61d68b24bd946df383017b7d546a75aacd300",
+        "dest-filename": "async-1.5.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2588,6 +4072,13 @@
         "url": "https://registry.yarnpkg.com/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz#8c5df0514936cdd133604dfcc9d3fb93f09b2b62",
         "sha512": "c301d81084b443cd1fe66a2cc772ff75f1b9b79ae311af45b79d464da36df3ad849e9c861e9833d91919bcb3e9d681794e70224e886410a544bbca503c923b56",
         "dest-filename": "asynciterator.prototype-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79",
+        "sha256": "8c254f30f70792645042e4d71f590ec49f8e386a475772f7430c73b964b57dcf",
+        "dest-filename": "asynckit-0.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2620,6 +4111,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ava/-/ava-2.4.0.tgz#a3bd8b0e01d8826004c91de375eb2313ba5237c3",
+        "sha512": "0905adcd9659794da0e12b688d1bfa30ef512118b8b0bc46481f7edc2de1bf4b6d5041b5b6424b4cbcab0507854b858478ad76678a2f1377f688f5614b2f1e94",
+        "dest-filename": "ava-2.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7",
         "sha512": "0cc0f42a2378e9e8a97b38924f52cf3ff4937c3534b2e7c84979a34a0bd5b28536b6ac5cb5078049e8d671f36dc582aa11333553143cb29d8ead2056a4763ab3",
         "dest-filename": "available-typed-arrays-1.0.5.tgz",
@@ -2634,9 +4132,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.5.0.tgz#c57103f7a17fc037f02d7c2e64b602ea223f7d63",
+        "sha256": "bf35697e73e18a9128022cc8c547bad773b807dcca74f17c47dee60b031abf8b",
+        "dest-filename": "aws-sign2-0.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f",
+        "sha256": "592829a38e2ffca197ae26799e7e635981d16bb5bba252074f4e333ad4aa9f3a",
+        "dest-filename": "aws-sign2-0.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8",
+        "sha256": "a8f9f4956c5951460f7298586ff35776fbabf4a686ef13bb7716c07703e07289",
+        "dest-filename": "aws-sign2-0.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e",
+        "sha256": "619adba4bec8d6a9df22ff5277abf347d6548e39363d7a57e4137f720dcd82c2",
+        "dest-filename": "aws4-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f",
+        "sha256": "b6110cc1af4f32d0cd37d38fe38f49b6efac4eb83d591af651e1ee871d228d08",
+        "dest-filename": "aws4-1.8.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/axe-core/-/axe-core-4.8.2.tgz#2f6f3cde40935825cf4465e3c1c9e77b240ff6ae",
         "sha512": "fdd969d1fc7233747c616ecc173687597adfe33cdbaf4bda61bdb754114297cdd1ee758d3e0ff2690c360dcf23cc23260d52e149dcc7f0c8ebb2e214baf5feea",
         "dest-filename": "axe-core-4.8.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621",
+        "sha512": "d80f1084e32b6e89a50ee88b78af5789b201cee1de45caaa34e1e9d02ca9e44a09d4814387e5d91f703a0645edbf42b880518223463804cec1d703848b446683",
+        "dest-filename": "axios-1.7.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2648,9 +4188,177 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/b4a/-/b4a-1.6.6.tgz#a4cc349a3851987c3c4ac2d7785c18744f6da9ba",
+        "sha512": "e539351cb93a6fa72d9a322401c53f523bffd56aa20e5d05d09751091f3456c39c5251dcbbba567964653aa40b1df0c4b15c7d607fda89fe401b87a1a02b539a",
+        "dest-filename": "b4a-1.6.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1",
+        "sha256": "81ac501721ff18200581c58542fa6226986766c53be35ad8f921fabd47834d02",
+        "dest-filename": "babel-cli-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b",
+        "sha256": "ce2fec717473e4484b1ec48f96ff22407ffc28a310bd4fee32e3e51ee3a8b6cf",
+        "dest-filename": "babel-code-frame-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8",
+        "sha256": "de5c7830c33d354a294d97d1d9565a3c1c1a327c29e5c35d1abd42a27dc77e2c",
+        "dest-filename": "babel-core-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90",
+        "sha256": "357ad762b1b3e43ada991c98817ecaea76abff9e49f026e11f4892e1b380f055",
+        "dest-filename": "babel-generator-6.26.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664",
+        "sha256": "5591cd94264c6dacf295c2ee686f6e47a2d26d94bb1ba435208ddbb1d9c26675",
+        "dest-filename": "babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d",
+        "sha256": "f55360dc5792122bc31fd4e7cd29427b51c182ade280ac86073e2f3bcb3ce4c0",
+        "dest-filename": "babel-helper-call-delegate-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz#a5f56dab41a25f97ecb498c7ebaca9819f95be5f",
+        "sha256": "bf5d8a0058d513ed3e1d8959bdfc03d0cb72af8e7a9a3d8ed62952b7aa16a1c8",
+        "dest-filename": "babel-helper-define-map-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa",
+        "sha256": "c95805377590dc77b65d0747c1ab7a3c8141715c7360b4777ffd4ba52e04cfcc",
+        "dest-filename": "babel-helper-explode-assignable-expression-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9",
+        "sha256": "8c83dd34e512c68e6a4c5567b8ae8b1e0479111e26d01b5c9fa50abfe9ea6de8",
+        "dest-filename": "babel-helper-function-name-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz#8f7782aa93407c41d3aa50908f89b031b1b6853d",
+        "sha256": "6b05270878634032ba38d2d055b3f8337686883a7a25f5860f86c6e2a6501aa5",
+        "dest-filename": "babel-helper-get-function-arity-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz#1ecb27689c9d25513eadbc9914a73f5408be7a76",
+        "sha256": "38e50f215aa6974937119b951e990246a0a8df3ce42356f91b2974f042528bd3",
+        "dest-filename": "babel-helper-hoist-variables-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz#f7a13427ba9f73f8f4fa993c54a97882d1244257",
+        "sha256": "07ccbbcb068000e2c2a19d292b2fe455230723e772973fa004ecb7a1567c6128",
+        "dest-filename": "babel-helper-optimise-call-expression-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz#325c59f902f82f24b74faceed0363954f6495e72",
+        "sha256": "b5a2e2fbb796895c5dc6a409cc6d4dbdf5ce194f5dd0f252bc273ec15610d8c4",
+        "dest-filename": "babel-helper-regex-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b",
+        "sha256": "ef32c8b7fa232e3d19ca5d8c4b8d26e2706b141e05e19283c9c61a5cc294193f",
+        "dest-filename": "babel-helper-remap-async-to-generator-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a",
+        "sha256": "b8956d8ee1dec5a5e79aad8bddd8cbb57999c064463e3ec98dc8a4cd1ed4d2f7",
+        "dest-filename": "babel-helper-replace-supers-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2",
+        "sha256": "00ceaafa3af598a8566ac3208abb18cf533b457e7be68de20dfca2b218a9d97f",
+        "dest-filename": "babel-helpers-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.5.0.tgz#c653985241af3c76f59d70d65a570860c2594a50",
+        "sha512": "a6e842caf05334b7af85b775a32c3ab77816062716a14011418282041fc1d66a227f5ecd6f28716ec7da76a648c3ccdf2490fe5bb570d0d6f6d291232f1917a9",
+        "dest-filename": "babel-jest-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5",
         "sha512": "06bbc6637c594b011c0b32af2ac0a2d86807a83aac62438fe3f6f2e710a023019743120487ef1ec37826ac4d72ed7451e8b1d9223eb22d89d48bf9a6d8a5ca06",
         "dest-filename": "babel-jest-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-loader/-/babel-loader-6.4.1.tgz#0b34112d5b0748a8dcdbf51acf6f9bd42d50b8ca",
+        "sha256": "521c748b416bf738d9582ed29ea780aa2893222c8eae9f7fdb4380b820f30453",
+        "dest-filename": "babel-loader-6.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e",
+        "sha256": "487345a6086165fd5a3d69cd38bcb914dea5d27ea24176b802519d26647dd936",
+        "dest-filename": "babel-messages-6.23.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a",
+        "sha256": "cc3bff453634e5c801174d193b61b9c059ed5ad3ac99d3a464ca821e850113b8",
+        "dest-filename": "babel-plugin-check-es2015-constants-6.22.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz#f00f507bdaa3c3e3ff6e7e5e98d90a7acab96f7f",
+        "sha512": "a3aa85929790101c5caadd176255b3015c4d09209975481c47c2119610fff03ca5c638cee1fa0f72f4d6d0618a6bf715b77aefc59ee8e62a6927eff49ef2e195",
+        "dest-filename": "babel-plugin-dynamic-import-node-2.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-espower/-/babel-plugin-espower-3.0.1.tgz#180db17126f88e754105b8b5216d21e520a6bd4e",
+        "sha512": "32ce3d53b54802d43f4ed72a45b0fa501989054092c620b7fb33dcf9e1aac4a50814ed654ec8721034548e1a006dddab59fc187f7719eb6a17a33addf16e89d0",
+        "dest-filename": "babel-plugin-espower-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1",
+        "sha256": "0fc22874c4ae821f9186f3f5e3a5c0a0c26a77e25868b84d39c9bd9bbaf28bd6",
+        "dest-filename": "babel-plugin-external-helpers-6.22.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2662,9 +4370,254 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.5.0.tgz#8fdf07835f2165a068de3ce95fd7749a89801b51",
+        "sha512": "cedc0d90797e83519aa1071bf1fd81111e02dcb32f497b85eca56ab548a85d0812712127925ea52e00882d460847e08f4f02fc1f717f3cd2f37bae073d617d24",
+        "dest-filename": "babel-plugin-jest-hoist-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz#aadbe943464182a8922c3c927c3067ff40d24626",
         "sha512": "11201cfd126f193144cd1c0e4d3e3e94d0e4fc634732429b373b2f4f4a8a45f0f2c984ec931079ae75369e3203615c570811c7108d5cd18c07a1bdd6698ba33a",
         "dest-filename": "babel-plugin-jest-hoist-29.6.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95",
+        "sha256": "d1e2646eeae782e138c301db9d673b39a834c918cc0b5549517d3ef9bc2c067c",
+        "dest-filename": "babel-plugin-syntax-async-functions-6.13.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de",
+        "sha256": "17309a2b1fa4f9cc918fe65791e924b53809057b0d4fdacfc99d060bc4255cbf",
+        "dest-filename": "babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3",
+        "sha256": "392ecb6039ddf1c577d2106ea03201e4cf686352acf3297b7d2fb1eb0bc62c69",
+        "dest-filename": "babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761",
+        "sha256": "818036c530167d684f38e850a9f27f3c297869d8ad07597d0970a55250ef5a3c",
+        "dest-filename": "babel-plugin-transform-async-to-generator-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221",
+        "sha256": "538b807a9dace3a621d084085c5f9a3bc739ed5f3a287b331dfdfdd263461d57",
+        "dest-filename": "babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz#bbc51b49f964d70cb8d8e0b94e820246ce3a6141",
+        "sha256": "7921372d06328726305fc77fd6fe8a958df4628959c436f4cd9ec56ab7e177c9",
+        "dest-filename": "babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f",
+        "sha256": "c720227672e8178adddcc0154822fc2b23dd1c7dc9138f1a47836fdd94bbb707",
+        "dest-filename": "babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db",
+        "sha256": "2bddc84ed1ea2a2a69d4bd05e42f9358cbfbec72e172cd26ca7c945661af2d05",
+        "dest-filename": "babel-plugin-transform-es2015-classes-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3",
+        "sha256": "1d88d043485401a938dc950e798d8c45d2792bd99ea27080368fa8a88fc8c02b",
+        "dest-filename": "babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d",
+        "sha256": "2240aaca93fc6eae1f263478e4b0564d5913bf0bb59e2ae7746f952d4942b890",
+        "dest-filename": "babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e",
+        "sha256": "e6f82395e2e8d36f4518c46f56251e732d90194bfcc6014483648391585e5887",
+        "dest-filename": "babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691",
+        "sha256": "0a58b5579348561ebf5adc794c209ac2a1da4e58ee843e195c56eefae8f12af0",
+        "dest-filename": "babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b",
+        "sha256": "e35efde05af4d2b06d9bd09115b545f5343b4379c8d5a24cea4e682a326785a0",
+        "dest-filename": "babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz#4f54a02d6cd66cf915280019a31d31925377ca2e",
+        "sha256": "5430af6c2aa583f1027d16690cf944c57e96e4048b5a29140e95e27ef16e4391",
+        "dest-filename": "babel-plugin-transform-es2015-literals-6.22.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz#3b3e54017239842d6d19c3011c4bd2f00a00d154",
+        "sha256": "4311efbff5d70677c05b13350cf993f53c95dd3bc10f0fef7720c76ef88485a6",
+        "dest-filename": "babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a",
+        "sha256": "09b25093d740b7db66a32067b8fa3b263a44672043c45519b0527182a0d83f76",
+        "dest-filename": "babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.7.7.tgz#fa5ca2016617c4d712123d8cfc15787fcaa83f33",
+        "sha256": "5616c3ef5ddad61826a6578eca95eb40cc1f60ab189b075a5f46a00ad101e6ef",
+        "dest-filename": "babel-plugin-transform-es2015-modules-commonjs-6.7.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23",
+        "sha256": "b7dff91c5cc2dd5766911766f5b8b76186c385e2d7efcbc9a23acf50037cf599",
+        "dest-filename": "babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468",
+        "sha256": "b9083f68f55c20030010a24eb5579ae44b20a4e34962245944dbc5bab87d2296",
+        "dest-filename": "babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d",
+        "sha256": "b921263cb2d1ea5855010f4dce07a828f9c93249d4f0ff02c28313551f1cb81a",
+        "dest-filename": "babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b",
+        "sha256": "eefdda72d2c2aad22638bc66635b07eec4a298f5fa11d562a1cccf8ec30cb157",
+        "dest-filename": "babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0",
+        "sha256": "0e557f298c9834c5efa602102d40a7fc1b2289cd54efa337a2fe415879dd90c4",
+        "dest-filename": "babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz#d6d68a99f89aedc4536c81a542e8dd9f1746f8d1",
+        "sha256": "c18cb2823590b87ab708620dec79c6861c7d3c07ab55ae7f13c77f863939f0a7",
+        "dest-filename": "babel-plugin-transform-es2015-spread-6.22.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc",
+        "sha256": "b17ebc49093f2d76f08835fa6aa95fdfcf99a5f0e728d245dc386213fcc1582f",
+        "dest-filename": "babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz#a84b3450f7e9f8f1f6839d6d687da84bb1236d8d",
+        "sha256": "64189bc0fe4ec43e017dc69243584d3fb99a8c8e2a628e9d883d106a50160373",
+        "dest-filename": "babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372",
+        "sha256": "ae0833c0430c3096680db7d321f0af06630074dc0cb9e5c0a8832161c60eddf6",
+        "dest-filename": "babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9",
+        "sha256": "6a586be6bd2e668c0fa3ba48aa41e019c43c85330793ce23f4a10215a5fb33ba",
+        "dest-filename": "babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz#733d3444f3ecc41bef8ed1a6a4e09657b8969ebb",
+        "sha256": "a756a12850903110e8b5714b8bc5d2eb735b9098969aa446015c6ac9193e4ed9",
+        "dest-filename": "babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz#b2078d5842e22abf40f73e8cde9cd3711abd5758",
+        "sha256": "f3eb3389581cd2b13eb11efaa7bbf2d89ba6b338ba61562206c3299ddaec0470",
+        "dest-filename": "babel-plugin-transform-es3-property-literals-6.22.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e",
+        "sha256": "72f6aeb6f5c93b0b457a6f4aabaad04acfa28b9a4714ad3134e8e72fcc37b9e9",
+        "dest-filename": "babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f",
+        "sha256": "832e40c88f4f2b499e289985b6ffc686ced9a2a27a2e743857250e7aa0d4ba3f",
+        "dest-filename": "babel-plugin-transform-regenerator-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.6.5.tgz#079a982bd56e2235e31ee3b17ad54aeba898d4e7",
+        "sha256": "dffba0e938028819068024ce2f4ad88b277c215cacce1a1bf5055ff6678e1a53",
+        "dest-filename": "babel-plugin-transform-regenerator-6.6.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758",
+        "sha256": "3f009b8bc9f42b66cff4a4f1fcca53e32d3122838dbc8cb89ee4e89c19aa7291",
+        "dest-filename": "babel-plugin-transform-strict-mode-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153",
+        "sha256": "c5832182f92d691d5a786bb65c263fa659f21b61e954afb38755ca241abebc16",
+        "dest-filename": "babel-polyfill-6.26.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2676,9 +4629,86 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b",
+        "sha512": "33b2d0d1bc5aae4c50a0dfafcf96893ec2c19fbee7f10813166a3c58ad3fe386ae2b6c65097ad8714c47171814eea5b9633c3f0a398b44adae27368277b2efa9",
+        "dest-filename": "babel-preset-current-node-syntax-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-preset-es2015-mod/-/babel-preset-es2015-mod-6.6.0.tgz#e105b62eb7c1001090ab86225298904cf90c1e8e",
+        "sha256": "132552a47aaeccff043efaee9d53747630bd8b66027e13ea0acb800b08a76657",
+        "dest-filename": "babel-preset-es2015-mod-6.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939",
+        "sha256": "89abd630f618a53a9608c5b3e4a5d7ce2deeb68e925bb027160b8cdd7cf104f4",
+        "dest-filename": "babel-preset-es2015-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.6.0.tgz#88b33e58fec94c6ebde58dc65ece5d14e0ec2568",
+        "sha256": "62bfe43219a66c6529cf05b222b1d890a47fc871f0d6d0a48a009c3f6ae87b60",
+        "dest-filename": "babel-preset-es2015-6.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-preset-es2016/-/babel-preset-es2016-6.24.1.tgz#f900bf93e2ebc0d276df9b8ab59724ebfd959f8b",
+        "sha256": "d7fd839ec3b5696def4a8206014bca386165f627172acba198e6ab65aa35aa12",
+        "dest-filename": "babel-preset-es2016-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-preset-es2017/-/babel-preset-es2017-6.24.1.tgz#597beadfb9f7f208bcfd8a12e9b2b29b8b2f14d1",
+        "sha256": "e2678aa5aff7992b7f25a68c0f4e9c761de802a7565ce800d0b74a70c680e531",
+        "dest-filename": "babel-preset-es2017-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-preset-es3/-/babel-preset-es3-1.0.1.tgz#e08dd950a1670dab8b50abceaa9b93d3d9accd1e",
+        "sha256": "55bab8a54c96f59ec9ffe24b89e8d16586dd7424f8d5bfa88bfe12f3ddef742c",
+        "dest-filename": "babel-preset-es3-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-27.5.0.tgz#4e308711c3d2ff1f45cf5d9a23646e37b621fc9f",
+        "sha512": "edb7eed5c2419602bf9ca7d3bcc9449730378e98ba1b30d65f77e7b67c8fd9c412ce88bf294cfa7b01a571bdcf4916191b2bfeb8f9d51d8d089b725bb158aa80",
+        "dest-filename": "babel-preset-jest-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz#fa05fa510e7d493896d7b0dd2033601c840f171c",
         "sha512": "d01ddb87147ab27597259b51fd19621d30cf4609f5b0d1ce474c95b6afc8890172b8e563152fb0ba2a3f478812364c9898a989078c0666fd8d65a9e62a64e734",
         "dest-filename": "babel-preset-jest-29.6.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-preset-latest/-/babel-preset-latest-6.24.1.tgz#677de069154a7485c2d25c577c02f624b85b85e8",
+        "sha256": "0d32228c58cee79e1c28ecdbd60ba655cbe1698b747ebe376a4caf24b4c695dc",
+        "dest-filename": "babel-preset-latest-6.24.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071",
+        "sha256": "ce40b5b54ecf4049bda21168d66db50ddf080f5995bd358e53edcd5c41d215e4",
+        "dest-filename": "babel-register-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19",
+        "sha256": "a06d81bbc70200b4d31efe11e7189a714bb01799a41a09a1e3faf6b9a3cb6ae8",
+        "dest-filename": "babel-runtime-5.8.38.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2690,9 +4720,79 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe",
+        "sha256": "14d2488946744b70c47999b48b1989aa3b85d828181b3c61f35818be9033946b",
+        "dest-filename": "babel-runtime-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02",
+        "sha256": "0560b9872b2eec15ed29a81e4fbd1326d47f80e951f62287cc6ba347e832df83",
+        "dest-filename": "babel-template-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee",
+        "sha256": "a32a6f73c2770a56bd1f8a92b50d8c1a7824523170bd93227a7deeb20b3f1ac9",
+        "dest-filename": "babel-traverse-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497",
+        "sha256": "87be443f0c98a35a9d9c718e7eab868529bb515206cf284fbcfbe762ba196de9",
+        "dest-filename": "babel-types-6.26.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3",
+        "sha256": "ce1e81d36b5789279f8aba716d2ec5aabecbc306585f867f1a6a1c8dc478d88c",
+        "dest-filename": "babylon-6.18.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947",
+        "sha256": "67fb84b00393fbc8cf65d325e741d9fad729daa87216bc0e57a5ec20c507da12",
+        "dest-filename": "backo2-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838",
+        "sha256": "2af5559389b5274d3a8b5834dad7bbe0ca51509324f8cc2ecc2a368de4e20ad8",
+        "dest-filename": "balanced-match-0.4.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767",
+        "sha1": "89b4d199ab2bee49de164ea02b89ce462d71b767",
+        "dest-filename": "balanced-match-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767",
+        "sha256": "2896602c12d3cef566bfbed7ccdef79232f4f1e00622fc5c9b40737465baffad",
+        "dest-filename": "balanced-match-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
         "sha512": "de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
         "dest-filename": "balanced-match-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bare-events/-/bare-events-2.3.1.tgz#5af2ee0be9578f81e3c1aa9bc3a6a2bcf22307ce",
+        "sha512": "b099d2393544494459eb55e01257aa98fdb9e53eb34d8c073f0138afa4acb0887453dfee0ef7e9768258a5551eac92591f67ee78ef82753f194fe382ffb6990c",
+        "dest-filename": "bare-events-2.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2704,9 +4804,72 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8",
+        "sha256": "1fa54c7c3ccce10f005415b6680df8015834c9614d7556a8220fecf2b7b45a62",
+        "dest-filename": "base64-arraybuffer-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.3.tgz#fb13668233d9614cf5fb4bce95a9ba4096cdf801",
+        "sha256": "bd4659df62a1279233db13d87927ec65d224d2163ee4a6b30e393adaa6c8d87f",
+        "dest-filename": "base64-js-1.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a",
         "sha512": "00aa5a6251e7f2de1255b3870b2f9be7e28a82f478bebb03f2f6efadb890269b3b7ca0d3923903af2ea38b4ad42630b49336cd78f2f0cf1abc8b2a68e35a9e58",
         "dest-filename": "base64-js-1.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/base64id/-/base64id-1.0.0.tgz#47688cb99bb6804f0e06d3e763b1c32e57d8e6b6",
+        "sha256": "01e06819b06f185061803670b23e575e2cb0092de6f0948b602a43f67b12c9e9",
+        "dest-filename": "base64id-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/batch/-/batch-0.5.3.tgz#3f3414f380321743bfc1042f9a83ff1d5824d464",
+        "sha256": "c600c80bbf0b327b8991c7ea26b643d47bbd3c95ae217b32773e14ef6d369db3",
+        "dest-filename": "batch-0.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16",
+        "sha256": "2c1ae9bf8523ff4037bbf4f4558b31be1b37313fd629dbe8c66eea229c08aa3f",
+        "dest-filename": "batch-0.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d",
+        "sha256": "da5811c666dfbb44633116cb2698a0619da7514f77e03879ff9c38ce549a1679",
+        "dest-filename": "bcrypt-pbkdf-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e",
+        "sha256": "e13e9e9f5d438223a02a906e6b77dfc97985a4ccf469ddb65261012973f07826",
+        "dest-filename": "bcrypt-pbkdf-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809",
+        "sha256": "53f83758439cb76cdc9327f77f327078d508a623d097f39bbe1eebafcf5b2917",
+        "dest-filename": "beeper-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz#40866b9e1b9e0b55b481894311e68faffaebc522",
+        "sha256": "f517a806b33fc0e3dc145b1f347dc4c360adb4adccebe2aae0c02df4132b7a1e",
+        "dest-filename": "better-assert-1.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2718,9 +4881,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e",
+        "sha256": "cae37bac595b4f31a9812de8d19d82460004e1f3269ca666125cc388af8e6dce",
+        "dest-filename": "big.js-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328",
         "sha512": "bf22f63b2989c666ab3bc83132bd2684286c3bd406c21ca77eebb8f8c1d3016e9ccdfabd86e98207bacaa548c377d6148833d4e26ce9caea454af382940c1b99",
         "dest-filename": "big.js-5.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205",
+        "sha256": "749771ea8630c87f11dc086530aae1019249c9549ed744dc1a1497be79ace9ec",
+        "dest-filename": "binary-extensions-1.11.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c",
+        "sha512": "3e196dd29960a482013864d3fde85f1676cd95fb03122aa6cc4d8a457a17d5b2c8962af85ff311fb34b204490bd397df5a09d149ffc35eff96ad4015afddffa3",
+        "dest-filename": "binary-extensions-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2732,9 +4916,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/bind-obj-methods/-/bind-obj-methods-1.0.0.tgz#4f5979cac15793adf70e488161e463e209ca509c",
+        "sha256": "32d35b94b22de61805e035244028a030dd1760e326002d732261c8b30a55e492",
+        "dest-filename": "bind-obj-methods-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bl/-/bl-0.9.5.tgz#c06b797af085ea00bc527afc8efcf11de2232054",
+        "sha256": "ecf3bb1c5765c897989958ef45a7134f3325a099c26608788879d35a8a416900",
+        "dest-filename": "bl-0.9.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/bl/-/bl-3.0.1.tgz#1cbb439299609e419b5a74d7fce2f8b37d8e5c6f",
         "sha512": "8eb096e5985f43f56dd3b597d4d82cfb29fd043a8f2ff830dbc4bbb3d1fa40afe0ba99e2ccdcc902cb396a45b6d084a03ab6cb4e55ce3824c978d510aabb8059",
         "dest-filename": "bl-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489",
+        "sha512": "7ece06ebf1eee3f104f85ef927c0ee37fd08a50a8d8c0742eda110bfb42df0c1c6507ec292fd8cc1310478df507a10f4a5f20390c2356e41d890acbbc47c8a22",
+        "dest-filename": "bl-4.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921",
+        "sha256": "5266e0bef611df8a2ff768724c917e45e7e700bff031e278006a5a4e4e27e82e",
+        "dest-filename": "blob-0.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a",
+        "sha1": "13ebfe778a03205cfe03751481ebb4b3300c126a",
+        "dest-filename": "block-stream-0.0.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a",
+        "sha256": "d900ce261c297442a61c9791211c622e42d292b5478d9408221e19ff810d717b",
+        "dest-filename": "block-stream-0.0.9.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2746,6 +4972,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1",
+        "sha256": "49de1425a5886e0e7eebd1d25cffd0596cc3d5f3577a5edddf962f378fdafb67",
+        "dest-filename": "bluebird-2.11.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9",
+        "sha256": "b72913a58374c9b1b0610b86bbd3b304adee5b73f592b0707ef60e9926716890",
+        "dest-filename": "bluebird-3.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9",
         "sha512": "30a88b895f88d40039f7ab7dc35b1027c8e4892af9f992a2d162ab606527e9dd45c7e223e2d223fa6d96310486733b398d9571577dfd72113c8b093a17ae308c",
         "dest-filename": "bluebird-3.5.1.tgz",
@@ -2753,9 +4993,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de",
+        "sha512": "0dd9b2a060a57899e46e9de791bc532c9d7cae30ec138c8282013028d5e4795d76dec3cd7ce098783a1eb8e63e17616b4a33b561771353e76ccbde8a332fa072",
+        "dest-filename": "bluebird-3.7.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f",
         "sha512": "5e9363e860d0cdd7d6fabd969e7ef189201ded33378f39311970464ed58ab925efd71515f9acf1026f2375664dd3a413424fb63765c1f6344392f6e6426711b6",
         "dest-filename": "bluebird-3.7.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.12.0.tgz#be7367938a889dec3ffbb71138617c117e9c130a",
+        "sha512": "ce8f8721d221ce88efe85d6c8903ea3c544ec95cbb0b9d0acc7bff93f233f81b6fb55cd21d788c5cea6adb009f364781a9d0aff95f17395f7ab6c12dd96ff7ad",
+        "dest-filename": "blueimp-md5-2.12.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/body-parser/-/body-parser-1.14.2.tgz#1015cb1fe2c443858259581db53332f8d0cf50f9",
+        "sha256": "cb6007be137a5e6285f4d552f1009186609b7e89e7a0cf7c3b9c8f31c2601cc7",
+        "dest-filename": "body-parser-1.14.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454",
+        "sha256": "3f8a5db54c8cc647d4f1846b96aeadc5ee78d19582e6dd320c56575361070027",
+        "dest-filename": "body-parser-1.18.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2781,9 +5049,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f",
+        "sha256": "a61cb4df27252b2945f69cdfcbe4bc879bf57ea1a4a7ec5838ef7fa56294cedc",
+        "dest-filename": "boom-2.10.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31",
+        "sha256": "400761ec483099a94903fc024d3cd0cd1192ade340b017b60d1b4b778b8aa59c",
+        "dest-filename": "boom-4.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02",
+        "sha256": "b45c0d14c84c11e8c0d7ea399fb6c2b757c9293a2d379fc488f32f4db7c03331",
+        "dest-filename": "boom-5.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b",
+        "sha512": "4cd3e37d3af8df6ab1ef23a34326979b7752474307f6f5e9ede4f50454a5fc2e7583e1059ce47d85383522b79a8460660cd09e86c72c85ee397fe0b54c165b2f",
+        "dest-filename": "boxen-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/boxen/-/boxen-3.2.0.tgz#fbdff0de93636ab4450886b6ff45b92d098f45eb",
+        "sha512": "714e09ffe36874cdc81dd48bdb237c6ea62a9e69414e2743478442ee726ceb5666b46cfc559cccdc72d05f4cd8e66ad298fb51df15b0b2ada339442a15937cf8",
+        "dest-filename": "boxen-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.2.0.tgz#43a9d183e5bf9d545200ceac3e712f79ebbe8d0e",
         "sha512": "cf433e6f23138734260fd3482d19e20945d8b18a63c2794ef0de6e085682a883a9a91b090ab40bf4d2b726c0faec23796b4f27179a082f66c3ea5a137473ae2b",
         "dest-filename": "bplist-parser-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+        "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da",
+        "dest-filename": "brace-expansion-1.1.11.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2795,9 +5105,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59",
+        "sha256": "b3c9a39d83fc4c3e37f885b84153aefac683b20fcab248166f65987773af3b0a",
+        "dest-filename": "brace-expansion-1.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae",
         "sha512": "5e7008bd0f1e33e902e9a50bc7ac2e422c15b27cec8bd7775b1cd5dc5a564c6035f45eb6d64c1d6ec01c14a5e02941d95accbe998ea22f5b074f1584142cad0c",
         "dest-filename": "brace-expansion-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/braces/-/braces-0.1.5.tgz#c085711085291d8b75fdd74eab0f8597280711e6",
+        "sha256": "8aa0c6707b44c65bccdca12771547cf49f7c5e1f1c9c207b47613360589c54f2",
+        "dest-filename": "braces-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7",
+        "sha256": "9c7fdc41cccb6e146eb1e4c1f9236af514a6c261f8b230fdd3a1ca979e8c2395",
+        "dest-filename": "braces-1.8.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2812,6 +5143,48 @@
         "url": "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107",
         "sha512": "6fcba6f8bd51cccdd60d2cef866ea0233d727d36c1b7a61395c10a02fb26a82659170e3acfadba9558fd8f5c843d6df71f91fe94142964c3f593c97eefc1dad0",
         "dest-filename": "braces-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626",
+        "sha512": "f68e5479c2371a192933a0eb5ebebd3db948b96c4f2a4f58d231c1461768719db2ed81020450ac1e6efd3ebdcec91d80be384391a6c525a0c931845acc782ca3",
+        "dest-filename": "browser-process-hrtime-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce",
+        "sha256": "0e2dd5b2e04f8f6e27ceeb659623261bf7859c1f482a77dde6c773a08ab8f14b",
+        "dest-filename": "browser-resolve-1.11.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f",
+        "sha256": "a711aeeb3d1d7d50b984d8dc89f18ea55e5566c7819de9beb21cf15c0521a87e",
+        "dest-filename": "browser-stdout-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-0.4.0.tgz#067149b668df31c4b58533e02d01e806d8608e2c",
+        "sha256": "a7b7def7f86abe9640d6a767e56af25a14ee46c89dddf4911a2f95d532a99a6e",
+        "dest-filename": "browserify-aes-0.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.1.4.tgz#bb35f8a519f600e0fa6b8485241c979d0141fb2d",
+        "sha256": "e63bb7a2388c6837470407d48b906b85ab2cd2bcc0a877ba15bd4878aef4bc35",
+        "dest-filename": "browserify-zlib-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browserslist/-/browserslist-4.19.1.tgz#4ac0435b35ab655896c31d53018b6dd5e9e4c9a3",
+        "sha512": "bb6b5b6c6e4f74a45352872d3b73410fc150e4774f8756573c7ce9d6bc1a6b98d373e455f7ff9195688020a9a344f405fb16c633d2a4963e5b65015adacff7f0",
+        "dest-filename": "browserslist-4.19.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2844,8 +5217,29 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05",
+        "sha512": "810c53344fc601f208ae61cb504de8272a7914ee874417e18e7c38ff032603add91832675819a063f972401a670d490698085b49edfdb71d9dfe24ce01f825c1",
+        "dest-filename": "bser-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buf-compare/-/buf-compare-1.0.1.tgz#fef28da8b8113a0a0db4430b0b6467b69730b34a",
+        "sha1": "fef28da8b8113a0a0db4430b0b6467b69730b34a",
+        "dest-filename": "buf-compare-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242",
         "sha1": "0d333e3f00eac50aa1454abd30ef8c2a5d9a7242",
+        "dest-filename": "buffer-crc32-0.2.13.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242",
+        "sha256": "27d1154427f0131259994c6849888411be7d43723589e383487fd5886f53c66d",
         "dest-filename": "buffer-crc32-0.2.13.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -2854,6 +5248,13 @@
         "url": "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.1.tgz#2f7651be5b1b3f057fcd6e7ee16cf34767077d90",
         "sha512": "428577a6d804690a6f5706d77523b7f62a8f4130b1485ec0e54f7d0316c762a51d0a2ccbfe51f6674036cba9db66e7313043ad37265f1b6b3a82c56e806a4a92",
         "dest-filename": "buffer-equal-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer-from/-/buffer-from-0.1.2.tgz#15f4b9bcef012044df31142c14333caf6e0260d0",
+        "sha512": "4625887a7bac26c988d8a72fa9000107cded2f1081c84deea523fc414deb2433151463d62ef3d026dfced52bbd9a8456787eddf90d8761bebc7fafaffadc36be",
+        "dest-filename": "buffer-from-0.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2872,9 +5273,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51",
+        "sha256": "8a48c530185235304d1c0c7185f8162d4b17c4483a06da2e48c8490eaaf2adbb",
+        "dest-filename": "buffer-shims-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298",
+        "sha256": "186d0c8a8ded6ded2b5166d90a927d9084dc2d65459c0a349bb040ac2eb389a6",
+        "dest-filename": "buffer-4.9.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0",
         "sha512": "10773220f050e0148696f8c1d7a9392a0009dbb088b0763fd8906609145ea38f32f6b43731a533597dca56505ae14eccc97d361dd563d0aec2dd6681de3bbb15",
         "dest-filename": "buffer-5.7.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bufferstreams/-/bufferstreams-1.1.1.tgz#0161373060ac5988eff99058731114f6e195d51e",
+        "sha256": "2b6df127bcbf9971f81c94da24180751de48d60602ca4c29706bf8d36137f8b9",
+        "dest-filename": "bufferstreams-1.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2900,6 +5322,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f",
+        "sha256": "e789717824e8688269c241c203d9f615cf15286d6217d74defc7f395b0da5f11",
+        "dest-filename": "builtin-modules-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8",
+        "sha256": "316e1896e859fcbfb492c4af3e7bf5d74e2443e98c04929b36e96c7541b79db8",
+        "dest-filename": "builtin-status-codes-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/bundle-name/-/bundle-name-3.0.0.tgz#ba59bcc9ac785fb67ccdbf104a2bf60c099f0e1a",
         "sha512": "3ca03805e4af06940a43c88f38609289e965f8df0ff937f50e5c2a9988697b680084a3c79fc1183b1553f9286e1a6860f2537c5e24a54bcd32884c4a5eb51197",
         "dest-filename": "bundle-name-3.0.0.tgz",
@@ -2914,9 +5350,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/bytes/-/bytes-0.1.0.tgz#c574812228126d6369d1576925a8579db3f8e5a2",
+        "sha256": "32954618600f6566ecd95aec0ea0ae3318a1b4a29bf6a7970462c29a843bf701",
+        "dest-filename": "bytes-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bytes/-/bytes-2.2.0.tgz#fd35464a403f6f9117c2de3609ecff9cae000588",
+        "sha256": "d14c9e01e6b767719f4cf821bef2b9de221821f20031fa2a071a144e78621975",
+        "dest-filename": "bytes-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339",
+        "sha256": "3106da5d0bafb3b5f446a95c62a37d339ab3cb807df72fe1245101ef6ba4a164",
+        "dest-filename": "bytes-2.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048",
+        "sha256": "67792a7835e3bd2a584307ece4432f21d4bcad19e248957164e41781204c54e5",
+        "dest-filename": "bytes-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5",
         "sha512": "fcd7fb4f2cd3c7a4b7c9124e6ce015efde7aafc72bdbe3a3f000b976df3048fdc1400a1e5f9f0da07c8253c3fccc690d5d2b634d28ba7f33ba174a4175c61b12",
         "dest-filename": "bytes-3.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cacache/-/cacache-18.0.3.tgz#864e2c18414e1e141ae8763f31e46c2cb96d1b21",
+        "sha512": "a9709de2b87a234edc9c3aa1f15e3cffde1373f5927e3fa8dc69fa359d1a668bd2db9e5b531f0ed77b8ac5115dd9e586d3182c728efe608b5034f69ae44f3986",
+        "dest-filename": "cacache-18.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2935,9 +5406,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912",
+        "sha512": "3a3ddc0063c2a8e657ed1cfae149f2d8660064d962412a9f6de3eb800435c0a022858982527ada06d26d29c191e31cfbc05f8ba090beb2c159befe41805f4882",
+        "dest-filename": "cacheable-request-6.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.2.tgz#ea0d0b889364a25854757301ca12b2da77f91d27",
         "sha512": "a68b96f3f16688f41bb86a645d0f4100fbff328e710c600d812357cd3cc9f03aca1ae5ceb2c338c084118df6a735187762ee5c7d83ef728aea6e183628826d7b",
         "dest-filename": "cacheable-request-7.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/caching-transform/-/caching-transform-1.0.1.tgz#6dbdb2f20f8d8fbce79f3e94e9d1742dcdf5c0a1",
+        "sha256": "896fdefa039680425b81fd9837eef6c4e3c01cab9306418eba4374fb3828ceca",
+        "dest-filename": "caching-transform-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/caching-transform/-/caching-transform-3.0.2.tgz#601d46b91eca87687a281e71cef99791b0efca70",
+        "sha512": "32d81cbf7961dd4d334628bfeaa56040e0dd3c0e06df3846fa3b5b0968f7f515ee5054cccc7d2f71d32d6894b58cfa3077e22dd8faabeb2dcd24c42a3aa084db",
+        "dest-filename": "caching-transform-3.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2963,6 +5455,48 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/call-matcher/-/call-matcher-1.1.0.tgz#23b2c1bc7a8394c8be28609d77ddbd5786680432",
+        "sha512": "22840b78dc307fd29335bb5203b68405bd727c36dd9f3c2309eb63902f22a39a0678e98ad8204d760d31afeb5a75160a3b4a7bb90c99cefa27d245e565bbc6af",
+        "dest-filename": "call-matcher-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b",
+        "sha1": "26d208ea89e37b5cbde60250a15f031c16a4d66b",
+        "dest-filename": "call-me-maybe-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/call-signature/-/call-signature-0.0.2.tgz#a84abc825a55ef4cb2b028bd74e205a65b9a4996",
+        "sha1": "a84abc825a55ef4cb2b028bd74e205a65b9a4996",
+        "dest-filename": "call-signature-0.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f",
+        "sha256": "ed68cc7e1c03ff41f6dc57f857113f23ef3ef6c1e8d4615fd59e00e724dfd4eb",
+        "dest-filename": "caller-path-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20",
+        "sha256": "876b917417dc17e9fe43fa3ea81bb52531d95ef62ef51272b636e08ec20ef347",
+        "dest-filename": "callsite-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca",
+        "sha256": "e300486ed2df652216ad05a0325c2aa9f866149e8cb512d3085968c0f5eb249c",
+        "dest-filename": "callsites-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73",
         "sha512": "3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69",
         "dest-filename": "callsites-3.1.0.tgz",
@@ -2973,6 +5507,48 @@
         "url": "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a",
         "sha512": "83119606b4d3d49b8cc7a47ea393d35cc9949e19d5ccb43d48dbad0f862a2ad23a6a9f3deedded28409895aea0096124a655e794dc9b124660f46106c4a14283",
         "dest-filename": "camel-case-4.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7",
+        "sha256": "103680f30598d0217c8b64d899bb2c04d9b0a6756bffa2552651dd24a2eae9e4",
+        "dest-filename": "camelcase-keys-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77",
+        "sha1": "a2aa5fb1af688758259c32c141426d78923b9b77",
+        "dest-filename": "camelcase-keys-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39",
+        "sha256": "09f39e3f9fdde6f23671234381258840cc1995dc76fca7612c01bb5607fa50e1",
+        "dest-filename": "camelcase-1.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f",
+        "sha256": "3dc15e1abb0eb9fa85846e661df399ccbcdbd1bf100506eadc610c8667c686a6",
+        "dest-filename": "camelcase-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd",
+        "sha1": "d545635be1e33c542649c69173e5de6acfae34dd",
+        "dest-filename": "camelcase-4.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd",
+        "sha256": "9a3bf68000a538b7f58d96a81eca7267965b058167ea2990782c170eda7592f5",
+        "dest-filename": "camelcase-4.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2991,6 +5567,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz#e0ee78b9bec0704f67304b00ff3c5c0c768a9f62",
+        "sha512": "3e5f2f7e28260575eafbfc94cf58d4c142deabdc61309ce7cdd73fc7097859c94302e79b7131d579fa73f2513f6cc23e50ded33a44927bb07b46765debe7738c",
+        "dest-filename": "caniuse-lite-1.0.30001309.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001384.tgz#029527c2d781a3cfef13fa63b3a78a6088e35973",
         "sha512": "0415ade7b92a59b7341986576f8ef04d7a66020aabe4b4a26cfccd8e4fc058c76624c4212ea3a5ddcfca77838053fb6ee0d2df624331f1396add154190e06895",
         "dest-filename": "caniuse-lite-1.0.30001384.tgz",
@@ -3001,6 +5584,48 @@
         "url": "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz#a528b253c8a2d95d2b415e11d8b9942acc100c4f",
         "sha512": "c6b13ffdadceed33f4bda27c8a4ce40f673636071552fb047b622f1539ed57861dd59f4557387e816f9e9d7f7a2f4a6cadb68531c55c1f697dd3136e18359cf3",
         "dest-filename": "caniuse-lite-1.0.30001565.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d",
+        "sha512": "99840b667c7942dd49801d561223027f6eb8ee996919e43634c47fe4bd07359cc6428e1fb923e72bec237cf9ca655d1a8890e0ce65aaaa457f83b243f835b4ab",
+        "dest-filename": "capture-stack-trace-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7",
+        "sha256": "932b3f659aec445a9b1543ed7b69afcd9a45e7e5065a7c68caa11e25d3124b10",
+        "dest-filename": "caseless-0.11.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc",
+        "sha256": "4d7eb172144890213264deda324bd94a7654302265d18e66bfaa63a351fdae98",
+        "dest-filename": "caseless-0.12.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/caseless/-/caseless-0.9.0.tgz#b7b65ce6bf1413886539cfd533f0b30effa9cf88",
+        "sha256": "846f0201b6785c18be5608e18c039afd58686d28d96fb3928bf7a8515b30db89",
+        "dest-filename": "caseless-0.9.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad",
+        "sha256": "447c612d0c7d8985c9d8862cc83bf4c29d122a085e21ce25fa1611e1a259b28f",
+        "dest-filename": "center-align-0.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247",
+        "sha256": "aca8137bed5bb295bd7173325b7ad604cd2aeb341d739232b4f9f0b26745be90",
+        "dest-filename": "chai-3.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3019,6 +5644,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98",
+        "sha256": "33979c4833fa486f3e1ea6afb5557e55abc38d37ad518e80c9f9261c9d54445d",
+        "dest-filename": "chalk-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba",
         "sha512": "033e73251d8206e8daa76aea5c668929a3c7c89d08ad48a6bd8357fa7702cbc3c93f896d3864eb1d4228d3ded968bdb331e298a6209da83bd2eb376b4c5a24dd",
         "dest-filename": "chalk-2.3.0.tgz",
@@ -3026,9 +5658,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65",
+        "sha256": "1e48c7d2f0e154fe9da418482ddb1bbc4ca9b8d12f82249ee56e3f73ae09c23d",
+        "dest-filename": "chalk-2.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424",
         "sha512": "32d8be7fd96924d730178b5657cfcead34ed1758198be7fc16a97201da2eada95c156150585dbe3600874a18e409bf881412eaf5bb99c04d71724414e29792b9",
         "dest-filename": "chalk-2.4.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a",
+        "sha512": "ab0c75d80c577b6439c50e3701cfff23abf96974e2a58ad211274e833acdfbd5e3804a728e92aebd219a378a84f777fb4d04e57ab410f12f844341320e854bd4",
+        "dest-filename": "chalk-4.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3043,6 +5689,27 @@
         "url": "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf",
         "sha512": "916597cedbd9e5205057e79180a15e87cab9b0bb99636fbc5942339715954e0fa81b0635e2aca5c7529b2b31ddf0fe99624020d31c880d4f4930787224c6758f",
         "dest-filename": "char-regex-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e",
+        "sha512": "993f220dcae1d37a83191466a00da1981267c69965311fb4ff4aa5ce3a99112e8d762583719902340938acf159f50f39af6eee9e488d360f193a2c195c11f070",
+        "dest-filename": "chardet-0.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468",
+        "sha256": "97251f40f7d95d94dae3664255898e3539063a1208be5548af3ad1842a07b337",
+        "dest-filename": "chokidar-1.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.0.tgz#12c0714668c55800f659e262d4962a97faf554a6",
+        "sha512": "74698a2c3753dc6765edf0547bc5cafa002d1a6cf2e459f45e491642e63118881654f3ec7b60b1140e66b6b943d133876878c452a9163723f55dd1e82444bfe0",
+        "dest-filename": "chokidar-3.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3082,9 +5749,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/chunkd/-/chunkd-1.0.0.tgz#4ead4a3704bcce510c4bb4d4a8be30c557836dd1",
+        "sha512": "c71dcf6f9545f506aa0a8b68972675cb0141832b899aeebef5d2e2a81c607a512c7bd5ecaf7c94969a17dcee0e875d4cd34193da460cb110724ca20c256d8b92",
+        "dest-filename": "chunkd-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497",
+        "sha512": "bec19d9304820e95a63fcd277004d7ee279ae435907a6835520096e49f2daa3537958c3814162e8fcf49d024d5a2603b0447ef49977ce06987928f8cc45414d8",
+        "dest-filename": "ci-info-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46",
+        "sha512": "e6d2bb12dad9d0df8e2c532d86da8e8f87c8d8979bf3c0b808064fbb6e4b0d55205c9d00dc9b383cc1aaae7d095355b4321d7f67cc19cd83f1a94ad77816e809",
+        "dest-filename": "ci-info-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2",
+        "sha512": "ae24ffdef239629547ebfaa89a50e7268c3a4c179ed8f04a484a71dcedf61063d86d618846c2251919acdd29bbe30604d49328f119ced381dbd76fafd49e480b",
+        "dest-filename": "ci-info-3.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4",
         "sha512": "348c45e7986fe274aa42cc2401e88e8b5afcdf1cbc26574e1434d68ae839e4a06ef499db96771dd94e958879988077f4d533d94bbecd24184130a7568fd1d031",
         "dest-filename": "ci-info-3.9.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ci-parallel-vars/-/ci-parallel-vars-1.0.0.tgz#af97729ed1c7381911ca37bcea263d62638701b3",
+        "sha512": "bba771db41415e6f9aa4c8bee71ed4566e841fb04bd607385eb72741ec23701ec7591728aff579a96737446d87c29803276ea0222d83484bb707bb17ca7030fe",
+        "dest-filename": "ci-parallel-vars-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d",
+        "sha256": "5e2793b948498b64bcc6301e53829d3c1b4654b0b72261a4f0180749a0f4c4db",
+        "dest-filename": "circular-json-0.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66",
+        "sha256": "4c3310ccbfb63fc08f8f316d7b9728c0b54352c45b955977ea78fabb66659c18",
+        "dest-filename": "circular-json-0.3.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40",
+        "sha512": "70e53dbac670f3f7572172adc1af29334393250b8993130deb0df472c35151eac77de43947a53792453f16d25e21fdccdb4d8e1df63653c71c227046effc6880",
+        "dest-filename": "cjs-module-lexer-1.2.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3099,6 +5822,13 @@
         "url": "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.5.tgz#17e793103750f9627b2176ea34cfd1b565903c80",
         "sha1": "17e793103750f9627b2176ea34cfd1b565903c80",
         "dest-filename": "class-utils-0.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463",
+        "sha512": "a8e84f6bf163eece9363c1fc7ac1aee5036930c431cfbf61faeaf3acd60dea69fef419f194319fe5067e5de083b314a33eab12479e973993899a97aeae72cc7a",
+        "dest-filename": "class-utils-0.3.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3124,9 +5854,128 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b",
+        "sha512": "e1d882f4769313e29100c5a10e1ac63840a0599c687af31ce5396439b32a352b1553ad8f6335d9fd23138f3c8600517562eb20c46712593117061a7408fc10d4",
+        "dest-filename": "clean-stack-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz#63fb110dc2ce1a84dc21f6d9334876d010ae8b68",
+        "sha1": "63fb110dc2ce1a84dc21f6d9334876d010ae8b68",
+        "dest-filename": "clean-yaml-object-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz#63fb110dc2ce1a84dc21f6d9334876d010ae8b68",
+        "sha256": "ea6e988354b7bbae8fbbb0ea538483ce30b0fe69f51c23ec6937ac1d56ca3912",
+        "dest-filename": "clean-yaml-object-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143",
+        "sha1": "4fa917c3e59c94a004cd61f8ee509da651687143",
+        "dest-filename": "cli-boxes-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d",
+        "sha512": "829681acc022cd510034ea5f669fc41148b14d70f21adec317374ae6153e51b5adfc9d25074c36d277198f9f59f5af77c476fdbb5db3179052ea2f5129bb60e3",
+        "dest-filename": "cli-boxes-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987",
+        "sha256": "966d25ecd83527aefeb109ac1b622955341f053548c259a9502a928720449505",
+        "dest-filename": "cli-cursor-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5",
+        "sha1": "b35dac376479facc3e94747d41d0d0f5238ffcb5",
+        "dest-filename": "cli-cursor-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307",
+        "sha512": "23fcc7030b0a7fd16a1a85cce16591002a1bf7e48dba465377de03585e7b138b68a2e46e95b0b171487a44a5043909584c7267ce43ccc92bcf35a6922cd7cb67",
+        "dest-filename": "cli-cursor-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.2.0.tgz#e8b988d9206c692302d8ee834e7a85c0144d8f77",
+        "sha512": "b605377cac3362388b11080f303f49b7e2631d52fd916f7716220c5ff97bae2bef383e3f2cbd0c7fb81d6b7fb8536289065a326f0823e4a1284201918a832229",
+        "dest-filename": "cli-spinners-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.0.0.tgz#68ff6aaa53b203b52ad89b8b1a80f1f61ad1e1d5",
+        "sha512": "0b8869fbc18220556c514897730f9c7beef07b1556226c3cad0ae030116ca9eaf1f4bbef7069709bab0c8d060012657f5dbf3bc5cd5be53b71e74e4c4a9655aa",
+        "dest-filename": "cli-truncate-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7",
         "sha512": "9fc7ce8b1c030fa6ff39b8a7cd3ae9d59285cdb82f299beecff4ef7a39cb9f56907c2eabe765c4c7ce459ae0bedc723e24cedca0145752f36a114d8f1d5ac7a6",
         "dest-filename": "cli-truncate-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cli-width/-/cli-width-1.1.1.tgz#a4d293ef67ebb7b88d4a4d42c0ccf00c4d1e366d",
+        "sha256": "2a8c709d66b67318c6eb8dff012acd88fa31b9462eab2b935d1bf450292b6de3",
+        "dest-filename": "cli-width-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a",
+        "sha256": "22ef273d76939cb7d9def92255ba39f563df51df0695c8d62adccbc9aa358c71",
+        "dest-filename": "cli-width-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639",
+        "sha1": "ff19ede8a9a5e579324147b0c11f0fbcbabed639",
+        "dest-filename": "cli-width-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cli/-/cli-0.4.3.tgz#e6819c8d5faa957f64f98f66a8506268c1d1f17d",
+        "sha256": "96545932d177cd118a60d482a41fa819aea4aeed61342addcb88b92ca09c7bfb",
+        "dest-filename": "cli-0.4.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1",
+        "sha256": "7555af1730a8ec76a3fb649d3da5db30d7080f69eab698698c8bf863ac4dcbdb",
+        "dest-filename": "cliui-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc",
+        "sha256": "fb95696399a517ad43910fd7270a11b772d91c0b6546a49aa9022dbe1d93b0a2",
+        "dest-filename": "cliui-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5",
+        "sha512": "3d87864849a61cceb3be879fdb0f133f396b9cda572234e2a582bbf3462cc2620ff6f8f199de98d9adc20762acebf014f0d1e366e817be8f30de858cdaa9f05c",
+        "dest-filename": "cliui-5.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3159,9 +6008,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1",
+        "sha256": "62ab5e392b2022f9ed21070eb5ff01763ce00f86ad2cb0413897a57d642db420",
+        "dest-filename": "clone-stats-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/clone/-/clone-0.2.0.tgz#c6126a90ad4f72dbf5acdb243cc37724fe93fc1f",
+        "sha256": "d719e99c5072e785bdbaa3e35b3e1cfe82437ccc6cf160331ae9fdb5ce785335",
+        "dest-filename": "clone-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149",
+        "sha256": "db06c6dd58dc1e02bafc69e195e6460327370f18736872a02cdbd59ecb6f91ae",
+        "dest-filename": "clone-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/clone/-/clone-1.0.3.tgz#298d7e2231660f40c003c2ed3140decf3f53085f",
+        "sha256": "d6760f140a886ada32f95e78208350cc0aaa2903af308b34cb072af31c5b0412",
+        "dest-filename": "clone-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e",
+        "sha1": "da309cc263df15994c688ca902179ca3c7cd7c7e",
+        "dest-filename": "clone-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cmake-js/-/cmake-js-7.3.0.tgz#6fd6234b7aeec4545c1c806f9e3f7ffacd9798b2",
+        "sha512": "757b36ceaf56c6b57cedba49f966e718abfc5940570f0f1b94d8b0347a117bf8adfa9b6c7318501ca0754895dad70fa4a1c2cc78fdbc4e4e3f79309ece0e28fb",
+        "dest-filename": "cmake-js-7.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184",
         "sha1": "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184",
         "dest-filename": "co-4.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184",
+        "sha256": "21d4362a4a3822e68fe1852409381dd0be9851756eabfbf6d0723ef51e39cf98",
+        "dest-filename": "co-4.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/code-excerpt/-/code-excerpt-2.1.1.tgz#5fe3057bfbb71a5f300f659ef2cc0a47651ba77c",
+        "sha512": "b492e11f7129166ff5c7b85e216d217a65c94d45391169765741085f9e7c8e9d3932dd54e8356bc82824a77977edcc6ab3e0cd6cd8311b8dd2930257a50d7827",
+        "dest-filename": "code-excerpt-2.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3173,6 +6078,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
+        "sha256": "5279ca78986d6381852ac1b02592ae2dc5cc979317284b8aa1d7554107770b3d",
+        "dest-filename": "code-point-at-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/codecov/-/codecov-3.6.1.tgz#f39fc49413445555f81f8e3ca5730992843b4517",
+        "sha512": "214241e961b8ee758aee8e747ad17c8c169dc5d330ec39a8420d39c88963b2d5c504607a725399b088fa883e0ff364f661a214deaabe145bbc2bda718240890d",
+        "dest-filename": "codecov-3.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/codemirror-mode-elixir/-/codemirror-mode-elixir-1.1.2.tgz#61227208d2684d928500af6934e4b9c995fb0960",
         "sha512": "d6822e4551f25212efd196bdb0422c23bbab023d3a1288703bfc958f5d1b83b6879e298743deb85a4deeba83c7d189fc2f7f0490e77e4b050b6290e2090b684c",
         "dest-filename": "codemirror-mode-elixir-1.1.2.tgz",
@@ -3180,16 +6099,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/codemirror-mode-zig/-/codemirror-mode-zig-1.0.3.tgz#bbe0ca19d90b740299b0920256836cc5dce82ba6",
-        "sha512": "5e80393f93ecbb1800801518753a38f8d22b827b16580c7c59b1f5e9a7e5694395bdf3773cc592306cad96bb1549a3aaa62a766101bd91e7665acddb1885e9ec",
-        "dest-filename": "codemirror-mode-zig-1.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/codemirror-mode-luau/-/codemirror-mode-luau-1.0.2.tgz#282689d3f3c10f1bc262c885ce79ff90731d3a72",
+        "sha512": "5af1085f49ad769fec1db42a1c92f264986ef59e8484a1337292be883ac438063fb42000d538683d8710f5e15fe2a4b1fcfdeabc39d6e75f266720529ad2635a",
+        "dest-filename": "codemirror-mode-luau-1.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/codemirror/-/codemirror-5.60.0.tgz#00a8cfd287d5d8737ceb73987f04aee2fe5860da",
-        "sha512": "0042fb2e114e9713e508bf087537090db9499bccab00689bec8f8312b24f75977897a8a6c7c20c80a2b745b95580142acf74d9251e28927434ddbcfeb8d8c160",
-        "dest-filename": "codemirror-5.60.0.tgz",
+        "url": "https://registry.yarnpkg.com/codemirror-mode-zig/-/codemirror-mode-zig-1.0.7.tgz#589416e4de4bd28636a34cbeed276e6fb2d4b380",
+        "sha512": "e24bef6744fbcf6ce86c1a10abfbdf727e9365915d66be4e84f0c70d4a9f913de22bab56d7c4a47ccecc61b5adb3b5e602f5cf97ac02f358b4a690ce0a8397cb",
+        "dest-filename": "codemirror-mode-zig-1.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/codemirror/-/codemirror-5.65.17.tgz#00d71f34c3518471ae4c0de23a2f8bb39a6df6ca",
+        "sha512": "d733ac531de5cc03aefe09cc019910f64a481dc3d839cf72d456e6d94564e5404f91dab7f349e191e946d2a5309b57fbc0fbd36e776ef59625ba0df913001945",
+        "dest-filename": "codemirror-5.65.17.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.3.3.tgz#150d6b4cb522894369efed6a2101c20bc7f4a4f4",
+        "sha256": "deedd2cf9d5abe2bad724e6809bec40efa07215dae85f44d78cd37736bb50bc5",
+        "dest-filename": "coffee-script-1.3.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3215,6 +6148,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed",
+        "sha256": "0b20ed48be09d825e63e623592780923133e6e6de496d3c856e69580f5cd2703",
+        "dest-filename": "color-convert-1.9.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8",
         "sha512": "41f014b5dfaf15d02d150702f020b262dd5f616c52a8088ad9c483eb30c1f0dddca6c10102f471a7dcce1a0e86fd21c7258013f3cfdacff22e0c600bb0d55b1a",
         "dest-filename": "color-convert-1.9.3.tgz",
@@ -3236,6 +6176,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25",
+        "sha256": "b0ef3371fb2563cbeb6379f1639dc2a8c0a895d1d48ac72c7ad43c5ff409784e",
+        "dest-filename": "color-name-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2",
         "sha512": "74ecbedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
         "dest-filename": "color-name-1.1.4.tgz",
@@ -3246,6 +6193,20 @@
         "url": "https://registry.yarnpkg.com/color-string/-/color-string-1.9.0.tgz#63b6ebd1bec11999d1df3a79a7569451ac2be8aa",
         "sha512": "f4caf3d8040b79f907d54bc048a8fabfa863ffb7968239d3fdc56c47c0ae9a278ba13fa0f74d1ec5678da20aadc1e23c7719685cdf410d04d8ae8d685aeff909",
         "dest-filename": "color-string-1.9.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2",
+        "sha256": "61c34eade2dd22c8b767c361c6c0951ca88cf8e671df4c6a75e54712275eb755",
+        "dest-filename": "color-support-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2",
+        "sha512": "aa20639296cc2cefc72faf32fa5878ab4fced4c6458f6457e97fca98c6b7fa0243df3f96c08d59cc31f2b2fa87192de63fa9b39cf724a579b0d6723d7098f246",
+        "dest-filename": "color-support-1.1.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3264,9 +6225,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc",
+        "sha256": "9aa80fa7120a2dae524e03833a732a6b2e5530e7678cf77c7e70109e39f855c4",
+        "dest-filename": "colors-0.6.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63",
+        "sha256": "80f07ff4eaeb43093d654bc1209d67af1eb517533a41de31179c6cc0c2ef060b",
+        "dest-filename": "colors-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243",
         "sha512": "060bca262b95bb58a00541769048d10995e897ac228866d8e62a4bfe854fc26d012fdb08a4c23333c20aeefc2ec48233397315dc4cb9c3ebf1866d2b47f4cdf3",
         "dest-filename": "colorspace-1.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/combined-stream/-/combined-stream-0.0.7.tgz#0137e657baa5a7541c57ac37ac5fc07d73b4dc1f",
+        "sha256": "848e1c4911ea0ef76d105909e43f6dbf6c9d11db836549872e2f0296a06c6f96",
+        "dest-filename": "combined-stream-0.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818",
+        "sha256": "b293da68c7f54cf581abc9a512892c7d2ef41ad5bbc460f390aa2b82d57a14b4",
+        "dest-filename": "combined-stream-1.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828",
+        "sha256": "fe0b19b9d1b297f36350c2087e9139c5b2acf3692ac620ec03cb9bb392f8a099",
+        "dest-filename": "combined-stream-1.0.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3278,9 +6274,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/commander/-/commander-0.6.1.tgz#fa68a14f6a945d54dbbe50d8cdb3320e9e3b1a06",
+        "sha256": "7b7fdd1bc4d16f6776169a64f133d629efe2e3a7cd338b1d0884ee909abbd729",
+        "dest-filename": "commander-0.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa",
+        "sha256": "2851f33fbef1c34ec9b9f2d37b970163a2e0b36fa436cfda80140ab3549bb1fa",
+        "dest-filename": "commander-2.14.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f",
+        "sha256": "7dd7f9210626735d7f3195d900470d687e255e215946415ec3b518f13d2a3453",
+        "dest-filename": "commander-2.15.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33",
         "sha512": "1a956498cf2f176bd05248f62ef6660f7e49c5e24e2c2c09f5c524ba0ca4da7ba16efdfe989be92d862dfb4f9448cc44fa88fe7b2fe52449e1670ef9c7f38c71",
         "dest-filename": "commander-2.20.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/commander/-/commander-2.3.0.tgz#fd430e889832ec353b9acd1de217c11cb3eef873",
+        "sha256": "7d8a726755f1c6900aa9511350866a5dd9a3f91a87fe08efde14c89b4880109b",
+        "dest-filename": "commander-2.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4",
+        "sha256": "197a1e0b408bc686fbf62ed5ef43210251c616ba1b09721e8299d4484217bd47",
+        "dest-filename": "commander-2.9.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3320,6 +6351,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-1.0.0.tgz#cd52f6f0712e0baab97d6f9732874f22f47752c0",
+        "sha1": "cd52f6f0712e0baab97d6f9732874f22f47752c0",
+        "dest-filename": "common-path-prefix-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b",
+        "sha1": "ddd800da0c66127393cca5950ea968a3aaf1253b",
+        "dest-filename": "commondir-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b",
+        "sha256": "5b89851be4f799923e48320a13165883d2ffcb8cd4ec71023263255497c251b0",
+        "dest-filename": "commondir-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080",
         "sha1": "0162ec2d9351f5ddd59a9202cba935366a725080",
         "dest-filename": "compare-version-0.1.2.tgz",
@@ -3334,9 +6386,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1",
+        "sha256": "1cd21bf068bb7544ed0b1e14955430776618c9a8e9233f30607ac304e751e482",
+        "dest-filename": "component-bind-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.1.2.tgz#296594f2753daa63996d2af08d15a95116c9aec3",
+        "sha256": "6ef9e9cd24757d555ae7704bf040af3ea2f85bade4f3b5e0ec721d26a9a394d7",
+        "dest-filename": "component-emitter-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6",
         "sha1": "137918d6d78283f7df7a6b7c5a63e140e69425e6",
         "dest-filename": "component-emitter-1.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6",
+        "sha256": "5ff1fe2cc660cd91de7036c1fa73024bf820ff339aa38643956c2f0fb1c42ded",
+        "dest-filename": "component-emitter-1.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0",
+        "sha512": "45ddec7ba401fac3b54f0a998ec710aeeae910f21f3b4ff26274a29fa43fac3de63aeb47bd4ac202126e6f7afdd2e35bf9211206e134418a01f7461d7dab6c46",
+        "dest-filename": "component-emitter-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143",
+        "sha256": "53760c1c7003b517a46822e883a02eb808f7f25b06f6d4e88c490410d2da2a4b",
+        "dest-filename": "component-inherit-0.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/compress-commons/-/compress-commons-0.2.9.tgz#422d927430c01abd06cd455b6dfc04cb4cf8003c",
+        "sha256": "8903fb6c5808bb74ee90bd620dbf6861b0586cfbf2729c965f047d8c200059d2",
+        "dest-filename": "compress-commons-0.2.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/compressible/-/compressible-2.0.13.tgz#0d1020ab924b2fdb4d6279875c7d6daba6baa7a9",
+        "sha256": "129456edf7186342bb4d9069fdc358baeacb4bdb66d032a343cd121cbd118708",
+        "dest-filename": "compressible-2.0.13.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/compression/-/compression-1.7.2.tgz#aaffbcd6aaf854b44ebb280353d5ad1651f59a69",
+        "sha256": "addf2308a40400e65a2a9c7c35534fa4291d6b8c36e83c3be6b3de054f2b41a4",
+        "dest-filename": "compression-1.7.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3349,8 +6457,43 @@
     {
         "type": "file",
         "url": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+        "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261",
+        "dest-filename": "concat-map-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b",
         "sha512": "fd2aefe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
         "dest-filename": "concat-map-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7",
+        "sha256": "a50982b2f3a23302a571f24414d1862f56473bab1722121ac2fe906be3535237",
+        "dest-filename": "concat-stream-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.1.tgz#261b8f518301f1d834e36342b9fea095d2620a26",
+        "sha256": "92b19ce98afdbf6e1dcc5c731731e6ecffa59979c4600466aa01f5ab67a8905b",
+        "dest-filename": "concat-stream-1.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz#f55b3be2aeb47601b10a2d5259ccfb70fd2f1dd6",
+        "sha256": "36fd27af3865a57a41f9234c56733ed58ca21760c3c7cb9d8136b317ea5691c9",
+        "dest-filename": "concat-with-sourcemaps-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/concordance/-/concordance-4.0.0.tgz#5932fdee397d129bdbc3a1885fbe69839b1b7e15",
+        "sha512": "974445b81f112df092d0fb7621ddfdfe808fca4134d69cb1800172a564e5686460bcb919aed73367c6ad107a53784216fb36165d306e03d70249e10e49cc5179",
+        "dest-filename": "concordance-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3362,8 +6505,64 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz#c6f25defaeef26df12dd33414b001fe81a543f8f",
+        "sha512": "bedbf91ed1a371852016b5dce8ac7be3b07cdcc451552e51d554c44285efb8ffa4308fa27fabb2c15d270c6a22c9d251cb8ca4ee1f687793a0d24c71e335179b",
+        "dest-filename": "configstore-3.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/configstore/-/configstore-4.0.0.tgz#5933311e95d3687efb592c528b922d9262d227e7",
+        "sha512": "0a6aae017141a1caf369233c9ad18f30cfc78969b2229af809c265feb818dae08e6d9fd2edc294d2c8a5c6c96a25e8e5fadfd3f474bc1343d43500fcd4919411",
+        "dest-filename": "configstore-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a",
+        "sha256": "07d73b239b9b920163d4a60f2bb85dfc1e379219d01519995a68a35aab2e9a67",
+        "dest-filename": "connect-history-api-fallback-1.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/connect/-/connect-2.4.6.tgz#012c2fe05018504ed2028668a16903199e6e7ace",
+        "sha256": "d6dbb4e1508f9d6fb41354e6354f2a823e206b8bc5a73c0fd2d2cba76deb3c67",
+        "dest-filename": "connect-2.4.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/connect/-/connect-3.6.6.tgz#09eff6c55af7236e137135a72574858b6786f524",
+        "sha256": "d0c13c236eef620ad994008274e027b04046b933d9e904e48aa8f0903660fcb4",
+        "dest-filename": "connect-3.6.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10",
+        "sha256": "ddec38650f2e8222cf11cd606b049deac50d04712c88d061decd4de650a3cb49",
+        "dest-filename": "console-browserify-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e",
         "sha1": "3d7cf4464db6446ea644bf4b39507f9851008e8e",
+        "dest-filename": "console-control-strings-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e",
+        "sha256": "f0d49b480cfabcf86c98b729e4dca966d17d187152b9458983b889473a128336",
+        "dest-filename": "console-control-strings-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e",
+        "sha512": "b72fdf4de929a43d9f23046f9d901575e3a219dd5ced85c48b16e0253373a9cc4958a4278c9fd5d5b344104ea1ca0a4cdd68f01c55152ba1d38d64b35786bcb1",
         "dest-filename": "console-control-strings-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -3376,9 +6575,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75",
+        "sha256": "ea9307fd609ddce9497e3ca6b49e6102d7326bd337f66c10143b7b326f931f59",
+        "dest-filename": "constants-browserify-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a",
+        "sha1": "fe8cf184ff6670b6baef01a9d4861a5cbec4120a",
+        "dest-filename": "contains-path-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4",
+        "sha256": "8d3dc84ba5e21d73703dbb3ae74f5a44cd1daa15a86c519470f5b6c76d9a23d2",
+        "dest-filename": "content-disposition-0.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe",
         "sha512": "16f7994cdb86c34e1cc6502259bce2eb34c02ff9617a16966d3b6096e261e3f13de43a8cc139a16b7299375680580f1c148847ccc654bcb7af930e51aa4fad49",
         "dest-filename": "content-disposition-0.5.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b",
+        "sha256": "db3e3f71df10b2b226a4e9abdc95a47aaa725e499dcee72099beddedcf9e1948",
+        "dest-filename": "content-type-1.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3390,6 +6617,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5",
+        "sha256": "7f0041f2260a56d45a42138ca14ad07ef266a478374269e98d00c6806b53c9bd",
+        "dest-filename": "convert-source-map-1.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442",
+        "sha512": "e052645f3297103075b270856652cfe20a42dc920b89c0a919bcc6f5ff46eed1aa182cc44d0da158fadc8a703da14e30b5fd9b8946841f9d3ae549cc791df7a0",
+        "dest-filename": "convert-source-map-1.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a",
         "sha512": "2afa78e7d1eb576144275080b22d4abbe318de46ac1f5f53172913cf6c5698c7aae9b936354dd75ef7c9f90eb59b4c64b56c2dfb51d261fdc966c4e6b3769126",
         "dest-filename": "convert-source-map-2.0.0.tgz",
@@ -3397,9 +6638,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz#7e3e48bbe6d997b1417ddca2868204b4d3d85715",
+        "sha1": "7e3e48bbe6d997b1417ddca2868204b4d3d85715",
+        "dest-filename": "convert-to-spaces-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c",
         "sha1": "e303a882b342cc3ee8ca513a79999734dab3ae2c",
         "dest-filename": "cookie-signature-1.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c",
+        "sha256": "89f345e24abee506e690eb6ff5bd1973957f916cba72b2a224ab2355544d5313",
+        "dest-filename": "cookie-signature-1.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cookie/-/cookie-0.0.4.tgz#5456bd47aee2666eac976ea80a6105940483fe98",
+        "sha256": "a917477c448a6a91ef73d550d8d8a6d4864e8fbd247b6f73baaca66c9bfc3b0b",
+        "dest-filename": "cookie-0.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb",
+        "sha256": "ccf7a7212a0d903cf9dd3e655a2d2714dad3f897c05e484717dad937b37fd42e",
+        "dest-filename": "cookie-0.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3418,6 +6687,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/core-assert/-/core-assert-0.2.1.tgz#f85e2cf9bfed28f773cc8b3fa5c5b69bdc02fe3f",
+        "sha1": "f85e2cf9bfed28f773cc8b3fa5c5b69bdc02fe3f",
+        "dest-filename": "core-assert-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636",
+        "sha256": "ee7360136b7f5b9bc46a64635d0164cdfda1369850ad9edc4cb12d4f1182c475",
+        "dest-filename": "core-js-1.2.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b",
         "sha1": "ae6874dc66937789b80754ff5428df66819ca50b",
         "dest-filename": "core-js-2.5.1.tgz",
@@ -3425,8 +6708,36 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e",
+        "sha256": "8980021c6183a5c2171e2a97bcee49ebf7dc7d0953c512deeb9a5740ea0dede5",
+        "dest-filename": "core-js-2.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/core-js/-/core-js-2.5.4.tgz#f2c8bf181f2a80b92f360121429ce63a2f0aeae0",
+        "sha256": "5757a88012b7dc1acac82d472a1d78eee0fa388edce2f4b1a01662565eac0b56",
+        "dest-filename": "core-js-2.5.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f",
+        "sha512": "237f6def8fb8b7ecdabbae043757c4e6fd96df501db5cfd1121cd637e8164515e0e961f9a80b199bad831e9435f9885ee34e3b4f9e63bf3cfb314a85fdd04194",
+        "dest-filename": "core-js-2.6.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7",
         "sha1": "b5fd54220aa2bc5ab57aab7140c940754503c1a7",
+        "dest-filename": "core-util-is-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7",
+        "sha256": "a4a44dab6579ede3e06ade58d26f8fd642eae09153fd59c608fcb7951a499398",
         "dest-filename": "core-util-is-1.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -3439,9 +6750,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/coveralls/-/coveralls-2.13.3.tgz#9ad7c2ae527417f361e8b626483f48ee92dd2bc7",
+        "sha256": "d9b14ba7e11833712e3dd52501d2dbb2eb05d56fd6ed13f7e1d4f2da3f61b3f7",
+        "dest-filename": "coveralls-2.13.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cp-file/-/cp-file-6.2.0.tgz#40d5ea4a1def2a9acdd07ba5c0b0246ef73dc10d",
+        "sha512": "7e6bd5e1c6819e87e13def2439c8ad0704a7d9fdfd40b8e70271aade03bd75f77be66532b7328d641d6175ee901ee9d6d91b7e3b0b8138c7378b5b4d1256eccc",
+        "dest-filename": "cp-file-6.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/crc/-/crc-0.2.0.tgz#f4486b9bf0a12df83c3fca14e31e030fdabd9454",
+        "sha256": "027c180bbbddd0960e6000f7ef60623997dfa61b3c2ef141acf00c29a1763b5d",
+        "dest-filename": "crc-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/crc/-/crc-3.8.0.tgz#ad60269c2c856f8c299e2c4cc0de4556914056c6",
         "sha512": "897de67e0713308ab764a2c8b151406efefe31cd7493169b00641bf07be3035a374f53c8629adb6a443ae5ddc8fb61c61edea748a90cf4f62382824ed8a70505",
         "dest-filename": "crc-3.8.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-0.3.4.tgz#73bc25b45fac1db6632231a7bfce8927e9f06552",
+        "sha256": "5821b71d1e6274de6fb3216be372a81d6d073fdad57e9107456aa11bacd4d1da",
+        "dest-filename": "crc32-stream-0.3.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/crc32/-/crc32-0.2.2.tgz#7ad220d6ffdcd119f9fc127a7772cacea390a4ba",
+        "sha256": "74a11b71d38cf82e5fe1fd5660bb8a04d28e46e9345a90d182f383a015534156",
+        "dest-filename": "crc32-0.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6",
+        "sha1": "06be7abef947a3f14a30fd610671d401bca8b7b6",
+        "dest-filename": "create-error-class-3.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3467,8 +6820,29 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41",
+        "sha1": "7b9247621c23adfdd3856004a823cbe397424d41",
+        "dest-filename": "cross-spawn-4.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41",
+        "sha256": "ad6f0fd0b683c3ae9a325d4c60fb5acbadc98b9fa2915511e49eaf61576fbb79",
+        "dest-filename": "cross-spawn-4.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449",
         "sha1": "e8bd0efee58fcff6f8f94510a0a554bbfa235449",
+        "dest-filename": "cross-spawn-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449",
+        "sha256": "910805e8cd5da64d6f42f789f0965eee18a37c57a2631f764f847f8e8fccff6d",
         "dest-filename": "cross-spawn-5.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -3484,6 +6858,34 @@
         "url": "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6",
         "sha512": "8910cf24a50f544343edd1cf3bcae46ce9cfa720f281c0c5b568e9796342832f163f6ad77315cbf13b2445e425e8eac1d86efe509ada82cd6ad7916e75cec6eb",
         "dest-filename": "cross-spawn-7.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8",
+        "sha256": "dac94398339bad4fcefe7212915171d1838ccf989ac1053910f10b778daa1238",
+        "dest-filename": "cryptiles-2.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe",
+        "sha256": "e107f183d9c876d911868e33e2a6d95c279f5860ffc394063133d2970d905729",
+        "dest-filename": "cryptiles-3.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.3.0.tgz#b9fc75bb4a0ed61dcf1cd5dae96eb30c9c3e506c",
+        "sha256": "dcff4605098b40b5f4a1515d3990e5dfc9245c78dc41f2c51a81464994f05c4e",
+        "dest-filename": "crypto-browserify-3.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e",
+        "sha1": "a230f64f568310e1498009940790ec99545bca7e",
+        "dest-filename": "crypto-random-string-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3523,6 +6925,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10",
+        "sha512": "a77a6f53baf5332caa6d393e59b3492202631b65664c8681d74ac8f772f354fae60c92a4cca60cb71c7202f41747f352ea8b6ecef788efeec106add28c14b69b",
+        "dest-filename": "cssom-0.4.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36",
         "sha512": "88ab9072af8d747aa501cc14634a3f1cbebd5d0ad469074c8e64ad27c2459946a289012b961ae6ba282483f094e04d89d08c94294acc020977e93bcdebb32a4f",
         "dest-filename": "cssom-0.5.0.tgz",
@@ -3551,9 +6960,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ctype/-/ctype-0.5.3.tgz#82c18c2461f74114ef16c135224ad0b9144ca12f",
+        "sha256": "bb58300f21d91728d2f9f8680d70bb9e8806a357fab945eb4be8ead1fbfb47fe",
+        "dest-filename": "ctype-0.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b",
         "sha1": "408086d409550c2631155619e9fa7bcadc3b991b",
         "dest-filename": "cuint-0.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea",
+        "sha1": "988df33feab191ef799a61369dd76c17adf957ea",
+        "dest-filename": "currently-unhandled-0.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea",
+        "sha256": "1c20bcdf73b38daafb49966907bd7f738b6391e606e072d8dfbf296eea16d61d",
+        "dest-filename": "currently-unhandled-0.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425",
+        "sha256": "f2d296db45adc732290bd2d72101700e2b998814c3315b8663d0795c51bdb7e1",
+        "dest-filename": "custom-event-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f",
+        "sha256": "ee05d232649da73fa59d4be7cc04b20cd93444c1ea7f175b0c8168a55e7c94ea",
+        "dest-filename": "d-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a",
+        "sha512": "9bad9284439b437f427eb6a58a51104631faa0032d342575c49c84c792e945851537e12f8a984381473f17786761b0039a488db3aed8fb7ca59a51bb2e7bbe14",
+        "dest-filename": "d-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3565,9 +7016,93 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0",
+        "sha256": "8b79ebde18aa8f10aba37e32dcecbe376023c79776510e06e9a53f5e68555340",
+        "dest-filename": "dashdash-1.14.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b",
+        "sha512": "5f97964d25cefc1266a5d20a091b8a5204828003743b096254adf23ca6f02165354ddc390516a3c65ccc89dbe1fa0c24a3d01f43dcc88f9da9cc5f75437600bd",
+        "dest-filename": "data-urls-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/data-urls/-/data-urls-3.0.2.tgz#9cf24a477ae22bcef5cd5f6f0bfbc1d2d3be9143",
         "sha512": "272fed8f795d8d9268eb7b1502f83a2c7b76987be5e15e80811026343b4b766edf6aab6cc7e6891b8dabb320a8f490a84552b03c5cca9483f1dc32226f048869",
         "dest-filename": "data-urls-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b",
+        "sha256": "58997a22bf6f63e0b6b07103d41c3ae6768dc5007c6717c4ff30ff715b15e2c3",
+        "dest-filename": "date-now-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/date-time/-/date-time-2.1.0.tgz#0286d1b4c769633b3ca13e1e62558d2dbdc2eba2",
+        "sha512": "ffdf82e385fb968b7421e8b27e0266113b5132106274160cd9014522419ad14d64fa14b263cecdc3b3d8dde0eaa6f0819bb23758249f3de66c916fd862aea6e2",
+        "dest-filename": "date-time-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dateformat/-/dateformat-1.0.2-1.2.3.tgz#b0220c02de98617433b72851cf47de3df2cdbee9",
+        "sha256": "e583b01c4d4016259dc1d8e7d90e2179a589da00e12b5d4312df2ccb310859c9",
+        "dest-filename": "dateformat-1.0.2-1.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dateformat/-/dateformat-2.0.0.tgz#2743e3abb5c3fc2462e527dca445e04e9f4dee17",
+        "sha256": "e6ba87c9b00f1b563cbd548c763a3c84d6f62ec683f7739fc21c4062aa3eec34",
+        "dest-filename": "dateformat-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f",
+        "sha256": "5ce5df47b00f65b6d84df8da4692a421edce014ad9d41fd72539fa103d85e453",
+        "dest-filename": "debug-log-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da",
+        "sha256": "ceea3fa142e24474b6d652bfa3f15caabf1f140c628130724332140f7a835d9e",
+        "dest-filename": "debug-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c",
+        "sha256": "5b66325ce2c557425ba9a5ad0b012816d9d9f001d226efd80b288aa0304a9cd6",
+        "dest-filename": "debug-2.3.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-2.6.4.tgz#7586a9b3c39741c0282ae33445c4e8ac74734fe0",
+        "sha256": "3bec8b03f796d1e1309da001ce5703535005a0949f7803570fa32918dd634199",
+        "dest-filename": "debug-2.6.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc",
+        "sha256": "8b3ba67947f1417648a8049a6fd1a21d71d7fe16ea50239e51a13a0e92ce324d",
+        "dest-filename": "debug-2.6.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f",
+        "sha256": "34ae48c66698f1f81e2a2e6e322f34e8a88b0986a3fa7b74bb5ea14c0edb1c98",
+        "dest-filename": "debug-2.6.9.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3579,9 +7114,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261",
+        "sha256": "dac8e5de92ce0e149d5708c893ef9d401fe80729ce9a0d66b4f40678708fd5ec",
+        "dest-filename": "debug-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b",
+        "sha512": "99e97e8dfee7aed125e4f9f5431e3acc0457283a416efcdecec7bba7b2ea20d99da0893c3d83f94b249ac44998bfa4d9d09c84280d61b0221de832218084ed59",
+        "dest-filename": "debug-3.2.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a",
         "sha512": "0858f3618022e1385f890be2ceb1507af4d35c7b670aa59f7bbc75021804b1c4f3e996cb6dfa0b44b3ee81343206d87a7fc644455512c961c50ffed6bb8b755d",
         "dest-filename": "debug-3.2.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791",
+        "sha512": "a58008cde468f09e8a3c4689d1558e8793f391bc3f45eb6ecde84633b411457e617b87cf1f1dab74a301db9e9e8490a45fe5d1426d7a7992ea2cd4bc45265767",
+        "dest-filename": "debug-4.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1",
+        "sha512": "217da7718efcbc34e364c154766b2f211158d827f81670f4c11b3e9d0c0953c2eef7dfed3c575bd15c9b8a23133dedc8eab426c2ca90a9106fc54f9b67f23cb2",
+        "dest-filename": "debug-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee",
+        "sha512": "76813076f9b83c278ae0add140dd990b60585016b1c0b0110aa666323b45f1ae7527645bd31a559681519c2383c2a8e9c270286a8e297a537c97744976fde045",
+        "dest-filename": "debug-4.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664",
+        "sha512": "ff3c70e7ebe1d537effb8427edae67b1b70928f692bc20e1a239fa14497dbeea702b6542483b44884b6aafc0c5b7360539dcfadcb064c5e73b0d8b9cda3a27e9",
+        "dest-filename": "debug-4.3.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3593,9 +7170,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-4.3.5.tgz#e83444eceb9fedd4a1da56d671ae2446a01a6e1e",
+        "sha512": "a6dd1b3449a778322f74bd57b1df680d0ff0ad04645c34f80145a535934f2af5b9c7f8f23bd5455e42543f4eef436ba99b0e4f95a21368f29cdf58cad7757e8e",
+        "dest-filename": "debug-4.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492",
         "sha1": "aa24ffb9ac3df9a2351837cfb2d279360cd78492",
         "dest-filename": "debuglog-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9",
+        "sha1": "d171a87933252807eb3cb61dc1c1445d078df2d9",
+        "dest-filename": "decamelize-keys-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290",
+        "sha1": "f6534d15148269b20352e7bee26f501f9a191290",
+        "dest-filename": "decamelize-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290",
+        "sha256": "b4adeff510e38c3a02703bcba72ffbe3c65b591f13c78c6a459b5e801a3e2864",
+        "dest-filename": "decamelize-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783",
+        "sha512": "574a5f85fafcb2ecf23c63b1de79aae1a1ea69b7a15199fa0a1f64c85a55efd4c60d3585987a94a9775a6d1ed01eac73ad8a25178fad566261506e0e51183975",
+        "dest-filename": "decimal.js-10.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3607,9 +7219,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545",
+        "sha1": "eb3913333458775cb84cd1a1fae062106bb87545",
+        "dest-filename": "decode-uri-component-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9",
         "sha512": "16a51843ef28d79f06c864eb305266b3daa1dc2a932af02a82ab139e42c8f2c2aed34dbca2ba8187134c16415e9f4cc6ca0e9ea40083df6a63564e7c9e0204ad",
         "dest-filename": "decode-uri-component-0.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3",
+        "sha1": "80a4dd323748384bfa248083622aedec982adff3",
+        "dest-filename": "decompress-response-3.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3628,6 +7254,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c",
+        "sha1": "2495ddbaf6eb874abb0e1be9df22d2e5a544326c",
+        "dest-filename": "dedent-0.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/dedent/-/dedent-1.5.1.tgz#4f3fc94c8b711e9bb2800d185cd6ad20f2a90aff",
         "sha512": "f8bc56f8a2d6c6edc75b7336c36ca6a70b6a3eba9847353c7ea8ba161775f1f0402ded796e524f23f238f941ef78c546ea526a07824d778506d12e5c9d51f022",
         "dest-filename": "dedent-1.5.1.tgz",
@@ -3635,9 +7268,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2",
+        "sha256": "b610fbaac6f476465858aff6d1802b8c36927652cc10d805adb00c548a89ab26",
+        "dest-filename": "deep-eql-0.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5",
         "sha1": "f5d260292b660e084eff4cdbc9f08ad3247448b5",
         "dest-filename": "deep-equal-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a",
+        "sha512": "c9df5ce40762a95711f898dcc1441bf4392125cf2780daf431a844046bc3889c3ca6e59a6f6c99961fa791ab0e9d93fe1064c03faad1a76273261259cef345f2",
+        "dest-filename": "deep-equal-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f",
+        "sha256": "8331745fc15edd48bf5065e21b9f8a0ef1103a449682f94d30621feb100f285d",
+        "dest-filename": "deep-extend-0.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3652,6 +7306,20 @@
         "url": "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34",
         "sha1": "b369d6fb5dbc13eecf524f91b070feedc357cf34",
         "dest-filename": "deep-is-0.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34",
+        "sha256": "9865e2fa7e023c342a65d5b23d73b404043d50b6f2c1c24a459caa6d74aba786",
+        "dest-filename": "deep-is-0.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz#4a078147a8ab57f6a0d4f5547243cd22f44eb4e4",
+        "sha1": "4a078147a8ab57f6a0d4f5547243cd22f44eb4e4",
+        "dest-filename": "deep-strict-equal-0.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3673,6 +7341,41 @@
         "url": "https://registry.yarnpkg.com/default-browser/-/default-browser-4.0.0.tgz#53c9894f8810bf86696de117a6ce9085a3cbc7da",
         "sha512": "c17e695ced7e06b84c9126d1385b32c549b48bf7091127323610383cfc5ce35202bafd3965907f317dbcb3c699c7ac6399ab6f79b21aa45ea12c42847299de50",
         "dest-filename": "default-browser-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8",
+        "sha256": "20d21cd370f7b5dea9795fa4be3ca0c8d1e801b31d01f82ba74c842478d9676a",
+        "dest-filename": "default-require-extensions-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7",
+        "sha1": "f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7",
+        "dest-filename": "default-require-extensions-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d",
+        "sha1": "c656051e9817d9ff08ed881477f3fe4019f3ef7d",
+        "dest-filename": "defaults-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d",
+        "sha256": "a15fc2cdd8364c64ae7421f4b26c025e2ad6cf97436817733dff84df4df0ff60",
+        "dest-filename": "defaults-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.0.tgz#b41bd7efa8508cef13f8456975f7a278c72833fd",
+        "sha512": "584dac66872d5a6fefe2c99f08076361badf4b9e4988c45d958f59b9b161b186ed7822bdf81bc0c78615ee73e360ce999d7e4172854ac1f9b2c7db0815381031",
+        "dest-filename": "defer-to-connect-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3754,6 +7457,48 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693",
+        "sha1": "c98d9bcef75674188e110969151199e39b1fa693",
+        "dest-filename": "defined-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/deflate-js/-/deflate-js-0.2.3.tgz#f85abb58ebc5151a306147473d57c3e4f7e4426b",
+        "sha256": "6e2ef2477533b866dd0d70434dd303b38668e9b4bae6148e08e3d87fff77d089",
+        "dest-filename": "deflate-js-0.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8",
+        "sha256": "70dd6dd95dcd35366d284afdebc0e5b7b77676d9a1163e81908132857c58c9c1",
+        "dest-filename": "del-2.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4",
+        "sha512": "4301ae114a2e3f6915c107a702c3a87f916ff0af6ddc3f026bc3717172ab2291078d35cae49da75cb74ff802c8d5c82ff308fb2aec01853c0190e65224a3395d",
+        "dest-filename": "del-4.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-0.0.5.tgz#d4b1f43a93e8296dfe02694f4680bc37a313c73f",
+        "sha256": "f40e440dac0f853577d5225d7bd4b2026ea1447a724f4ba1096e29983ee595dd",
+        "dest-filename": "delayed-stream-0.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619",
+        "sha256": "ac38fce4217dfb1d772427c7d8d0d073e35ecd832915e97a61d9ab5c504129d3",
+        "dest-filename": "delayed-stream-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619",
         "sha512": "672483ecd7fdd5a2c1d11c4be0a1ab28705797b11db350c098475ca156b05e72c3ed20e1a4d82db88236680920edaed04b8d63c4f499d7ba7855d1a730793731",
         "dest-filename": "delayed-stream-1.0.0.tgz",
@@ -3768,9 +7513,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a",
+        "sha256": "bfefdbf411ed50a94c7befbdd75fc49c4ff53b063d481e05bbac2f670acf6461",
+        "dest-filename": "delegates-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359",
+        "sha256": "e0f1deb3ffb30452e7e41e0ee7ad0b6d5c78ddb5c5324a6630446b0c4b17d52d",
+        "dest-filename": "depd-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9",
+        "sha256": "83e26be6b5821152c78a0b247c8290c2cb5e0a0a7f8f673ef238487ae12bc41c",
+        "dest-filename": "depd-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df",
         "sha512": "83b9c7e8fe9dc838a8268800006a6b1a90ad5489898693e4feba02cdd6f77c887ad7fb3f9cfb1f47aa27c8cc2408047f3a50b7c810b49444af52840402cb08af",
         "dest-filename": "depd-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/deprecated/-/deprecated-0.0.1.tgz#f9c9af5464afa1e7a971458a8bdef2aa94d5bb19",
+        "sha256": "dc3db250d03618767c92f1ca619de8f74c550b06ebfda3f6de9deeb7cf2d46c6",
+        "dest-filename": "deprecated-0.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3789,9 +7562,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80",
+        "sha256": "5b579622f4650fdd0effe150fca231e5a8b4cbc464430424a1e730c785423e56",
+        "dest-filename": "destroy-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015",
         "sha512": "dac246253697208691d70e22252368374867318ec6a5cfe7f03e2a482270f10a855977fb72e0209c41f1069c1e69570f7af0b69772a98d80b1dcdca941081a26",
         "dest-filename": "destroy-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/detect-file/-/detect-file-0.1.0.tgz#4935dedfd9488648e006b0129566e9386711ea63",
+        "sha256": "5a2fa1aa41751735c8fc63d82b3e6eb1603d515863cd2600dfb28b22f0e8df3f",
+        "dest-filename": "detect-file-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208",
+        "sha256": "d4436cafa0273e1d69d67968a9432b3b78a1ed2b55a32e57c52f0772f818c3d2",
+        "dest-filename": "detect-indent-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3803,9 +7597,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b",
+        "sha256": "7a2af298b85cb36f877693318e157e4d20719ce8dca02b34d68c12142b71218b",
+        "dest-filename": "detect-libc-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.0.tgz#c528bc09bc6d1aa30149228240917c225448f204",
         "sha512": "4b9e4bcd497c1d46aff25f44d8f053942e4f009ac72bbb6433e5d71460fe7dbb1b913ce10a91ba2b4e4bc497143845b331ae2fea9b5c319f6cddf39d243bb467",
         "dest-filename": "detect-libc-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.3.tgz#f0cd503b40f9939b894697d19ad50895e30cf700",
+        "sha512": "6f0cb43065b9e5b1b8d55ab1c72a4eb1d49d1aa2f05cf23f7e873081360214c6dd522040c4b83d085cc6d3cb33d9aab3927c225fb1e49746d010d8e0f222c1cb",
+        "dest-filename": "detect-libc-2.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3838,6 +7646,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c",
+        "sha256": "a192d9bc1a082c26df075a48b7a5af719693e0e8fca6a0b6d93c4641826d6e8d",
+        "dest-filename": "di-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975",
         "sha512": "c4baa97b3f998fd18a4a73d64b4599c358a01a8719faeb9af3ecbee5d0cd4d3f77e0ddd0b98d6ca762e41f3c22698406cfad2132ad298c0b2175e5e6e5550e13",
         "dest-filename": "diff-sequences-24.3.0.tgz",
@@ -3845,9 +7660,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.0.tgz#a8ac0cb742b17d6f30a6c43e233893a2402c0729",
+        "sha512": "66c3815a7857887f999f40dc04d5ffb6242caab4441ecffaa10b04572d952498eb4db97290f8a66b5d69c8731203fecf1a60fe7f07254e729528bfeab4d4440d",
+        "dest-filename": "diff-sequences-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921",
         "sha512": "12378f2b5b2b0f73f4f28da3e1fd04c67ca5a91b3907db498dca7db7592b1f6a918bc08276c61fc1ef498122eeac5056c2ae2e3a58a9cdf9397c736fc052abf1",
         "dest-filename": "diff-sequences-29.6.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf",
+        "sha256": "3af62189e9387a90422edec8a8431c26a34e3fceef30221f02a0b0bfb16f83a2",
+        "dest-filename": "diff-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9",
+        "sha256": "6d908956880eaf2cfa63bbe0c8aead7fca3ba3ddbd952afefc6a812bbcdb3259",
+        "dest-filename": "diff-3.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3862,6 +7698,13 @@
         "url": "https://registry.yarnpkg.com/dir-compare/-/dir-compare-3.3.0.tgz#2c749f973b5c4b5d087f11edaae730db31788416",
         "sha512": "27bfdeb775a51940b18dd9c3dc7000cd0ea7b2773458be830fb59cc096fb737f621f5f8059f83ef4eab324d688e8f901c01be6d6685934bf6263f9d18995e53e",
         "dest-filename": "dir-compare-3.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4",
+        "sha512": "7fd2c18b9416cc85b723a7bffeec59a0b06552df64729ebaaa8d2c482c4be9864a73be51d5ce0c142a1efcb6998811a682e8ef41dc5ce419f74217f2bcae47b3",
+        "dest-filename": "dir-glob-2.2.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3883,6 +7726,27 @@
         "url": "https://registry.yarnpkg.com/dmg-license/-/dmg-license-1.0.11.tgz#7b3bc3745d1b52be7506b4ee80cb61df6e4cd79a",
         "sha512": "65dce6ab02a6102396269a9e7e5a02e4e272d7e599041b1ee7e311f3ccfd83d667e1563e598524032a239a1cc97241f961b6d919c608b86024639fd8b3938cd9",
         "dest-filename": "dmg-license-1.0.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/doctrine/-/doctrine-0.7.2.tgz#7cb860359ba3be90e040b26b729ce4bfa654c523",
+        "sha256": "425ffd99e7274b82d10b0c594a9fc1d302316914dcf3e1bf3c2d9eb1f4cc4074",
+        "dest-filename": "doctrine-0.7.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa",
+        "sha1": "379dce730f6166f76cefa4e6707a159b02c5a6fa",
+        "dest-filename": "doctrine-1.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa",
+        "sha256": "60c6b6c70db418e2261db4a71af21f456a2686b94d2f56f64c90c8d3e38e4a8d",
+        "dest-filename": "doctrine-1.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3922,6 +7786,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/dom-serialize/-/dom-serialize-2.2.1.tgz#562ae8999f44be5ea3076f5419dcd59eb43ac95b",
+        "sha256": "52a2ed7a1a2e37883ac8839fefa5510caac22fdd981bb08e532807623e330752",
+        "dest-filename": "dom-serialize-2.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91",
         "sha512": "e5ce78064e43c38a80c4d388d691448b33d28d5b31e7e6e924a98bda43e7f0984152adaad3db5309ade68e28ee9f635f2bbf0d328b8360d30190eacf6624be8a",
         "dest-filename": "dom-serializer-1.3.2.tgz",
@@ -3929,9 +7800,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda",
+        "sha256": "3c718c3d69621d7830dbabc1efd0396715772a6d274b16e7a48c4983eeb4856f",
+        "dest-filename": "domain-browser-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57",
         "sha512": "0ed04ca3cda9bf5745b54987cabe3c6de8aeabbf764b1a21afef079bdce8c649583df6ba9f46770728e3d8857b6e6af6232a82967a844217e01c9279405d11e4",
         "dest-filename": "domelementtype-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304",
+        "sha512": "cb1276985cbfb226d5425bb9a878ce91ff49dcaeb38260b1809f78bb611dbc3395d3d1fedf62ed46cc04714b2651637bda954b3849d3491688555cd54204b476",
+        "dest-filename": "domexception-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3971,6 +7856,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57",
+        "sha512": "b54317af1944c525ba5361178a228648155d620b55f2a9472fe0b5d13b16e0f51163f89cf9e6b2b274a4c01e2403f981942cb2fc828327e2dcdf06d679a5edb9",
+        "dest-filename": "dot-prop-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.2.0.tgz#c34ecc29556dc45f1f4c22697b6f4904e0cc4fcb",
+        "sha512": "b845326832a8490d4ce0eabc978e61484dba4a74f12fab27367aaf2bf556c79c098667dfe73d055152432836a7a2bffac379331378bb5d93a4fbbc02d045ebd4",
+        "dest-filename": "dot-prop-5.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0",
         "sha512": "617425d4349ae3f3d0c917e0aefe9aa0d8e16aca7fa78aacf458c9e2ae1c424fbc9b8afa938652884cb2b4a1bc7fc5bd822f16b10b4839b36629dfad33335398",
         "dest-filename": "dotenv-expand-5.1.0.tgz",
@@ -3985,9 +7884,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/dugite/-/dugite-2.7.0.tgz#9d7b5a29034ee9d0fdd2046e45305e7969db302c",
-        "sha512": "3ca245a6b09884d1259aee8bcf0b869d0aca7e060bc5ac00f1b0dcc21c72a29d63210bfe109fb6f26a8475a3fc9b59383d93f619d6b9993a78f81e501048a292",
-        "dest-filename": "dugite-2.7.0.tgz",
+        "url": "https://registry.yarnpkg.com/dugite/-/dugite-3.0.0-rc3.tgz#1f8b3a8223d30b8efbd463561e71e1752701c150",
+        "sha512": "413f2416efd983d6bc86c6249bc68101e64da60e842670827c968e6f6c9c36472df9870efd0299a2e854d95f4effa7b8164286ade71808db02e685771c6eb33d",
+        "dest-filename": "dugite-3.0.0-rc3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3999,6 +7898,55 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db",
+        "sha1": "c614dcf67e2fb14995a91711e5a617e8a60a31db",
+        "dest-filename": "duplexer2-0.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db",
+        "sha256": "bd1031223aec9a032a9de6802ddbf8c72fd5c810ef60913568aa9c5dcece8b88",
+        "dest-filename": "duplexer2-0.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1",
+        "sha256": "5f8e60bee82c2600ca6b517441f16b8caf7bc9b7fb31e5a6107c4ffe42619b69",
+        "dest-filename": "duplexer2-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2",
+        "sha1": "ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2",
+        "dest-filename": "duplexer3-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.0.tgz#1aa773002e1578457e9d9d4a50b0ccaaebcbd604",
+        "sha256": "da1c887f98d34d5a6c7f858f26569ab06a03b6e1eb87d65838666efc9e3bb305",
+        "dest-filename": "duplexify-3.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/each-series-async/-/each-series-async-1.0.1.tgz#7e3f8dfa5af934663960e5a17561362909b34328",
+        "sha512": "1b8ce2a7f130a70afa250c56efed9136090f774f61fd435e739525bc0ff12b0978a9fe5b97204d2ba6bfce341cdcca2382cc5a39bf7707dbf74fdd9053a20c56",
+        "dest-filename": "each-series-async-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb",
+        "sha512": "23cf1361959cf578981d1438ff7739ae38df8248e12f25b696e18885e18445b350e8e63bc93c9b6a74a90d765af32ed550ff589837186be7b2ab871aee22ea58",
+        "dest-filename": "eastasianwidth-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/easy-stack/-/easy-stack-1.0.0.tgz#12c91b3085a37f0baa336e9486eac4bf94e3e788",
         "sha1": "12c91b3085a37f0baa336e9486eac4bf94e3e788",
         "dest-filename": "easy-stack-1.0.0.tgz",
@@ -4006,8 +7954,29 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505",
+        "sha256": "9296acf374d7488b07e9466c03098cc9e6b90aa6bfdd9c614c6ee63975642c4c",
+        "dest-filename": "ecc-jsbn-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9",
+        "sha256": "609ad25ccc6d5301c822fbf52ccd3f77f46dd02ce626b85d8020c3fb61a46974",
+        "dest-filename": "ecc-jsbn-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d",
         "sha1": "590c61156b0ae2f4f0255732a158b266bc56b21d",
+        "dest-filename": "ee-first-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d",
+        "sha256": "5148e8eb7e222b2a09127618bbdb5033daf6262cfc735d3101ea98620128b99c",
         "dest-filename": "ee-first-1.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -4083,6 +8052,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.66.tgz#d7453d363dcd7b06ed1757adcde34d724e27b367",
+        "sha512": "7f545714cb2fc2e7d62f0614c5388fec79a3a6b297aea1161e24248c061af4325e548959939bfc80119c695f8586d5cb972e82d4e4d5cd063ed9442b00288b96",
+        "dest-filename": "electron-to-chromium-1.4.66.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/electron-window-state/-/electron-window-state-5.0.3.tgz#4f36d09e3f953d87aff103bf010f460056050aa8",
         "sha512": "d66353c027e4a255e5de431fe74c96def1369598f4cbdd8ffc7616141adbfafd92fe90a46b999dc0dddc6a02a6e39f00ecd8e7752c228f29d781c2d646876c56",
         "dest-filename": "electron-window-state-5.0.3.tgz",
@@ -4097,9 +8073,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/electron/-/electron-28.3.3.tgz#2df898f653c4f77b66b4cf3eeba79d8bea6d03c0",
-        "sha512": "39b28c2d23cd8689ad08e040c454bc3f60d6ff8ba6921ef6a2e6549542b35c6b58b8fce0af549886c92115683302c3ed53384bd82cf2576b1f6c77045b8097ab",
-        "dest-filename": "electron-28.3.3.tgz",
+        "url": "https://registry.yarnpkg.com/electron/-/electron-30.0.8.tgz#aa54bab26ce706c9e1b244d79047a451733eb4b0",
+        "sha512": "8afcd7249ffd81d6f8a0ec3ee520ee699a52227cfc0be674db574a65f14b325b4a6c36b8b12aade5c44189483b277e99da476eb3e25a8b46dd1d6bad604f7000",
+        "dest-filename": "electron-30.0.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4118,6 +8094,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/emittery/-/emittery-0.4.1.tgz#abe9d3297389ba424ac87e53d1c701962ce7433d",
+        "sha512": "af879149e4ad1067fa33948a76b42184b2b96cec0e071421204dd84939d91371a92a22df9e7844fad3edac913bf7e7832609b7f4133a2d2a08f120b1e076f095",
+        "dest-filename": "emittery-0.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860",
+        "sha512": "b837ef52356b7c62498729b1fe4cfaa6b96d7a7c35bbb5ab0a0d686bde33618f31c55a4b2d4bb4e392c04f47610d97571b9f3f1293cbff9900d7cd1f43faae76",
+        "dest-filename": "emittery-0.8.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156",
+        "sha512": "0b004b444210ecbbd8141d16c91bf086ae4de6a3e173a3cc8c3e9b620805948e58c83825fb4bf1ab95476cc385a8b83b85f5b39aef13e59d50a1f8664c8848b4",
+        "dest-filename": "emoji-regex-7.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37",
         "sha512": "3128d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8",
         "dest-filename": "emoji-regex-8.0.0.tgz",
@@ -4132,9 +8129,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389",
+        "sha256": "de3f19c4feaa0098508bc96c8a3c9332c330fad611e48e8f8d8eb4c9515a5577",
+        "dest-filename": "emojis-list-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78",
         "sha512": "fe4c8cd7c11f8a7c1765b9e8f45c9419e161f3b282f074500501a295d1d96c4b91c9614e9afd54d74a3d041a7c5d564354d36e40ac88188bb96580005c9d15d9",
         "dest-filename": "emojis-list-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/empower-core/-/empower-core-1.2.0.tgz#ce3fb2484d5187fa29c23fba8344b0b2fdf5601c",
+        "sha512": "83af8ae867b2735a3a15d5ecf47c2b5e578215a9fb77ae86e714827d217bc759890c27aceadd289bd945406df33abce1dc191bff8e4dd1c6791aab1fed8af319",
+        "dest-filename": "empower-core-1.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4153,6 +8164,41 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59",
+        "sha256": "cb46598dbb11155157acb5eeeedf93dd9c4522783a9c92c4240a0ad259dc4e8d",
+        "dest-filename": "encodeurl-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9",
+        "sha512": "11305aba8c354f7e58fd664c922a3d8e2334679c631c7989e179a364eab597f757cf796bdac467f3b9c9cb6d11ba9a928751769b71c73d2a7c4a120f409ac9dc",
+        "dest-filename": "encoding-0.1.13.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-0.1.5.tgz#8e177206c3c80837d85632e8b9359dfe8b2f6eaf",
+        "sha256": "ed663b6f91f43e34e4b11a9b84b3dc58582d686ef426bfb047b2f439743161d9",
+        "dest-filename": "end-of-stream-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.0.0.tgz#d4596e702734a93e40e9af864319eabd99ff2f0e",
+        "sha256": "7bceeae240f1d82517a7c1532ce58924759bb45e8578e48737c551f4b96b4557",
+        "dest-filename": "end-of-stream-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43",
+        "sha256": "3fccf9867cbecb7a355e43d9c9d5c2cbe216bd7b35532d52b6d9cc12b0ba385e",
+        "dest-filename": "end-of-stream-1.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43",
         "sha512": "d4c92b64dbd64ca09a8a06e7f96d797a5ab6041fcbdb69eaad26390ca968dd7ebebdc9499bc05be5d8d72419845fa7d2dfecc287f1785412b96762b126de2cd9",
         "dest-filename": "end-of-stream-1.4.1.tgz",
@@ -4167,9 +8213,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-1.8.5.tgz#fe7fb60cb0dcf2fa2859489329cb5968dedeb11f",
+        "sha256": "36cdb9104d99bba98f03dee9024f6ee532133d78a7906f764c60276e9440675f",
+        "dest-filename": "engine.io-client-1.8.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-1.3.2.tgz#937b079f0007d0893ec56d46cb220b8cb435220a",
+        "sha256": "0be66b62e4246c655305b9d590d635e8c10ba3405c2cf86f0cc67924a538914f",
+        "dest-filename": "engine.io-parser-1.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/engine.io/-/engine.io-1.8.5.tgz#4ebe5e75c6dc123dee4afdce6e5fdced21eb93f6",
+        "sha256": "94cd6ceeebab9202032b2eb978c8bd6cfa3b4877a9c71666a086c21f8f3e9995",
+        "dest-filename": "engine.io-1.8.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/enhance-visitors/-/enhance-visitors-1.0.0.tgz#aa945d05da465672a1ebd38fee2ed3da8518e95a",
+        "sha1": "aa945d05da465672a1ebd38fee2ed3da8518e95a",
+        "dest-filename": "enhance-visitors-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz#4d6e689b3725f86090927ccc86cd9f1635b89e2e",
+        "sha256": "cbb27151b1691bacd17a275a8cd77b839c3ae664a18725585b50c4ace96af5dd",
+        "dest-filename": "enhanced-resolve-0.9.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz#300e1c90228f5b570c4d35babf263f6da7155634",
         "sha512": "4074d723fb19426928d5c6c3a0d01ade6279aa159450d02adef474fd8883dfbf5f590adc7eea17d7e1d6d92d0c4eded79a83cb6a975a0ca52d7a55123e273b85",
         "dest-filename": "enhanced-resolve-5.12.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d",
+        "sha256": "9676ecdffd2aefe5593a20d7c95e6c23c997f4f32094751e68e96f4c93b39418",
+        "dest-filename": "ent-2.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4202,6 +8290,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2",
+        "sha512": "fa1d6590b2a164c4d88e8835544a49346ecd64959cb9cd830e4feab2a49345108e5e22e3790d5dd7fb9dad41a1a8cc5480097028d67471fdaea9a9f918bb92d8",
+        "dest-filename": "env-paths-2.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/equal-length/-/equal-length-1.0.1.tgz#21ca112d48ab24b4e1e7ffc0e5339d31fdfc274c",
+        "sha1": "21ca112d48ab24b4e1e7ffc0e5339d31fdfc274c",
+        "dest-filename": "equal-length-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9",
         "sha512": "d9b9a546934a0714ff09198f3a5c88490a4d8fea92798bdcca6fee4f4271d9b30e94a2ed4b2d5998bb95c5210a2b2a2bfcde7286fa7f6621b5a04dc311831214",
         "dest-filename": "err-code-2.0.3.tgz",
@@ -4216,8 +8318,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618",
+        "sha256": "77a94dbec5c34dd8c440bc92019277d54da89baf931a49ffd06735ff6716c0d4",
+        "dest-filename": "errno-0.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc",
         "sha1": "f855a86ce61adc4e8621c3cda21e7a7612c3a8dc",
+        "dest-filename": "error-ex-1.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc",
+        "sha256": "77b75727ed24faaba5d36a73c231b5ed4aa9243afaebf04ac7d0cef4617a32c1",
         "dest-filename": "error-ex-1.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -4233,6 +8349,20 @@
         "url": "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165",
         "sha512": "0bc171ff48c5995e483e830e14f03d3fd1b936da96fb870e3e2b77308baf476b7b020d8ad791094e9c671c0613ccbf9a61024811261e5d998305f3811351dca4",
         "dest-filename": "es-abstract-1.12.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9",
+        "sha512": "bc365f83fca4371415c2ea7ff04d4166157315f071b3d36a33319cbc826baa0e64dbfe596b66d6a38d1d2b6275a602e7819edcf92861f25c18b4b1b2af03eeb6",
+        "dest-filename": "es-abstract-1.13.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.16.2.tgz#4e874331645e9925edef141e74fc4bd144669d34",
+        "sha512": "8d8a3f27c5d4d9e98b5e5dce2f07f0b6e15fb85db0e8360fb3ec72f597d5c8f90372b6aebba2d8af0fead93c82b6b6dcfca51d0a20b97bd51a8d1860364568a4",
+        "dest-filename": "es-abstract-1.16.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4314,9 +8444,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377",
+        "sha512": "a99af204e26357ffcb6b12d357a502fff59ec27781dcb71738bf4d3fefa8cca557b08208a66ff6735dd40e20fd269d9e4e1b1e730f66de33ea0f04f2a1b71d6e",
+        "dest-filename": "es-to-primitive-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a",
         "sha512": "4023a5960649b5a528f6689805c2c285351a1cd8c91773d8b35562743ec0c22123d6463129e41372d2c07b300e1f964a447d20d8880f9fa2b0078213f22469bc",
         "dest-filename": "es-to-primitive-1.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.15.tgz#c330a5934c1ee21284a7c081a86e5fd937c91ea6",
+        "sha256": "52315a829f3cf67ff89f913461f2756c4b795c6a0c84b41c89d1c803a4c96597",
+        "dest-filename": "es5-ext-0.10.15.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.39.tgz#fca21b67559277ca4ac1a1ed7048b107b6f76d87",
+        "sha256": "6d6d906188218b1907f31c1e2c9b3ad8de7a291fa030bc35ff6c0c6b0c4e9b4e",
+        "dest-filename": "es5-ext-0.10.39.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1",
+        "sha512": "5ecd92b70e8d88d1d6ca9cd14d8d4cb5a1bfb899700a4f241fcd7ddb499af26bcdf17ab582c7e166fa642262d002bc3c0079eff0c4f6238e49ddcd11f2c944f9",
+        "dest-filename": "es5-ext-0.10.53.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4335,9 +8493,93 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512",
+        "sha256": "8948e17295a80a715a3608fad6b58a4ed7e5db873087f9b4501277de452fc084",
+        "dest-filename": "es6-iterator-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7",
+        "sha1": "a7de889141a05a94b0854403b2d0a0fbfa98f3b7",
+        "dest-filename": "es6-iterator-2.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7",
+        "sha256": "cbd6f6ff4de66edb320b8b35c2e455e84b0c6cb12744eaf6cb32bcba5d308f43",
+        "dest-filename": "es6-iterator-2.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0",
+        "sha256": "676e8a2958770bb8acfb6bcafb24606d3e948f64b2850b870460aa5f5c28742f",
+        "dest-filename": "es6-map-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613",
+        "sha256": "cb920c89db01cc86c45750a52b7ee5d552976a07476b5f18c72d3a1862ebc72c",
+        "dest-filename": "es6-promise-3.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29",
+        "sha256": "730fae24f0d44a5f620b9abb7c63aea6a1b55236d30bd6cec746bb019be1200a",
+        "dest-filename": "es6-promise-4.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a",
+        "sha512": "1c90c6c7975ac5e22fc5d071bc6d9c6fd838b44bf0224de2f3e9e15f4c86ad89995336e4760f106c37af85e0c1f20774fffb8f8f8735110b9af10f8c5624f4ff",
+        "dest-filename": "es6-promise-4.2.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203",
+        "sha1": "5109d62f3e56ea967c4b63505aef08291c8a5203",
+        "dest-filename": "es6-promisify-5.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1",
+        "sha256": "4072a28d46b728026f6581bac30b2d64d3e492a714dde482437990d6bc294bb1",
+        "dest-filename": "es6-set-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.3.tgz#9bfb7363feffff87a6cdb6cd93e405ec3c4b6f26",
         "sha1": "9bfb7363feffff87a6cdb6cd93e405ec3c4b6f26",
         "dest-filename": "es6-shim-0.35.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77",
+        "sha256": "21ff01e38a152467acd425bb06c1a18f4efe8f9461356c69a0458d0caeea0354",
+        "dest-filename": "es6-symbol-3.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18",
+        "sha512": "349e989f716e0e29c168145697fab95ffb3892844706b80a02efb2188e890817a2bb7aab71b261c13d86791fc45d57f295193c7694152682c41612be32edf534",
+        "dest-filename": "es6-symbol-3.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f",
+        "sha256": "0e086de2a26501594feaddbe163c419dd6f77d240b6a42dd74207a4b8f8ad0bf",
+        "dest-filename": "es6-weak-map-2.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4356,8 +8598,29 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988",
+        "sha256": "a101155c3cbdfb1e4f98f2f83c8b5e392db6accfa606df0eba8b87a5762b0366",
+        "dest-filename": "escape-html-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1",
+        "sha256": "b25ec850234b5faf7af2109ab08626463c902db3773a9687dd0f795c16e57fa6",
+        "dest-filename": "escape-string-regexp-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
         "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
+        "dest-filename": "escape-string-regexp-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
+        "sha256": "e50c792e76763d0c74506297add779755967ca9bbd288e2677966a6b7394c347",
         "dest-filename": "escape-string-regexp-1.0.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -4377,9 +8640,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/escodegen/-/escodegen-1.7.1.tgz#30ecfcf66ca98dc67cd2fd162abeb6eafa8ce6fc",
+        "sha256": "656f5a1e8b003782404a0271c2ac44c5c3275d2e6fe2ddc8150c8526a6af3ed5",
+        "dest-filename": "escodegen-1.7.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd",
+        "sha512": "9a61cacacfc2f01154188f8c01635c498a0e4582cc74fce3ae49ddd9573e6d4b233796d772bf0486b341f944ea7cbd72dc8f5ce1fc368a182d30f40b051890c7",
+        "dest-filename": "escodegen-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17",
         "sha512": "d8d9480d3c145893749913d039db500736d41ef7466363f55574b253cdd0df12b133b5875f6425f1d2aaefcd90f5381050d38b133118bbd6f32cd8f5abcf08e7",
         "dest-filename": "escodegen-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3",
+        "sha256": "1574e4ccea6e6c32f79078077046eeb06390e01358fa7eac0bd48aa309627ed5",
+        "dest-filename": "escope-3.6.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4398,6 +8682,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz#b23da2b76fe5a2eba668374f246454e7058f15d4",
+        "sha512": "105e9792bac655bbeff212ff9186bf9babe7be6513f8af36a4925ce0925530cebe420aa1d299f0a6b4b175db832c1f69ffb6c8c43f985793b4c1f6fc96670f6c",
+        "dest-filename": "eslint-config-standard-14.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-formatter-pretty/-/eslint-formatter-pretty-1.3.0.tgz#985d9e41c1f8475f4a090c5dbd2dfcf2821d607e",
+        "sha512": "e4363ae18d6b6029bb71f1431c41949f9e1bbc29cafb0494545d3b37ca177aa50915277e82760e4d76f37a54351eeac44a5b98ea09c440f997388901e166be80",
+        "dest-filename": "eslint-formatter-pretty-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a",
+        "sha512": "b1f993a897cf4a2cd6bb86b299b3ebe0889da79c8a9bcc83907a7e22bdd88931e28837f187af66394b268aa5ba459f7345715a17ae06b5898dedefbc18706fe9",
+        "dest-filename": "eslint-import-resolver-node-0.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd",
         "sha512": "d049f4c34dcd455327f548b29fc6113c32af5a3c425a4b25504846353746c75e51bcf25843e95b3a5aab94d236bc402ce290d82b87ff1cdd936c39a4e533f48b",
         "dest-filename": "eslint-import-resolver-node-0.3.6.tgz",
@@ -4405,9 +8710,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz#7b4675875bf96b0dbf1b21977456e5bb1f5e018c",
+        "sha512": "1fa0ce8fe7a3c3b4deb1d81b7ece23792e18305ad3f2e23cc7077582d42a5ecb1a474110dba2fed8eff0eb0918172d8cca638dd1f4f01e65c1bef7cb35955913",
+        "dest-filename": "eslint-module-utils-2.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974",
         "sha512": "8f8193fabab30a844a1f05115fba5d76d20f1b24a75fd4a2fdc80c239cedadca8e3ed93974311e677e024153e9867aa4272b6573ded5ba4d39526da627780440",
         "dest-filename": "eslint-module-utils-2.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-ava/-/eslint-plugin-ava-9.0.0.tgz#a8d569ae7127aa640e344c46d1f288976543b1bd",
+        "sha512": "989a90d7043da71062e4fbbe82baea8dfb922f18924a09e96b9a79bcc744a41a80f67f5c533482bf4c4c67f3644cc023e6278e0774d617c8feec2df4622bf844",
+        "dest-filename": "eslint-plugin-ava-9.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz#0f5f5da5f18aa21989feebe8a73eadefb3432976",
+        "sha512": "7fa7dc795b60dbb051d361189c186058b1507cae9b3782e5d27405ac11ce942b00cb1799927d0d1e7b393b461938fad5d41deb6a677a7201706a814b71293011",
+        "dest-filename": "eslint-plugin-es-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4447,6 +8773,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz#02f1180b90b077b33d447a17a2326ceb400aceb6",
+        "sha512": "e68869b0702250144d681580174f22cf050695bac9a0927e5bdfd3070b06a11d4c9e581fc0c20aac57928d66edea6a1a6e25d6f7136fb45cfef7b28745f2381d",
+        "dest-filename": "eslint-plugin-import-2.18.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b",
         "sha512": "8587e2dc55da33c58f2dfe12d5c8a487faf82319ceeb3ae165b106cf66faeb410945bbb18290d2e60902b988065a0db1c61dab06e22be0fbe1bdeffb737d64a0",
         "dest-filename": "eslint-plugin-import-2.26.0.tgz",
@@ -4482,6 +8815,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz#fd1adbc7a300cf7eb6ac55cf4b0b6fc6e577f5a6",
+        "sha512": "d424b233f4028ece8f5da4f5f3ecee017b235c6206a39470eb7d2b48ac28912b368eb614450738479259a686a7342ab03667a983ed1e67d2fb62245425bf2389",
+        "dest-filename": "eslint-plugin-node-10.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2",
         "sha512": "8d90daf33efa92546aa3e4dd1834c52526afc1b9d62b6669a8628d67e56fc1e316e75ea90d43264369285efc44138261ccdbd3bfeada7727bf6d6181980ea39a",
         "dest-filename": "eslint-plugin-prettier-3.1.4.tgz",
@@ -4496,6 +8836,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a",
+        "sha512": "568334f6f4fb6df03b0feba9b7e1637813b9787209401516922d5a3ef07ebdb3621d2dfea062091887b206d2904cc13a50f5d7cb7bd5d3b38bd6d1dddc036e0f",
+        "dest-filename": "eslint-plugin-promise-4.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz#69ee09443ffc583927eafe86ffebb470ee737608",
         "sha512": "ef741030a00b02b23cffbc462cd23fdcbca5ac462b94a6526f90bdfaadceb4e7b04e73108b9713f9a13d138d6c2c29a58b723d3c61a60f5ca2672772a381443f",
         "dest-filename": "eslint-plugin-react-7.33.2.tgz",
@@ -4503,9 +8850,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz#ff0519f7ffaff114f76d1bd7c3996eef0f6e20b4",
+        "sha512": "bff2819dfc9a38c3e665cfdd99cea8cce756a9e906a7b6c11aae232c079c11f3c699f2a2592e2c03cb02d0baa257dc39aa65c0b57567e0cde9d634b2858f3949",
+        "dest-filename": "eslint-plugin-standard-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/eslint-rule-documentation/-/eslint-rule-documentation-1.0.23.tgz#4e0886145597a78d24524ec7e0cf18c6fedc23a8",
         "sha512": "a5645ebb77e4a21c32bf3b71fe84165a095dda269ddb94df51d8bac2f8616833c84231d4fe9caf94a817170d645f7d5240ad8dabd307faf443581d192f2f1f63",
         "dest-filename": "eslint-rule-documentation-1.0.23.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9",
+        "sha512": "a18ae1256ed2d1bc40143bd6ab3bcc3d19baa5c81c9d6738427a1f080a914d17d00b425cc1e9f31a0953b6c2f222eb9615f92a0c6f6fcfaedc9edb52779ddd8f",
+        "dest-filename": "eslint-scope-5.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4524,6 +8885,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f",
+        "sha512": "7db04de56db1758e392ae9465e62c76777371477d56262a0d08ac02863a44ffe3ae0f42cc7651e2337f3d51984722f8a2e6d5b05a03364087cfbf13e5c0799f1",
+        "dest-filename": "eslint-utils-1.4.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2",
+        "sha512": "f32f588ed335241254fc0f4a73e49b68e578cb6f6c4967240703076be146b558f980dfec6e72837fac49525fbc83b1408a3f4b55a3fc0b6e035221ff7ffd99f4",
+        "dest-filename": "eslint-visitor-keys-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826",
         "sha512": "990facbaa2895727aec0660701d8cc16a8c2c9f97cf8b767c6eca9de576230114a92fcadad751959a88f0846aff2a0c72adcb8e1b0fea95d483f84fec3ec5744",
         "dest-filename": "eslint-visitor-keys-3.3.0.tgz",
@@ -4538,9 +8913,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint/-/eslint-1.10.3.tgz#fb19a91b13c158082bbca294b17d979bc8353a0a",
+        "sha256": "4c2c9f02e5d35105a4b1532ea5b859065198c1dbb64a0f3273411a148a522d96",
+        "dest-filename": "eslint-1.10.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint/-/eslint-2.13.1.tgz#e4cc8fa0f009fb829aaae23855a29360be1f6c11",
+        "sha256": "5be06b609737841ebfd18b0c02604bbe56b3219484b04d710ac43e2fbdfd8dbb",
+        "dest-filename": "eslint-2.13.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint/-/eslint-6.7.1.tgz#269ccccec3ef60ab32358a44d147ac209154b919",
+        "sha512": "516cc14bbf6935cb034b18316dd8e49b39ff07a061b1731f51a3879cdc3213c9c3f90ea9c93f7aa30d8c71c55ac944d5e32322778a8b84c8906b2c1cb519012c",
+        "dest-filename": "eslint-6.7.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/eslint/-/eslint-8.55.0.tgz#078cb7b847d66f2c254ea1794fa395bf8e7e03f8",
         "sha512": "8b251400cd0f08a8f9429c067e60801bd5d76d9096b2a3ff796016ac6fd6d2e9af8ee2d10440b048576dfab0a7b63bb4c441fbb5e20004fc17a5a85fb4869374",
         "dest-filename": "eslint-8.55.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10",
+        "sha512": "535b2e899da80d55afe333cee7a4b435c47942b8846a11ad74dd8e47a162386e1626f723055141d2a238f9e2a85851f8f373ca1ae2eebba57c6784f983add454",
+        "dest-filename": "esm-3.2.25.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/espower-location-detector/-/espower-location-detector-1.0.0.tgz#a17b7ecc59d30e179e2bef73fb4137704cb331b5",
+        "sha1": "a17b7ecc59d30e179e2bef73fb4137704cb331b5",
+        "dest-filename": "espower-location-detector-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/espree/-/espree-2.2.5.tgz#df691b9310889402aeb29cc066708c56690b854b",
+        "sha256": "60c6ebf8a8d6abf49bc7e341dc2c674af8e8ce0b25b9a0c63ba7c8106aa88716",
+        "dest-filename": "espree-2.2.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/espree/-/espree-3.4.1.tgz#28a83ab4aaed71ed8fe0f5efe61b76a05c13c4d2",
+        "sha256": "6fcce72bfa55a790dde060e149ed0627699d921474c2998356aa6b07628e445d",
+        "dest-filename": "espree-3.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/espree/-/espree-6.1.2.tgz#6c272650932b4f91c3714e5e7b5f5e2ecf47262d",
+        "sha512": "da250fbae3cffb25b53d968c48333d7b255ff03e4fd078bc87cdd8b59e5b3dcff31d88c8239921a22c4851330eefde0d398f05fd3845d41a3c9dc6482daad44c",
+        "dest-filename": "espree-6.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4552,9 +8983,72 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad",
+        "sha256": "6563db49cec2ea05167e4f9e1217ab49dbbcec4ecea4a41aa2c704c46da77d4f",
+        "dest-filename": "esprima-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esprima/-/esprima-1.2.5.tgz#0993502feaf668138325756f30f9a51feeec11e9",
+        "sha256": "e7a2adb2d6c045d15cdef2cfe3392ab5db76828b60a9b99a155095e58bdfe647",
+        "dest-filename": "esprima-1.2.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esprima/-/esprima-2.5.0.tgz#f387a46fd344c1b1a39baf8c20bfb43b6d0058cc",
+        "sha256": "e6076e7c437c6bca592f52c916eb458b89b9944f4586732fbf195bda7afc76a6",
+        "dest-filename": "esprima-2.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581",
+        "sha256": "19ed5686afdace96f0b42f4c2ae3205ade6ea299341b99be6f7687645d519be0",
+        "dest-filename": "esprima-2.7.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633",
+        "sha256": "6ce53f45b7ccf15d62df7768a387a96ef1893014a2a7db68a3299029a6fd43cf",
+        "dest-filename": "esprima-3.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804",
+        "sha256": "1367ea7204a4819d1771feaf562fb240496a50e46b6deeb770eee1f3622aca47",
+        "dest-filename": "esprima-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
         "sha512": "786b85170ed4a5d6be838a7e407be75b44724d7fd255e2410ccfe00ad30044ed1c2ee4f61dc10a9d33ef86357a6867aaac207fb1b368a742acce6d23b1a594e0",
         "dest-filename": "esprima-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/espurify/-/espurify-1.8.1.tgz#5746c6c1ab42d302de10bd1d5bf7f0e8c0515056",
+        "sha512": "643928e9e63fa3e0ff807096c874d4f3998a0e061c4b81498fb4be603e962089e6ec643a0273a399c2f8f9bb8557f24eced54b10b8bfecc9ae194e4d1ed6b432",
+        "dest-filename": "espurify-1.8.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/espurify/-/espurify-2.0.1.tgz#c25b3bb613863daa142edcca052370a1a459f41d",
+        "sha512": "ef0fdd52b45e23f41b2451d1c1fa264e5910397681d4db82ac1467e58dba1d79f982f875f3fd7d0202db6b256b3715d07e4724be0ac99685b2bd90ee27b76110",
+        "dest-filename": "espurify-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708",
+        "sha512": "4a68b2679cc8587f5533e49151178b4b943c6bb1b1b51771101559a66f7cac933b49bf80f435429dd5df91e1547776f275eae0f846c391f9debdf0b0ca759a34",
+        "dest-filename": "esquery-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4566,6 +9060,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.1.0.tgz#4713b6536adf7f2ac4f327d559e7756bff648220",
+        "sha256": "6e6925b22ac2e0d5404ab0690033fac4b30f2f8d1eed9b6b326cb8d70f06ffe6",
+        "dest-filename": "esrecurse-4.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf",
+        "sha256": "d757a917a617f6adcb6994bd9d0341a22bd12cfd5fa49880417425a2487b4d19",
+        "dest-filename": "esrecurse-4.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf",
+        "sha512": "eb844107ef9f20e0173f0dcff5ccbcf6a7cc96f6445d992aa89923aaa5c8bf33f97b34598d6fa53d68f0df9517ff712150f1586e0e44478258803c38d34eff0d",
+        "dest-filename": "esrecurse-4.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921",
         "sha512": "2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a",
         "dest-filename": "esrecurse-4.3.0.tgz",
@@ -4573,9 +9088,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/estraverse-fb/-/estraverse-fb-1.3.2.tgz#d323a4cb5e5ac331cea033413a9253e1643e07c4",
+        "sha256": "3c7c18404f1b22888bb6d4eb151541e57dd2254b50c237e1a0bc32c716dccae2",
+        "dest-filename": "estraverse-fb-1.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44",
+        "sha256": "99fee6a2e9166fb53ab910cd967c366c176e8998b38bf84355e6dbda38a417ec",
+        "dest-filename": "estraverse-1.9.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2",
+        "sha256": "c36e2853259b5163b27c399981b3ef746f717f0d983e8f56ab060a931f9a87cd",
+        "dest-filename": "estraverse-4.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13",
         "sha1": "0dee3fed31fcd469618ce7342099fc1afa0bdb13",
         "dest-filename": "estraverse-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13",
+        "sha256": "91a8e27f8a2c714192be9b5412a59c8ce08d6083de2a4872dd0d729791d85bef",
+        "dest-filename": "estraverse-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d",
+        "sha512": "dfd9e729f7d6cfcc4dd4153fd9cefd9fd9c1f470f3a349e2614ab1eb1caa527ca8027432c96a4e4dd6447a209c87c041bb9d79b78c29f599a055f5619fd101a7",
+        "dest-filename": "estraverse-4.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4594,6 +9144,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e",
+        "sha256": "cafb1a4b68a310246d00fcc8dc77139a8f69479a6d3b3fc0836efc7bab648c98",
+        "dest-filename": "estree-walker-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esutils/-/esutils-1.1.6.tgz#c01ccaa9ae4b897c6d0c3e210ae52f3c7a844375",
+        "sha256": "5ff3d734c004f1a9d06afd8bc8d268088351ce44549c84c93794301a697d3223",
+        "dest-filename": "esutils-1.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b",
+        "sha256": "9e978bed6f447a9f644f2a371e64a51673d5f2cb13401974fae6ee373304d796",
+        "dest-filename": "esutils-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64",
         "sha512": "915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea",
         "dest-filename": "esutils-2.0.3.tgz",
@@ -4604,6 +9175,20 @@
         "url": "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887",
         "sha1": "41ae2eeb65efa62268aebfea83ac7d79299b0887",
         "dest-filename": "etag-1.8.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887",
+        "sha256": "f6a96c78a973d2ab660c9efeee6aa74a399cd9e770625ba1ed95e1aca9fd0faf",
+        "dest-filename": "etag-1.8.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39",
+        "sha256": "01285fbf386851ffa16974b3a077a314898c09fc52184ac0d4b45281ec0468b1",
+        "dest-filename": "event-emitter-0.3.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4622,9 +9207,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-0.4.14.tgz#8f61b75cde012b2e9eb284d4545583b5643b61ab",
+        "sha256": "cad55c0afe49fd2d959881a2e85cbd387113fa33b2064c17a7cbc937f2dfc787",
+        "dest-filename": "eventemitter2-0.4.14.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508",
+        "sha256": "5dfef02e7a327e992c41e8b1c767e2b133a293d1003d861fee8acf279dfcfbdf",
+        "dest-filename": "eventemitter3-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/events-to-array/-/events-to-array-1.1.2.tgz#2d41f563e1fe400ed4962fe1a4d5c6a7539df7f6",
+        "sha256": "22bb8b138dd546c49d640c0c7421ebeb8a87d01d7a8e1d71d73a9aec2261748f",
+        "dest-filename": "events-to-array-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924",
+        "sha256": "71ca4a4b9ea06b21282e63bd65edc5816db8d71842b2cbbde015bf76b3dc416e",
+        "dest-filename": "events-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400",
         "sha512": "990c3ed9f9106c02f343b574318d08a9d9d734e793b4fe2bd2537dcfb0006b009782a79aedb0e28b6d0062b201ac577f1f1d0cd8e733e92d75d4268591471bd1",
         "dest-filename": "events-3.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eventsource/-/eventsource-0.1.6.tgz#0acede849ed7dd1ccc32c811bb11b944d4f29232",
+        "sha256": "aa8ad077c8bfdb3be77893ad66ecae8ae2df095b6da8231bec99502995ff827a",
+        "dest-filename": "eventsource-0.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777",
+        "sha1": "944becd34cc41ee32a63a9faf27ad5a65fc59777",
+        "dest-filename": "execa-0.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777",
+        "sha256": "da8b373ec5ee3e58795a5f12762d839c883e1f88c58b5826b190be1449375c16",
+        "dest-filename": "execa-0.7.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4650,9 +9284,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/execspawn/-/execspawn-1.0.1.tgz#8286f9dde7cecde7905fbdc04e24f368f23f8da6",
+        "sha1": "8286f9dde7cecde7905fbdc04e24f368f23f8da6",
+        "dest-filename": "execspawn-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8",
+        "sha256": "2e0eca59946b60335a11e5411de4085341da9347bc6eb04866ed694d09e58f22",
+        "dest-filename": "exit-hook-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c",
         "sha1": "0632638f8d877cc82107d30a0fff1a17cba1cd0c",
         "dest-filename": "exit-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c",
+        "sha256": "485f06ca0939c28f18128926c4345162d0adcfd340c62e292bb827c2cfe82a41",
+        "dest-filename": "exit-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/expand-braces/-/expand-braces-0.1.2.tgz#488b1d1d2451cb3d3a6b192cfc030f44c5855fea",
+        "sha256": "cfd14082cfe5c8fea52de1d6724a5a3a68d8f4feb0e49044b5fec57fd17e54b8",
+        "dest-filename": "expand-braces-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b",
+        "sha256": "83059b85f78245edd96e498c3eef432faabe985a3e06124d3bb22b272e5befbb",
+        "dest-filename": "expand-brackets-0.1.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4664,9 +9333,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/expand-range/-/expand-range-0.1.1.tgz#4cb8eda0993ca56fa4f41fc42f3cbb4ccadff044",
+        "sha256": "1dbbc809827888897208c6e26c89afe6b8bd777cfd30fb8da9cf9efce85e21c3",
+        "dest-filename": "expand-range-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337",
+        "sha256": "f423822ca3fcb9755c2242177ec8abfae026548a2537270ff23a202fc2cbe8b4",
+        "dest-filename": "expand-range-1.8.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c",
         "sha512": "5d87ee28cbe3e0edf97ffa4e5cb39b9dd211bf243effee8084e0e1f8e2968fd4bde3df291c79ff20cb331fe82dd1f04245630d7e4d594a9e71dc089f9a7236be",
         "dest-filename": "expand-template-2.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-1.2.2.tgz#0b81eba897e5a3d31d1c3d102f8f01441e559449",
+        "sha256": "6ba4bb7552cd1f8b94c30de5301a101a752840e1e3be045e53602fef68880a11",
+        "dest-filename": "expand-tilde-1.2.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4678,6 +9368,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/expect/-/expect-27.5.0.tgz#ea2fbebb483c274043098c34a53923a0aee493f0",
+        "sha512": "cfbdc6675df6701aab6a93b45fa05e463c815ea3adf58791b670ed78724842aa79b36a59e351f3db75546ec54531f92bb052d4f46c282114b46732ee14af0ce7",
+        "dest-filename": "expect-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc",
         "sha512": "d9992cd217f554b15823591b8742398cfdca1c7c821e991fc87073b125d116097f060f665987cc5bca03f8f74c3e5130cb91cdb11f49bad632ea931e3a1eb59f",
         "dest-filename": "expect-29.7.0.tgz",
@@ -4685,9 +9382,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6",
+        "sha512": "757edefcb1d527a5b70c4d4c1d68bd4b5118cc311210d7cbad8a211b61befa8bd9ad83a49b82a7c1ad26735727f38c49391e0a114d1649c8612db77452495b1f",
+        "dest-filename": "exponential-backoff-3.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/express/-/express-4.16.2.tgz#e35c6dfe2d64b7dca0a5cd4f21781be3299e076c",
+        "sha256": "30b8dd924dd2452ecd85ad400f104b5ad723f32296e7bd183550ffbb8539d662",
+        "dest-filename": "express-4.16.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/express/-/express-4.19.2.tgz#e25437827a3aa7f2a827bc8171bbbb664a356465",
         "sha512": "e53ea7863b13f8438ccee724f098c11c04531df321b743cece503ad16576a4c0f78325f0d8b66767eb9e19d3711bed1c6a538971629ba4572eccb67dd585aaf5",
         "dest-filename": "express-4.19.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ext/-/ext-1.4.0.tgz#89ae7a07158f79d35517882904324077e4379244",
+        "sha512": "29ecb9348b14c5da8a837bc8b1dc3d752b97a4f090dbdef2eb00632f7d1e771c0f82dd84e3859c58165ecbf66f51ceac1112d3c4a7720aee206459946e4d50ec",
+        "dest-filename": "ext-1.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4706,9 +9424,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4",
+        "sha256": "b4e19a28d7d07cb049f71e1f8ba019723a683f7d0e451d734a921548475d88f9",
+        "dest-filename": "extend-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444",
+        "sha256": "945da184c09e2fb0d920a73bac25a747b41eb8da99fa456c80e907f3cdfa2eba",
+        "dest-filename": "extend-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa",
+        "sha256": "1d91d0b0faa50cba223fa937c7b5a4a662968b1d78b3e59dca5c917dd5cf72b2",
+        "dest-filename": "extend-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495",
+        "sha512": "84c438097d69d62ce6b8b63266a2cc3bfa86370d74c12bfd40308f7f35dfc85ace682492a117ea13529fd6ce5a9fae89e49642eb635ec06fa62b8f63382b507b",
+        "dest-filename": "external-editor-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1",
+        "sha256": "2855f0194e6d68b7582b4217727d195797ea9d57e87f68545b09244a6bd62a98",
+        "dest-filename": "extglob-0.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543",
         "sha512": "3666fa4179042ecb81af6e02252922968e941c781b7a42b95226607c4e941c3dc46f6ed80baa03f9b85c4feb49e9c97c766b20750c675a572bcbc92c04804ba7",
         "dest-filename": "extglob-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c",
+        "sha256": "994b624cc584e0471b56342d0074f07937a189515df3de809ad3e4efeb4aafa6",
+        "dest-filename": "extract-zip-1.6.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4720,6 +9480,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05",
+        "sha256": "cf9b392605f59c195d1d44f20162170a4e44bcedc01dddf3cbe6bc594faed044",
+        "dest-filename": "extsprintf-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f",
+        "sha256": "b567ce8a7571941a3b0b2eae6e67992c4e47fee9301c47d07fa11f9cfb62f0d2",
+        "dest-filename": "extsprintf-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07",
         "sha512": "5ab937e5ef327422838ff02b0a5a3556b3d598df33a61e55e00b47c08b8786f317b0a7fbdd44f704e0fe6b30485bedf0389e058441fbcf2689085bc286362f30",
         "dest-filename": "extsprintf-1.4.1.tgz",
@@ -4727,9 +9501,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0",
+        "sha256": "4fa6db8f2c9926fb39a211c622d7eb3a76efbc4878559f9bd155d647a6963735",
+        "dest-filename": "eyes-0.1.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-5.0.1.tgz#1111a2b6981eaaad03027d816a8536a940d36cee",
         "sha512": "bf1c9b1f6f4ec2d73a92157f52ccb8ec1d60f9e2b0ca11625fc9f0a420b8b5ddf6d23bf0aca4031fabcdb5c259814cd5c667ec488947ccb290cd3efa24c08eec",
         "dest-filename": "fake-indexeddb-5.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.0.tgz#45be17d02bb9917d60ccffd4995c999e6c8c9948",
+        "sha256": "fc3e066f2da75988e2abf45a85b61f5c49ca001995331deaf1ef70416478e8cb",
+        "dest-filename": "fancy-log-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/far/-/far-0.0.7.tgz#01c1fd362bcd26ce9cf161af3938aa34619f79a7",
+        "sha256": "155d0987eb3a267c56689523bf3b96b021600d255bb19e75fde6de0c3ae3824e",
+        "dest-filename": "far-0.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614",
+        "sha256": "4862f3bec17c5a9be48b23e0d1278fce7c0f5020ca879625558f9973075f591d",
+        "dest-filename": "fast-deep-equal-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49",
+        "sha1": "7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49",
+        "dest-filename": "fast-deep-equal-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4748,6 +9557,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c",
+        "sha512": "fddf6c7e8b38cb1ce9c240e4b8dee4d92a852ad60d9824f381f129cfcdb1df820cf7fcdcf0a1b14285e0d6588d0bf8b3a5133f30176de38366c78d595aa93e15",
+        "dest-filename": "fast-fifo-1.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d",
+        "sha512": "8352ae4301ce64098e64cb81b477710ed8eef93d914fc8e0082f5a00db1ba5d8830d34a78e07ee56c20134a6d4789237a0a31113171f343b499783a16df7ccb3",
+        "dest-filename": "fast-glob-2.2.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.1.0.tgz#77375a7e3e6f6fc9b18f061cddd28b8d1eec75ae",
+        "sha512": "4eb533dd31e2ab6572ddb8df414076c0dc8f74605e1a67636f3cc12e17c7378605bab629b422b01aafd37e245abdb1b2c0547363a53609d990d739ac639c986b",
+        "dest-filename": "fast-glob-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9",
         "sha512": "c6b3b7fb56f14a8dd9547027ab3cae7b0613e9a3051d101de0a72cf76300a278f04192ec2bd774485d48c90de4e4fa22af14d6d0e7bf46a160310e9370d13913",
         "dest-filename": "fast-glob-3.2.11.tgz",
@@ -4762,6 +9592,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2",
+        "sha1": "d5142c0caee6b1189f87d3a76111064f86c8bbf2",
+        "dest-filename": "fast-json-stable-stringify-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2",
+        "sha256": "c0fdc9166f441026aedca007c1497dfed2b44e95f93071c2123670c5b451f7ca",
+        "dest-filename": "fast-json-stable-stringify-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633",
         "sha512": "96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
         "dest-filename": "fast-json-stable-stringify-2.1.0.tgz",
@@ -4769,8 +9613,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz#0178dcdee023b92905193af0959e8a7639cfdcb9",
+        "sha256": "b83d610898c77452bfb0def04104db812a92198ef5b6488e4b6213f37a7c40f1",
+        "dest-filename": "fast-levenshtein-1.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917",
         "sha1": "3d8a5c66883a16a30ca8643e851f19baa7797917",
+        "dest-filename": "fast-levenshtein-2.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917",
+        "sha256": "bb4b50306b8b0f048475efddae11810e245937dca8ae85498ab4a171697bbf3c",
         "dest-filename": "fast-levenshtein-2.0.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -4783,9 +9641,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2",
+        "sha512": "8e6c6a43767f9d7a1ec8399603317d907d5a1994a2b3a7bf49b7cf989a549f2674a20afa8ac70741a9a5e30b047a911649db66a72f9e557982448329c5a5ea38",
+        "dest-filename": "fastq-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4",
+        "sha256": "bcd93f4a422ae2e1a4bfc04e75baabc7df4f4b910c3e0e5cc3d54199c9be45c8",
+        "dest-filename": "faye-websocket-0.10.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38",
+        "sha256": "96d0c14e98c13ab345877f726c1786e95cb8638ac2a9c5b2d86d416f7634ce81",
+        "dest-filename": "faye-websocket-0.11.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58",
         "sha1": "54e9abf7dfa2f26cd9b1636c588c1afc05de5d58",
         "dest-filename": "fb-watchman-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85",
+        "sha512": "0e43c9290798ea42b09ae32b7ad061afb1ba56876bedb1700d84d72247c6d608ef3696b1053415dcf6d783a6d1d5cd543f88cf397d231d46db1c034bf6f46356",
+        "dest-filename": "fb-watchman-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65",
+        "sha256": "29b165a7e5d7bf5c7a4c74e8a46d0979dd2b0f24f39fca2eec3156c0e4339f51",
+        "dest-filename": "fd-slicer-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4804,6 +9697,34 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e",
+        "sha256": "292bc5c2485f9c8f370b018275aed8059fe6c69b620594b3db36ba52445c1d89",
+        "dest-filename": "figures-1.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/figures/-/figures-3.1.0.tgz#4b198dd07d8d71530642864af2d45dd9e459c4ec",
+        "sha512": "adabe1f15457a87b8cbd9b7f77c19b9417aa0cc91d24c05dbffd8a9ed147fab6b931790eee7c4d2a9cd0de7e900ffd9d6b5907d1a5a634849dbe133b825da056",
+        "dest-filename": "figures-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-1.3.1.tgz#44c61ea607ae4be9c1402f41f44270cbfe334ff8",
+        "sha256": "90fddc3e3cea3a5a7401b7600152f997069341407bf7de0987d612d4f52484d7",
+        "dest-filename": "file-entry-cache-1.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c",
+        "sha512": "6c2836f6272db8168a530c00acae28b826aa0e02d9732b0214b98cfd89ff143a2a9dd87ff6f36e41f5d10ef4ee5ca2f17c3fc9b594062854fc30670904aeb8e2",
+        "dest-filename": "file-entry-cache-5.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027",
         "sha512": "ec6a6cfd75b299b2e4d902d82b8373a4c3ab623321748c57b88bf2d9006c2c4ea58eea1d2af7645acfdca72249dc25485691f43a2d47be0d68bdb3332dd14106",
         "dest-filename": "file-entry-cache-6.0.1.tgz",
@@ -4811,9 +9732,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz#a5e7a8ffbfa493b43b923bbd4ca89a53b63b612b",
+        "sha256": "daeea5782aa8e3e6426ec106ff9529ff46f307a3eb69478be0e0af7879e16371",
+        "dest-filename": "file-sync-cmp-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5",
         "sha512": "c35704b9fdd2f83acb0902fb113ea4cfe82694975babd27bc970928cafce6423c0faa10dd56c85e1901fd186096b8fec84726b6b6b7f77fafc495e098bec7ef1",
         "dest-filename": "filelist-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.0.tgz#996e3e80479b98b9897f15a8a58b3d084e926775",
+        "sha256": "8e20c85d4c892f6a66c61ad3fc6a43a77645afd3f134e81a3ac267c71d36dde9",
+        "dest-filename": "filename-regex-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26",
+        "sha256": "427984fa14af1ec14cafbdd524bdd0c145f8567325a6ece4ad39f73d763e946b",
+        "dest-filename": "filename-regex-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4832,6 +9774,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/fileset/-/fileset-0.2.1.tgz#588ef8973c6623b2a76df465105696b96aac8067",
+        "sha256": "5d3c8e1157488d78395ff4438a16aafede2960e8bf6a065339a1d50b820acb60",
+        "dest-filename": "fileset-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723",
+        "sha256": "45024df8d280ba034b447ee3128647b5e24d7693677a70dc517257b139fc8089",
+        "dest-filename": "fill-range-2.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7",
         "sha1": "d544811d428f98eb06a63dc402d2403c328c38f7",
         "dest-filename": "fill-range-4.0.0.tgz",
@@ -4846,6 +9802,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.0.tgz#ce0b6855b45853e791b2fcc680046d88253dd7f5",
+        "sha256": "91cfb920bc6d6bfccf93b9779b9f58961024e0326ffe956ffcf4f234507e7b02",
+        "dest-filename": "finalhandler-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.2.0.tgz#7d23fe5731b207b4640e4fcd00aec1f9207a7b32",
         "sha512": "e6e5dc5157ed9503059d60bdaaefecbe45afdc64ddd8f7d484aff73cb9183407bb15ba8932ddf9d791dac44e9e44bef819db2b8a2c2e8e26b075a0750691084a",
         "dest-filename": "finalhandler-1.2.0.tgz",
@@ -4853,9 +9816,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9",
+        "sha256": "fa7ad781a5d50ce33f04ff241f32315ed45c537beaf032f08d1e33e8841eb736",
+        "dest-filename": "find-cache-dir-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7",
+        "sha512": "4eae8f8b1134c3f54c15f0a06ce36792240856897f2492fb9d1322db47eacc0e0d46cf407dea8c19e45d3e2df0221624c63781696876af1c1aa67e53bb722a39",
+        "dest-filename": "find-cache-dir-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/find-index/-/find-index-0.1.1.tgz#675d358b2ca3892d795a1ab47232f8b6e2e0dde4",
+        "sha256": "6a56baade902028c05f3745f5e9060177ea7b57f719b589c348294cb4cb388ed",
+        "dest-filename": "find-index-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
+        "sha256": "b1e6968c7ccf27d31504353bed2b0748b9b0284bc847b0a0480f5b56137d8b7f",
+        "dest-filename": "find-up-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7",
         "sha1": "45d1b7e506c717ddd482775a2b77920a3c0c57a7",
         "dest-filename": "find-up-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7",
+        "sha256": "e3ffbffcc7334b7eace925188baedbc1eaa83e506fce2b8a734136b31633ad1d",
+        "dest-filename": "find-up-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73",
+        "sha512": "d720fa4662c8d5705fc6e82f391c25724e9fef9b582fe891d23ab0b0eacec4c672198a94b83849d25e005dd3b5897fc54ecf5c040304935816484c759126f296",
+        "dest-filename": "find-up-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4881,9 +9886,72 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.1.3.tgz#7f3e7a97b82392c653bf06589bd85190e93c3683",
+        "sha256": "39e1b0c636dd6d3c3ee30f08587706864a2148bd425082282b242a15cba6dfec",
+        "dest-filename": "findup-sync-0.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.3.tgz#40043929e7bc60adf0b7f4827c4c6e75a0deca12",
+        "sha256": "60782cf943e8ff3926098a20bad24f1a150830d3ac14d4bc2b540b9b8679de4c",
+        "dest-filename": "findup-sync-0.4.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fined/-/fined-1.0.2.tgz#5b28424b760d7598960b7ef8480dff8ad3660e97",
+        "sha256": "4614d76cdcab843e55e6777f86f1db4ff3a489bd8ad4eb5c8efc161096208817",
+        "dest-filename": "fined-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e",
+        "sha256": "2026f1347dc77563a4eb4ea01e3fc8964c34387073c79a83ad11e802d6d8377d",
+        "dest-filename": "first-chunk-stream-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-0.3.2.tgz#ff191eddcd7088a675b2610fffc976be9b8074b5",
+        "sha256": "716a26cca54fbc158e6f95bc755cb159e10e4c9410f676645d83efa8a5428a5a",
+        "dest-filename": "flagged-respawn-0.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.2.2.tgz#fa86714e72c21db88601761ecf2f555d1abc6b96",
+        "sha256": "9e6d6ffb8a2b1b6d066208e19ed6a58ba3c32ebe0dff1eab03ed3b74c1107b32",
+        "dest-filename": "flat-cache-1.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481",
+        "sha256": "c01f06dbdea79be26dfb24767cae11cdf2a123c613862c4998b44d927804526b",
+        "dest-filename": "flat-cache-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0",
+        "sha512": "2e841eeb20ee50c0f3400107f2c82687831dea866773fecf8edc233454b3bde5ea487b7a91af5f3c1baca3b2067fd473e2eaa74a75a2147d81ff38f6e1ae5178",
+        "dest-filename": "flat-cache-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.2.0.tgz#2c0c2d5040c99b1632771a9d105725c0115363ee",
         "sha512": "09870435af85b5c50a2e6861ab272da5c96cabb405dfca4a8d91ec18d892405e6be05b6828359a6c50e5de1cda11032f4f52c7132b30e6dc202efa5861be2f6f",
         "dest-filename": "flat-cache-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08",
+        "sha512": "6b5850324b6a5bd366aabe5a92d02ec7724c36a6ae73119c8ed8d69d92c75fbcb23c29a5495dcce789c661ba93f0afb41a117734182624273799af963a05fc26",
+        "dest-filename": "flatted-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4923,6 +9991,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b",
+        "sha512": "c1637ad9821311a3a948ae7ce0465725a7c7d401a93bc45580495f92e5db4ceacf5f87c87cec84a56fc2b2235df09758ac0a0ebda7d14ce127bec3befaa0aa14",
+        "dest-filename": "follow-redirects-1.15.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e",
         "sha512": "8ea61f2e9ee6a3dbc8c907fcca45b6bfb03ed8de108de09e239f83cfd5eb6a23b58a09fcd708e21fb15bf6f48e5af41f36d9926b81f6468413aeb5e2bdd5199b",
         "dest-filename": "for-each-0.3.3.tgz",
@@ -4933,6 +10008,90 @@
         "url": "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80",
         "sha1": "81068d295a8142ec0ac726c6e2200c30fb6d5e80",
         "dest-filename": "for-in-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80",
+        "sha256": "4e7da30d44cd6cf66e4883328d6ced16fa83a5da11bbe46b4837ddfd526fa85e",
+        "dest-filename": "for-in-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce",
+        "sha256": "f0fa350a77c2e6375efb7730f2884e377e0cc0cf7fa4ba0b0539d8a34072b22f",
+        "dest-filename": "for-own-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/foreground-child/-/foreground-child-1.5.6.tgz#4fd71ad2dfde96789b980a5c0a295937cb2f5ce9",
+        "sha1": "4fd71ad2dfde96789b980a5c0a295937cb2f5ce9",
+        "dest-filename": "foreground-child-1.5.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/foreground-child/-/foreground-child-1.5.6.tgz#4fd71ad2dfde96789b980a5c0a295937cb2f5ce9",
+        "sha256": "f31c6279638e310b2469b4485e8ab1f06d698fc1c2219cdf7c2ecbfcbe7eed16",
+        "dest-filename": "foreground-child-1.5.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.1.1.tgz#1d173e776d75d2772fed08efe4a0de1ea1b12d0d",
+        "sha512": "4cc28352722d7ba6df6f99d6bfb57f71a235ebd38782fc236fb5785a4794bdb410763af9ad62aa1c588a59bfdf70ec01f82cc14fea9b5a3be3f8357046c92922",
+        "dest-filename": "foreground-child-3.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.2.0.tgz#5eb496c4ebf3bcc4572e8908a45a72f5a1d2d658",
+        "sha512": "0ab59035a125d7fe96799a1aadc33d2c7ba94e8dd1a593b63dd935be4b70ccf8904ec26700a2669b74c008a786e5465b5837da1f601bbd8c733fdeb2d0c4fb7c",
+        "dest-filename": "foreground-child-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91",
+        "sha256": "eca862e1fd07bf54ff68ccf70450a64dc3d6b807ee9e3ddeb5d96773a3c806c5",
+        "dest-filename": "forever-agent-0.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fork-stream/-/fork-stream-0.0.4.tgz#db849fce77f6708a5f8f386ae533a0907b54ae70",
+        "sha256": "c85df7541e9c896503b68043aff1a4047a4e8b2c27e1feeef4deb27ae2279dc1",
+        "dest-filename": "fork-stream-0.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/form-data/-/form-data-0.2.0.tgz#26f8bc26da6440e299cbdcfb69035c4f77a6e466",
+        "sha256": "531f372b9b8b06566bc628a9fce66d222ce599ed7c4f0e2ee2ac38b5e5d3b7a0",
+        "dest-filename": "form-data-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1",
+        "sha256": "f1292eb8ecd656db1e05bd9879282b961a9d8f30a703a745ebf7784b05a25a2d",
+        "dest-filename": "form-data-2.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099",
+        "sha256": "e42323e14e39e24873d2edc18aeca738b44c4f10481f7b619a5e21f9fefd78cd",
+        "dest-filename": "form-data-2.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6",
+        "sha256": "e39ecf83f4c79bb67004b7023d353e718db5a0c27bd4909957187b8d4e5033c8",
+        "dest-filename": "form-data-2.3.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4951,6 +10110,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/formidable/-/formidable-1.0.11.tgz#68f63325a035e644b6f7bb3d11243b9761de1b30",
+        "sha256": "39b345d14d69c27fe262e12f16900cef6be220510788866e0a12c9fedd03766e",
+        "dest-filename": "formidable-1.0.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84",
+        "sha256": "58e57c0198c7b9a94bc0f0442aae01d8f07e6191fdb21cb5b1aab64861e852cd",
+        "dest-filename": "forwarded-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811",
         "sha512": "6ee446d1fa41b511d24c238049eea10f6e7cb44b9b16844b6f864d03a3713151cdc3680e7301e8f70c9a6e5ccccce039cfdc40f4bd4a36393f36de8c4fd698a3",
         "dest-filename": "forwarded-0.2.0.tgz",
@@ -4965,8 +10138,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/fresh/-/fresh-0.1.0.tgz#03e4b0178424e4c2d5d19a54d8814cdc97934850",
+        "sha256": "c402fbd25e26c0167bf288e1ba791716808bfaa5de32b76ae68e8e8a3d7e2b33",
+        "dest-filename": "fresh-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7",
         "sha1": "3d8cadd90d976569fa835ab1f8e4b23a105605a7",
+        "dest-filename": "fresh-0.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7",
+        "sha256": "25e676f9f00a8dddc7214f46258b71c0188a0ee004903f05109ecfce9a5a844c",
         "dest-filename": "fresh-0.5.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -4993,6 +10180,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz#cf25554ca050dc49ae6656b41de42258989dcbce",
+        "sha256": "16f74868049d5c14ad65ee561da0827047bc466114e91c5af5085a0bd3057adb",
+        "dest-filename": "fs-exists-cached-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add",
+        "sha256": "069afc4275f180a5d03f28010d8c8e5f3e63e1280f38e13a12e13e59fd0764e5",
+        "dest-filename": "fs-exists-sync-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950",
+        "sha256": "eed8f1f41be7033d3ad7b5652459276fa461651bbdc389041cc94acc18a571ab",
+        "dest-filename": "fs-extra-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf",
         "sha512": "a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d",
         "dest-filename": "fs-extra-10.1.0.tgz",
@@ -5003,6 +10211,13 @@
         "url": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d",
         "sha512": "306204e073af4027940b39a51ecd2f5e98a1e32b33e3083daa2480bba71de36955c0f6d33354e357b46eb28c90a8c9a4ffde60750657ef6bbe616f9cdde12915",
         "dest-filename": "fs-extra-11.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b",
+        "sha512": "3e60e2deec0ae6716e5e1ed70d39559d2d7bc494bbbd6dfa8acdbec37c5cbfc495c620783720137f872d9156396e44a35f46389dbbd90aad7f123b44cabf64b7",
+        "dest-filename": "fs-extra-11.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5035,9 +10250,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-3.0.3.tgz#79a85981c4dc120065e96f62086bf6f9dc26cc54",
+        "sha512": "5d4040f570a51db9c95927c1ce3926e91bcfb32837b2bc99b74e81110a17705ec42bfc6919a41826040a0c94941f948667be98ee9171d500675f3d3dad4e456f",
+        "dest-filename": "fs-minipass-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.5.tgz#fe450175f0db0d7ea758102e1d84096acb925788",
         "sha512": "f2e31b063ae1cd6efa4d8804576ed8e44fff5b67ff953166c7bf0fdb0d7d1594b16ab848ffbf7c00f190cae182c2690dc60c06461acb7ef5b22c1bcdb6e3a67b",
         "dest-filename": "fs-monkey-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27",
+        "sha256": "eaf19d49df2319d79282391497fc43d25fe046c2720cb5e06239aefd9e9eaa17",
+        "dest-filename": "fs-readdir-recursive-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5049,6 +10278,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f",
+        "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c",
+        "dest-filename": "fs.realpath-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.3.tgz#11f82318f5fe7bb2cd22965a108e9306208216d8",
+        "sha256": "e8210b108babc8c2278fbd5b9bbef772e950b948469ccf7c23e6a7a8623f6a3e",
+        "dest-filename": "fsevents-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805",
+        "sha512": "478c03881c19d0ace980e59eb4a0ee83515971886a6275182ad7d962de260f9481cfbeaad0a47843da3b1883da9ac54f1a65b71183cf27474e3a3bf1df695d64",
+        "dest-filename": "fsevents-2.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e",
         "sha512": "02ec3d6b8031a96a5af4651f8f7ef404c3f3cf29dc7c10015bc31a6fb0465816038f822c82af9c0cab71d22eaef63717f694039ecc2c69a393813980e69123b9",
         "dest-filename": "fsevents-2.1.3.tgz",
@@ -5056,9 +10306,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a",
+        "sha512": "c62a8c411e3101e1d3b81f6e5a6f9f1517083a02813223813fe7978b24fb8ec8150aad5b915ca0b74d28012a3007b11db6938769a3e02adf35d8ff5a6fe0c328",
+        "dest-filename": "fsevents-2.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6",
         "sha512": "e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
         "dest-filename": "fsevents-2.3.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105",
+        "sha256": "30acfaf7aa9875a241c7c8e9398b060c9ae7c31adad48a46af47a6070175e04d",
+        "dest-filename": "fstream-ignore-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171",
+        "sha256": "c662581e8e2837bf9b81b42651242d300c6b9031bd6788adc5f51f6d270f1971",
+        "dest-filename": "fstream-1.0.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045",
+        "sha512": "5af275f773876b41873c42fe032704260c6f044c327d190dd6f86371adb739a3d530268b0974dde6a02ef360234dc80fd54266cad90e29beb762975eeeb68322",
+        "dest-filename": "fstream-1.0.12.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5073,6 +10351,13 @@
         "url": "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c",
         "sha512": "ed71cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648",
         "dest-filename": "function-bind-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/function-loop/-/function-loop-1.0.1.tgz#8076bb305e8e6a3cceee2920765f330d190f340c",
+        "sha256": "e047de7af6af3efaa550d0814911cecf19c43a5fcd8c444b4cec3c7627c3415d",
+        "dest-filename": "function-loop-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5094,6 +10379,13 @@
         "url": "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.6.tgz#cdf315b7d90ee77a4c6ee216c3c3362da07533fd",
         "sha512": "679931efdb305393f6ed611ac97335b418b965efe56c8ca2360537ab25d439ff5bdab81763217d0f2f42c7e210bff2dcf16086e8bf36cf050fa524bd8467a122",
         "dest-filename": "function.prototype.name-1.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327",
+        "sha1": "1b0ab3bd553b2a0d6399d29c0e3ea0b252078327",
+        "dest-filename": "functional-red-black-tree-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5126,6 +10418,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/gauge/-/gauge-1.2.7.tgz#e9cec5483d3d4ee0ef44b60a7d99e4935e136d93",
+        "sha1": "e9cec5483d3d4ee0ef44b60a7d99e4935e136d93",
+        "dest-filename": "gauge-1.2.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7",
         "sha1": "2c03405c7538c39d7eb37b317022e325fb018bf7",
         "dest-filename": "gauge-2.7.4.tgz",
@@ -5133,9 +10432,72 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7",
+        "sha256": "98d904d5d0987cf0f4f54ce033934c81bdb93a8b7d75e4fb6912b843c1496676",
+        "dest-filename": "gauge-2.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gauge/-/gauge-4.0.4.tgz#52ff0652f2bbf607a989793d53b751bef2328dce",
+        "sha512": "7fd9be0443798e483a6b47d98e57a2763379d551355fe98f150d83274bafd55dfda022c26ec19eeb28db067a7b78aef3ffe180a27f7d6b79c7baa6eebad8723e",
+        "dest-filename": "gauge-4.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gauge/-/gauge-5.0.2.tgz#7ab44c11181da9766333f10db8cd1e4b17fd6c46",
+        "sha512": "a4c6857ed5cfb621881c224775c514c7d45bcbfac54ff2a4b777c82060acfbd3cc0c89634b2462aab69397136d0517894437d479fa5adbadd1437be7a791bf2d",
+        "dest-filename": "gauge-5.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gaze/-/gaze-0.5.2.tgz#40b709537d24d1d45767db5a908689dfe69ac44f",
+        "sha256": "55d774be7bc0891f6d8572badf3ee9cf85da6356d5fc9cfe34f186c2fa6eca10",
+        "dest-filename": "gaze-0.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gaze/-/gaze-1.1.2.tgz#847224677adb8870d679257ed3388fdb61e40105",
+        "sha256": "d398cfc657ad9e1dc7f549bca920a14c0b1362b3d8c5275e99ba9a7bbd0a3492",
+        "dest-filename": "gaze-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74",
+        "sha256": "0f797a03289c5305433b7e132a73e5517e3a860bbc249a0cb9cdb1a886c7b4c2",
+        "dest-filename": "generate-function-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0",
+        "sha256": "623c3f9901713bcafa9b50d21ba8117d57062aaebf0f7c28a3984841967a5399",
+        "dest-filename": "generate-object-property-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269",
+        "sha512": "afc102e8d3b5b27807ff3743f5f8910cb75c8276dac976a1fa62e031a9d3688649a840b5319b2d9a7a31f0aa67236fdfc50c2ba793a908e6162e9e2b065e0972",
+        "dest-filename": "gensync-1.0.0-beta.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0",
         "sha512": "de137b35ab2462f3032d0639e609d6dcd43e99eb0401ea53aa583e5446e3ef3cea10c055361cdc19861ea85a3f4e5633e9e42215ca751dcb0264efa71a04bcce",
         "dest-filename": "gensync-1.0.0-beta.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5",
+        "sha256": "14c82f01361452d3ee9e7879d90e66819557d8e84a69ec0f6c7c65c6563049a7",
+        "dest-filename": "get-caller-file-1.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5189,6 +10551,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/get-port/-/get-port-5.0.0.tgz#aa22b6b86fd926dd7884de3e23332c9f70c031a6",
+        "sha512": "8a6ccc534163b19a8d6ba06a3a36db5bac39062bc722e40aa298e93ea727c740151c940a0b12b53be01bdcead55e1ade92a7d5323c00f5962ed3ad91f8a708b1",
+        "dest-filename": "get-port-5.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe",
+        "sha256": "cc2f878acc6081d9a1d7dce15163456e416e20d80970a44dafb5a9929bc94d48",
+        "dest-filename": "get-stdin-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b",
         "sha512": "8e9e2d1dac3257bf9f92448acaf8ee2d9b306e552dcfe4902b34969c16e28b5e81b9992c265535c2e0585d8ef9afe76e87f965175babea83708bed99ce3299ee",
         "dest-filename": "get-stdin-6.0.0.tgz",
@@ -5203,9 +10579,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14",
+        "sha1": "8e943d1358dc37555054ecbe2edb05aa174ede14",
+        "dest-filename": "get-stream-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14",
+        "sha256": "775e05b483a9a801fafb4f4858b200dbc34ce38a9bc1442efb4b00f92245006e",
+        "dest-filename": "get-stream-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5",
         "sha512": "18c6ade04279d7ad64232d877af2e5af896e363060be68f8d7729a400ee3b7857c078443b1fa4793b590f4656a7d8cb2c7c392fcbeba2a8c7eac944d9252caef",
         "dest-filename": "get-stream-4.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9",
+        "sha512": "117af514ecebcd37c678bd2041d78512f38c9b69b330e825ca2397493a4f0be8808c029fb5baf78e908c5b29e883062733e7928fdb0719ceb08c8703bd88b283",
+        "dest-filename": "get-stream-5.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5238,9 +10635,72 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/getobject/-/getobject-0.1.0.tgz#047a449789fa160d018f5486ed91320b6ec7885c",
+        "sha256": "2c0a44303fb9b403b6f50f188fedc43b4005cb4391c98e784c3c57c9750c104a",
+        "dest-filename": "getobject-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa",
+        "sha256": "8f0312ba10766d6c13bf71bae5168ca26191f6eed5c47ac5fa7c4df85b3ed445",
+        "dest-filename": "getpass-0.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ghreleases/-/ghreleases-3.0.2.tgz#1bdb6d31ec03a24a0d80f58f5e9a84a4db725818",
+        "sha512": "42247d98862f446ee177c26e418a3178134e7a556e4e9d83a5d881c91cb06c20c1489b9f2bd56aed5ba10fc07ee6ebe2331671d801240b3c9eeb552cf606209f",
+        "dest-filename": "ghreleases-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ghrepos/-/ghrepos-2.1.0.tgz#abaf558b690b722c70c7ad45076f6f9be8e495e1",
+        "sha512": "e86334a214834c0bfbc43e86b0a7f126257f09a8e8a1f472530bb413c976f5dd68ea51405319a6c8c3ff147df769f036d19ad7cf1c5c4ed37a4ec62fb9d32802",
+        "dest-filename": "ghrepos-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ghutils/-/ghutils-3.2.6.tgz#d43986e267da02787464d97a6489659e4609bb1f",
+        "sha512": "5a960780b424a94ec2bf5e3bc0a5044e1ca3eaa28709d9c01b608bf5146c45022655d2c6755a9b949dc95278f74e8430826d402cf4be157811d38e3c02018f52",
+        "dest-filename": "ghutils-3.2.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce",
         "sha1": "97fb5d96bfde8973313f20e8288ef9a167fa64ce",
         "dest-filename": "github-from-package-0.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4",
+        "sha256": "c7aa93cb5439345a22efef1ec734c5c7a68e236d34d916e108e3aeb826eda8a5",
+        "dest-filename": "glob-base-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28",
+        "sha256": "6331c038d9b238fcdea3b1721c26ffa33765b16354abfd5091aa58d2e070854d",
+        "dest-filename": "glob-parent-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae",
+        "sha1": "9e6af6299d8d3bd2bd40430832bd113df906c5ae",
+        "dest-filename": "glob-parent-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2",
+        "sha512": "aa3b5182721598e7e729413734901011d93e94aaf17f0f2de647bb497b5f3131dc8ec05f39f5970907dd6f7d337c3a194362114888a27668ed6c764f67ef8887",
+        "dest-filename": "glob-parent-5.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5259,9 +10719,93 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/glob-stream/-/glob-stream-3.1.18.tgz#9170a5f12b790306fdfe598f313f8f7954fd143b",
+        "sha256": "ffd74767ed611f939f2507dc51a96e5987f94e70fefa6cf77ece3e6ad27dd632",
+        "dest-filename": "glob-stream-3.1.18.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab",
+        "sha1": "8c5a1494d2066c570cc3bfe4496175acc4d502ab",
+        "dest-filename": "glob-to-regexp-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e",
         "sha512": "9645f51c95f0c8c729af0ff961465cdacec3ae90221c1db5fd5f84d6b1d4ad5368924bc1e9ba8ccd3d157d5ebff3a64d69bb75935e18388693ee70ef397dc88b",
         "dest-filename": "glob-to-regexp-0.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob-watcher/-/glob-watcher-0.0.6.tgz#b95b4a8df74b39c83298b0c05c978b4d9a3b710b",
+        "sha256": "c8f692991bbd9a9bf3abdf15eedbf3ea0f3fc154e6eeab5de8adf7e11cec9e2c",
+        "dest-filename": "glob-watcher-0.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob-whatev/-/glob-whatev-0.1.8.tgz#a33a763262e501e851bc84fd22b5736cff3826fd",
+        "sha256": "99ba5504d995d449f31dd73b0f519e2e7cf8c9364436865a31d2f39861c34982",
+        "dest-filename": "glob-whatev-0.1.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-10.4.1.tgz#0cfb01ab6a6b438177bfe6a58e2576f6efe909c2",
+        "sha512": "da37a5865ab7138868ef867254b374de829d0195546ba50367314b547d47edd9e86b1fb2f6ac9aabccc191f0c88208e7894d7dcf4c14d7ccb5ea3301d9ec9523",
+        "dest-filename": "glob-10.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-3.1.21.tgz#d29e0a055dea5138f4d07ed40e8982e83c2066cd",
+        "sha256": "36df6f1b38db24d60b3a555c71dbb517d733983151e6f8d7e471213b4d65f037",
+        "dest-filename": "glob-3.1.21.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-3.2.11.tgz#4a973f635b9190f715d10987d5c00fd2815ebe3d",
+        "sha256": "f9590b70b615298628eb327e02012ccc4e4d6407292902ea767600310efdb0a3",
+        "dest-filename": "glob-3.2.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-4.3.5.tgz#80fbb08ca540f238acce5d11d1e9bc41e75173d3",
+        "sha256": "d673c8640e3f7c08bc5454da61b93e455a483c084abfd55969f879d64cc15480",
+        "dest-filename": "glob-4.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-4.5.3.tgz#c6cb73d3226c1efef04de3c56d012f03377ee15f",
+        "sha256": "2a924d770cd71b9c645b5bcdade8a755578a1c9348ab6146d303e33187152d85",
+        "dest-filename": "glob-4.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1",
+        "sha256": "e3c945daf510834834abe87624deec08f6f7f4ec058cb6f3ff8c932edea448b7",
+        "dest-filename": "glob-5.0.15.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8",
+        "sha256": "17232040681c8bfa5badd0801a977fa79c05f0388974e8921fffabd380d10c0b",
+        "dest-filename": "glob-7.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15",
+        "sha256": "cf3d3e47a1308b512fd707f1df593737cb569079d04bf975e1fc48de6a629ed1",
+        "dest-filename": "glob-7.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5274,8 +10818,22 @@
     {
         "type": "file",
         "url": "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1",
+        "sha256": "deddc4cfaf4dac3c1e26486746680e9130ad90e116b3b2fc13d8b0961c25a5e1",
+        "dest-filename": "glob-7.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1",
         "sha512": "bdc7ee888c6880b5780e51811c850ec08d086eb27c1d63dce0c53b1f3be219e361a3f5090df8ba079a77b07796210d0a188534269c62e591f17a641f2e4900c1",
         "dest-filename": "glob-7.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255",
+        "sha512": "8642cf7a97a19a72a4e35a541a6dec631a05b3fba6bab61f60909eadb5c4c85216700cefa62a40815901aaa4fd44128c1a39eaea432ec98c216ba72cc5b88cd4",
+        "dest-filename": "glob-7.1.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5294,9 +10852,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/glob2base/-/glob2base-0.0.12.tgz#9d419b3e28f12e83a362164a277055922c9c0d56",
+        "sha256": "80bb12536fdb75aa47475bb7fa699deef5120dfffb4f56109be496f7b30c98ef",
+        "dest-filename": "glob2base-0.0.12.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/global-agent/-/global-agent-3.0.0.tgz#ae7cd31bd3583b93c5a16437a1afe27cc33a1ab6",
         "sha512": "3d3e9745e27e0f4ec9bc6a3140c913eaa8e2fe354d7d7fe1dfae171d9396791cf2eb8b1216bfb1279397ecb2376f830f43374be07f18f0cd31ccfa6c54cc00f1",
         "dest-filename": "global-agent-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445",
+        "sha1": "b319c0dd4607f353f3be9cca4c72fc148c49f445",
+        "dest-filename": "global-dirs-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/global-modules/-/global-modules-0.2.3.tgz#ea5a3bed42c6d6ce995a4f8a1269b5dae223828d",
+        "sha256": "12d55d9c7d6f496366e07880860b946dddf81857cd0b31b344696752a12b11f5",
+        "dest-filename": "global-modules-0.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f",
+        "sha256": "4c72b241776bcb15a6a8745460f4de192ca8c19e406fac7133a9092cab72fd4e",
+        "dest-filename": "global-prefix-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e",
+        "sha512": "58e069fc410652222c252a7bc1cbffcba30efa557d5289dc5aac6e15f9bc781c3358d8327c177a1b3f8878a43d8c29b28681fdf60d793374fe41a5471638b354",
+        "dest-filename": "globals-11.12.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5308,9 +10901,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/globals/-/globals-12.3.0.tgz#1e564ee5c4dded2ab098b0f88f24702a3c56be13",
+        "sha512": "c007e374b805b0f66c9252c9bce054066cd813cfc2c2112a48110c457037ab122236dcaabe362eac0b487c387a7219443d47e64d8dcc9d98791df878ab452523",
+        "dest-filename": "globals-12.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/globals/-/globals-13.23.0.tgz#ef31673c926a0976e1f61dab4dca57e0c0a8af02",
         "sha512": "5c0985d118e5ae3636dcc039d6adc796d7651b15295cfbe0d068a82a20fd5fa1c3dbc88c8e8d9d282f15ab09bb9677b818dafbf3e4474df96292d47a647d3dc0",
         "dest-filename": "globals-13.23.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/globals/-/globals-8.18.0.tgz#93d4a62bdcac38cfafafc47d6b034768cb0ffcb4",
+        "sha256": "0e702123f17302f80ebbcc11e0f2977df813119a3323868019d223f57b90874a",
+        "dest-filename": "globals-8.18.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286",
+        "sha256": "e405e62acf812ffeb1a19c107007afd69adbc534b5b97baba18c4ebd5e5c10f9",
+        "dest-filename": "globals-9.17.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a",
+        "sha256": "437a12c10dd45aa191c4a5d77648026f1d65a578b65e2c88ee249ec8945c737a",
+        "dest-filename": "globals-9.18.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5329,9 +10950,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/globby/-/globby-10.0.1.tgz#4782c34cb75dd683351335c5829cc3420e606b22",
+        "sha512": "b12b388a7135141d98422ca67264efe8d58436bc8006350d3de5a13af9a7e128ed2b26e096cc8f671141dd4d7ff8bd5b622d2b3590ea08b947c8b6039753eae4",
+        "dest-filename": "globby-10.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b",
         "sha512": "8e121768ecf2d6c6fc232a1c6abb964a7d538e69c156cf00ca1732f37ae6c4d27cab6b96282023dc29c963e2a91925c2b9e00f7348b4e6456f54ab4fd6df52de",
         "dest-filename": "globby-11.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d",
+        "sha256": "ab6cfbc6325c9db2198f39a2c6bfa5d7b8635c3111ee3a94ee33fad08b34c1dc",
+        "dest-filename": "globby-5.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c",
+        "sha1": "f5a6d70e8395e21c858fb0489d64df02424d506c",
+        "dest-filename": "globby-6.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d",
+        "sha512": "a2594f1d139ae667310c493083a6cfb7741b11fe290d048db5de893cbd58bcebc0a3feffd15026f5371c51ea1399aae33f0e297d4b61482a9cc9f341d48dd94a",
+        "dest-filename": "globby-9.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/globule/-/globule-0.1.0.tgz#d9c8edde1da79d125a151b79533b978676346ae5",
+        "sha256": "99bab6faaee221455a78d0372d1299486e03ae840c692a5d6bf2e719f1f5af17",
+        "dest-filename": "globule-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/globule/-/globule-1.2.0.tgz#1dc49c6822dd9e8a2fa00ba2a295006e8664bd09",
+        "sha256": "1fefaeef0dc3d0a470eaa9a5341ff71d011a387ed295ed85179221b3c1b41077",
+        "dest-filename": "globule-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glogg/-/glogg-1.0.0.tgz#7fe0f199f57ac906cf512feead8f90ee4a284fc5",
+        "sha256": "f83ff4271c7a992e4921f820e1c3cb5cd4096e5cee0bb52d1cd1ffe276319be1",
+        "dest-filename": "glogg-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5350,9 +11020,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0",
+        "sha1": "240cd05785a9a18e561dc1b44b41c763ef1e8db0",
+        "dest-filename": "got-6.7.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85",
+        "sha512": "47b796a6d5ee198c708a3b34795fafde8ebe5c7d48a952bc74938479c41f4e6927730f4057875cc3f0e1c62f0c765a8fb61c71a59ca2ccccf283c453984b06f9",
+        "dest-filename": "got-9.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-1.2.3.tgz#15a4806a57547cb2d2dbf27f42e89a8c3451b364",
+        "sha256": "b8d9e0af2261259525a65281573e416b70b91788ea7f7b13f4598aaa7818255a",
+        "dest-filename": "graceful-fs-1.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-3.0.11.tgz#7613c778a1afea62f25c630a086d7f3acbbdd818",
+        "sha256": "5ad3f98360c34edafd6a285e9cbe0b748202cebf51b4a74a57da910851f52503",
+        "dest-filename": "graceful-fs-3.0.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658",
         "sha1": "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658",
         "dest-filename": "graceful-fs-4.1.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658",
+        "sha256": "6ab070270ef8dd8edd446df87425829ed31091dc7e5f30787f5abb9cb5c2b6b8",
+        "dest-filename": "graceful-fs-4.1.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3",
+        "sha512": "45b279fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd",
+        "dest-filename": "graceful-fs-4.2.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423",
+        "sha512": "6b7d151019b83c4771d5d441ecc14aec17a37a3bc2bc1ae89db2e386dfac1ee1988fc3c7b3b33fe59fabb79970e79d6f67bc9f4c28f856ecb2de6489cad0d645",
+        "dest-filename": "graceful-fs-4.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb",
+        "sha512": "5a328f34917bf5db490159e2525186587606cf68d6c53e9584dff89b535d91b6769ceb0417e708d44760aa5e7309186cfd5b10611beb5dcb7192d557654922c7",
+        "dest-filename": "graceful-fs-4.2.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5364,9 +11090,212 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725",
+        "sha256": "c1ce83682d563874517386a13c364eb0a8494e99a69203cff264a1381cb3a300",
+        "dest-filename": "graceful-readlink-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6",
         "sha512": "12d2b0a0eea4c422fd58ee718a98874d9952cc19bb58b4fadbb4ea0bfb9545dd072a6abc357c9e6e7358c43a018bbc2df1e4d6ad4aca5c2395685abdc759206a",
         "dest-filename": "graphemer-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f",
+        "sha256": "ce59c063fd72fb355a42c943b055bf95265b166a12cb4b3584ecde3b28a99b28",
+        "dest-filename": "growl-1.9.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-babel/-/grunt-babel-6.0.0.tgz#378189b487de1168c4c4a9fc88dd6005b35df960",
+        "sha256": "7c2861feabcd665a22bbf667aa61c0293a5753925da1c2612c14d13115a7f33d",
+        "dest-filename": "grunt-babel-6.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-clean/-/grunt-clean-0.4.0.tgz#a7b4e188d7e94ca6c93bb88ec64096534931c40b",
+        "sha256": "099a0255887162cadf2894d799286f4cc4519c73ac45493ee3f37c53c1959a6c",
+        "dest-filename": "grunt-clean-0.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-cli/-/grunt-cli-0.1.13.tgz#e9ebc4047631f5012d922770c39378133cad10f4",
+        "sha256": "e639404d7b66ae2821edabc681104a1f035910ff20a2e21d67329c2a7674a443",
+        "dest-filename": "grunt-cli-0.1.13.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz#564abf2d0378a983a15b9e3f30ee75b738c40638",
+        "sha256": "32f882943df061e209928d3950e290228c08d45c29396b9a01279625cb9f57fb",
+        "dest-filename": "grunt-contrib-clean-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz#7060c6581e904b8ab0d00f076e0a8f6e3e7c3573",
+        "sha256": "7362702ff2868fa6e29d59d528347548d3fa3e5b880be9b4c59d54fa47e55b89",
+        "dest-filename": "grunt-contrib-copy-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-contrib-uglify/-/grunt-contrib-uglify-1.0.2.tgz#ae67a46f9153edd4cb11813a55eb69c70d7db2fb",
+        "sha256": "f7ba1a3c6618810b7686f7b16488b15055aceda93b4d23fcfa8d3ebebf36b9ea",
+        "dest-filename": "grunt-contrib-uglify-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz#84a1a7a1d6abd26ed568413496c73133e990018f",
+        "sha256": "05a1484d74dc800bdf0fbe7e84be2d68b870484c74e4997ac0ffc96adad0e90c",
+        "dest-filename": "grunt-contrib-watch-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-eslint/-/grunt-eslint-17.3.2.tgz#36a8b3be6ccde88c8b58f909745d75db19e5d4b0",
+        "sha256": "c34d3f3d066bd871fc7658296a73eebf91784f23fa6e1c55f99b6d5fa8106bde",
+        "dest-filename": "grunt-eslint-17.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-karma/-/grunt-karma-0.12.2.tgz#d52676ab94779e4b20052b5f3519eb32653dc566",
+        "sha256": "8428e7f079cab89f7d623e255e2ca5bb0f56dc256a7b7837e015aeea57f0d44f",
+        "dest-filename": "grunt-karma-0.12.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz#c0706b9dd9064e116f36f23fe4e6b048672c0f7e",
+        "sha256": "90b009c302df00f51a76909f8c0c40a62336cc35227ab208b56aab9d9845c101",
+        "dest-filename": "grunt-legacy-log-utils-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz#ec29426e803021af59029f87d2f9cd7335a05531",
+        "sha256": "0ed8e9116c91dc65aacf106c7036ba86bd6f1d7a8f591d39ac59df632ffbcabc",
+        "dest-filename": "grunt-legacy-log-0.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz#93324884dbf7e37a9ff7c026dff451d94a9e554b",
+        "sha256": "e59ef69ed551c741fb704d1dc806d18d03ea521a442c54b61ee27946f2c16db4",
+        "dest-filename": "grunt-legacy-util-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-mocha-istanbul/-/grunt-mocha-istanbul-3.0.1.tgz#a33525707b2fa82eb2f7fb3230513f7ca279bf60",
+        "sha256": "a53837f972134f9621d3ce22e5ed0daba1f50a5c1d801102dc73332ab2cbd372",
+        "dest-filename": "grunt-mocha-istanbul-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-mocha-test/-/grunt-mocha-test-0.12.7.tgz#c61cdf32a6762954115fe712b983e3dd8e0c9554",
+        "sha256": "331aab9ec19fd32dbee8a0de63aa7e6f5f57ecc0569ee7d8131a07d425803994",
+        "dest-filename": "grunt-mocha-test-0.12.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt-webpack/-/grunt-webpack-1.0.18.tgz#ff26c43ff35bae6cca707a93c4bcdd950a3ecbb7",
+        "sha256": "0e3c1149b36681bef07bc3cb82c6242eed75d850baf72f06f17c399410383fe4",
+        "dest-filename": "grunt-webpack-1.0.18.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt/-/grunt-0.3.17.tgz#f2e034d200befd5eeb38ba5c41d4ccd7235fd64d",
+        "sha256": "99faaad25b72e2f07a9b45448fc0f284e5e73c7c95607aa9d5acf719adf42648",
+        "dest-filename": "grunt-0.3.17.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/grunt/-/grunt-0.4.5.tgz#56937cd5194324adff6d207631832a9d6ba4e7f0",
+        "sha256": "6d7c28b8e3872cd723f9256013b26cde5f5305af06ed2c1c693995f51a33e5f5",
+        "dest-filename": "grunt-0.4.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gulp-concat-util/-/gulp-concat-util-0.5.5.tgz#c8f0633b4e6e950ff93c475b3c8d3b84be03b7dc",
+        "sha256": "e6e66b30caba8e682a33d9d170ae8f4065eda43bd1a7eaf1becec449a25d400a",
+        "dest-filename": "gulp-concat-util-0.5.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gulp-eslint/-/gulp-eslint-2.1.0.tgz#3fd5fe0b7236651f15b8d4bfb1407c3b74d0136c",
+        "sha256": "a7a0a3e6b870d7ff3569de42e0569daa2def637f7b14027be71cd54a39e9097f",
+        "dest-filename": "gulp-eslint-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gulp-if/-/gulp-if-2.0.2.tgz#a497b7e7573005041caa2bc8b7dda3c80444d629",
+        "sha256": "e308b8defbcd480a49e9552f99e7cf9dca779164fdbeaef836a8765c966a54e7",
+        "dest-filename": "gulp-if-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gulp-load-plugins/-/gulp-load-plugins-1.5.0.tgz#4c419f7e5764d9a0e33061bab9618f81b73d4171",
+        "sha256": "2321c9da6613cbed23105bb55252def330531f8ca32d39e0dec3f19119f5836b",
+        "dest-filename": "gulp-load-plugins-1.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gulp-match/-/gulp-match-1.0.3.tgz#91c7c0d7f29becd6606d57d80a7f8776a87aba8e",
+        "sha256": "321539cf23659f5008f381e506a4e8ab835f558f90cf535b28090566f6994241",
+        "dest-filename": "gulp-match-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f",
+        "sha256": "3c91a37a4f951d9be14879ab0688b0dcaa1f393c6fb0e62c50b57a7db3646155",
+        "dest-filename": "gulp-util-3.0.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gulp/-/gulp-3.9.1.tgz#571ce45928dd40af6514fc4011866016c13845b4",
+        "sha256": "61ca320c45410ffe09aa1b7b67ae48eb22c8b6d219ed9f91931f12d5e381fdb0",
+        "dest-filename": "gulp-3.9.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gulplog/-/gulplog-1.0.0.tgz#e28c4d45d05ecbbed818363ce8f9c5926229ffe5",
+        "sha256": "caf0b0c3f290f7b6cabde9b4468c44e79ecc6c90dbccb10d8c4b47bcc46ef600",
+        "dest-filename": "gulplog-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gzip-js/-/gzip-js-0.3.2.tgz#23117efeeb28cf385248deff0dffad894836d96b",
+        "sha256": "59624527d0e2c6d3f95296f249a9fe21b67d8116d85cad71f3d4a1cb4072bd98",
+        "dest-filename": "gzip-js-0.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gzip-size/-/gzip-size-1.0.0.tgz#66cf8b101047227b95bace6ea1da0c177ed5c22f",
+        "sha256": "bd4ffb6c2ca4c28add9dc78288888d36a1404c7165c0b2e08a3daf4218700a7c",
+        "dest-filename": "gzip-size-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5378,8 +11307,78 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc",
+        "sha256": "b3ca96fefb7fe3d85caa18d0f82c62549d21bce667385ca62f6c2bbeb62a3613",
+        "dest-filename": "handlebars-4.0.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482",
+        "sha512": "df23de709a091caff873a699852bf13b21b8bc9283b21577e951e9d225420d587ba3dc36bf08b73529cbd8c30f8f761d76ea9a05cbbb7066e080940cd1bafdc4",
+        "dest-filename": "handlebars-4.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e",
+        "sha256": "8ff4058be48bb686d115490fcfeee71c9bbec44e994f962bc0deb195f71016f8",
+        "dest-filename": "har-schema-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92",
+        "sha256": "2e7b84af0567ad7c6a5ddcb5f4c1bcc2bd29d4b089d734f628ac08517081be26",
+        "dest-filename": "har-schema-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-validator/-/har-validator-1.8.0.tgz#d83842b0eb4c435960aeb108a067a3aa94c0eeb2",
+        "sha256": "609625d76bbbc2f69775aa0ca79ee8a89235a9dde2cf18671a297dd40ff8a494",
+        "dest-filename": "har-validator-1.8.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d",
+        "sha256": "3b7af5b6d680153c83238e8d15829a8b1de34f5b249e0324d1bb7eea8793161f",
+        "dest-filename": "har-validator-2.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a",
+        "sha256": "b102d4b47fc28822809210e6035870d580daccb86f50f4130ad1de61a1978561",
+        "dest-filename": "har-validator-4.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd",
+        "sha256": "c7e53308bae7ddb691ac13f951eb2028f857909a71529cd6977d9b9c5b3a0c3f",
+        "dest-filename": "har-validator-5.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd",
+        "sha512": "9e64f64f49658dbc5d4197eca6c9e8f6182b1b7522afa2ace5a7e2b26eb6a68c6a04ceac0e7304b8f9b34eaf17374384c2a28b2dd8758d0237ab213ae8dcdbdf",
+        "dest-filename": "har-validator-5.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91",
         "sha1": "34f5049ce1ecdf2b0649af3ef24e45ed35416d91",
+        "dest-filename": "has-ansi-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91",
+        "sha256": "e30265eb491e78d3586ea64dea6b61f3d45a28a28d908caf73f04531764344ed",
         "dest-filename": "has-ansi-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -5399,8 +11398,29 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/has-binary/-/has-binary-0.1.7.tgz#68e61eb16210c9545a0a5cce06a873912fe1e68c",
+        "sha256": "659675a5c2d6eb2753ee60a2509d26bb47218c5ce871df822ec5d0487ba31305",
+        "dest-filename": "has-binary-0.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39",
+        "sha256": "c8c81f5ad214a4f329e75bbae22982150aff651da029772b5fd447cb09fa1293",
+        "dest-filename": "has-cors-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa",
         "sha1": "9d9e793165ce017a00f00418c43f942a7b1d11fa",
+        "dest-filename": "has-flag-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa",
+        "sha256": "48b69ec5354f64a225937160b1fc95e5583eb23db08041086d33a04e11ad4ea7",
         "dest-filename": "has-flag-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -5420,9 +11440,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd",
+        "sha256": "ed4b713220dc22ae02d063c210225ee2274a7905c9cd7db041ba6ef511a9e0ea",
+        "dest-filename": "has-flag-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b",
         "sha512": "1329094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
         "dest-filename": "has-flag-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-gulplog/-/has-gulplog-0.1.0.tgz#6414c82913697da51590397dafb12f22967811ce",
+        "sha256": "363b1bc4d68dee430db870138e0d65eb59ab6d9f6058485088510706476afcf4",
+        "dest-filename": "has-gulplog-0.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5490,6 +11524,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9",
+        "sha256": "d061dd9f29aa7e063efe6bae9906e8111a8e2b9b69876cf4e9e2337b7335ecac",
+        "dest-filename": "has-unicode-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f",
         "sha1": "7b1f58bada62ca827ec0a2078025654845995e1f",
         "dest-filename": "has-value-0.3.1.tgz",
@@ -5518,6 +11559,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/has-yarn/-/has-yarn-2.1.0.tgz#137e11354a7b5bf11aa5cb649cf0c6f3ff2b2e77",
+        "sha512": "52a051aa2e23bbb4fe4ea18d76a00ed0f692546b0318950142f93d79458d191635085183cd884b5a833b25011e9a796f55cbff60499cdb0356f010b6e049d4b3",
+        "dest-filename": "has-yarn-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28",
         "sha1": "8461733f538b0837c9361e39a9ab9e9704dc2f28",
         "dest-filename": "has-1.0.1.tgz",
@@ -5532,6 +11580,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/hasha/-/hasha-2.2.0.tgz#78d7cbfc1e6d66303fe79837365984517b2f6ee1",
+        "sha256": "e4b3742c85edf22c05bace8d2430c496d4b6c38c8a75a8d3924a880d0d8a9ec8",
+        "dest-filename": "hasha-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hasha/-/hasha-3.0.0.tgz#52a32fab8569d41ca69a61ff1a214f8eb7c8bd39",
+        "sha1": "52a32fab8569d41ca69a61ff1a214f8eb7c8bd39",
+        "dest-filename": "hasha-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hasha/-/hasha-5.1.0.tgz#dd05ccdfcfe7dab626247ce2a58efe461922f4ca",
+        "sha512": "3853c35a6ccf37597b6ad395d5380156636d071688cac4e82ba55ef432bebd3ea962e925c3f9cf353f8725b662d0a0dc23abd607ef6d82f679603edf03709770",
+        "dest-filename": "hasha-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c",
         "sha512": "bd4a6d2954e920985c7332816e09d2f91b5cb98301f3ea0dccf2b6fc7a7785a9f3f099a90137669a02e049a69d5511240e6f9eda0887c18dd9464ca34880c314",
         "dest-filename": "hasown-2.0.0.tgz",
@@ -5539,9 +11608,86 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/hawk/-/hawk-2.3.1.tgz#1e731ce39447fa1d0f6d707f7bceebec0fd1ec1f",
+        "sha256": "fcc9974a9160a45181576f3ba9856483a06e69e0f49991cec02c40f880401b01",
+        "dest-filename": "hawk-2.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4",
+        "sha256": "25a9c9d9755c48a1b2a9c69ee5d678796584d0f4464610277136d10098b1b283",
+        "dest-filename": "hawk-3.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038",
+        "sha256": "60b3bbf0a5f777a522ccc18cbbe8328f99eef3bf070497c2c13986605970a3d4",
+        "dest-filename": "hawk-6.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd",
+        "sha256": "a5caab6aef32441afbfa10aae3969b9737e7b45cd84450e90b8728c27278c480",
+        "dest-filename": "he-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f",
         "sha512": "17fd439d418fa29391662d278be0afac28074391721001d12d2029b9858c9ab6d2c28376327ffb93e1a5dfc8099d1ef2c83664e962d7c221a877524e58d0ca1b",
         "dest-filename": "he-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed",
+        "sha256": "b203a87561b58b0c712cf1df4a5b362d3709b851c5e6cc4bfa7c020bd372672d",
+        "dest-filename": "hoek-2.16.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb",
+        "sha256": "85ecf9a3eccbd7a23cb07aa34f190349b225920d7950a282da6ab343e4d46c63",
+        "dest-filename": "hoek-4.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8",
+        "sha256": "2e07d6ef4e1d16bb49c473ea64b72ec1b5437dcd7e9ea418a6b0d018c2369117",
+        "dest-filename": "home-or-tmp-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc",
+        "sha256": "fd654fb1e48b6d489ac3940583e8d5cc7b8ad23413e851198a74925f3dcb8b52",
+        "dest-filename": "homedir-polyfill-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hooker/-/hooker-0.2.3.tgz#b834f723cc4a242aa65963459df6d984c5d3d959",
+        "sha256": "1c8955d9b72d19fb404c5b9ec68cbee20dafc9c93dafe2a2e332218df2875849",
+        "dest-filename": "hooker-0.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c",
+        "sha256": "6147b743df5b0396ff5fde32fb088bc02b292c43412b2215e0db9e71a98b9e51",
+        "dest-filename": "hosted-git-info-2.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c",
+        "sha512": "92cb2369bf02bdd5df71731755cbec5ee9b81f076af571ad443dd3b5e304bc46ead0b5f288d42be80a6ba8aa9f79a0d7cdeed2c56bd1c5da7013a92eee290b92",
+        "dest-filename": "hosted-git-info-2.8.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5556,6 +11702,13 @@
         "url": "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224",
         "sha512": "9320ae10e5a326a66e0db447ccbf15f77373421c0807bd681564b2cd5a3e28f648fa99d03cfc6e71d92b399be42d19eb7f9511b1033e209d3d0f0dbd71100b20",
         "dest-filename": "hosted-git-info-4.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3",
+        "sha512": "0f925b38c04847f4d5664b9b1d3f8ec93dbbd3942fa20516e08067ea71ddef9e8ec2279217d6836058f876fe871c454661b1da2c44dadd6820658596332cb765",
+        "dest-filename": "html-encoding-sniffer-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5609,9 +11762,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz#495704773277eeef6e43f9ab2c2c7d259dda25c5",
+        "sha512": "4dc20c1b7a9e54b803af54c47765ef1da4e730fc1841440c2012f2fb9a4b48329815ced422a8f7f70f041b36646b1a0bbff9762bc1da234b7901503e6188147b",
+        "dest-filename": "http-cache-semantics-4.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a",
         "sha512": "7abdbde4328f56c57cda3e64c351a3b7e00303f5d81ec6a397cd9c18d406d9eca83e4be05215fe9c32327a5ce12166dbb173f7f441dc23a979b58b36158a985d",
         "dest-filename": "http-cache-semantics-4.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-errors/-/http-errors-1.3.1.tgz#197e22cdebd4198585e8694ef6786197b91ed942",
+        "sha256": "b70d1d2429b3d20bc5278e6e987d59a07525e82b2608ee9753700e46528cc1f8",
+        "dest-filename": "http-errors-1.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736",
+        "sha256": "84e6c2111b6c8473e22d2ceb3413e86ff8fb3e15350f04965827af521d88f386",
+        "dest-filename": "http-errors-1.6.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5623,9 +11797,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.10.tgz#92c9c1374c35085f75db359ec56cc257cbb93fa4",
+        "sha256": "73eaca79e82028af519b1ad3412ce0da0e4e4fc7d032305176c585c486da333b",
+        "dest-filename": "http-parser-js-0.4.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a",
+        "sha512": "934cdd360a964c603a69e211569bdf5686f87cbe767537da7a1ca583463852f4b24af3aafd8f813b23eb82952b03b1f296abd4f2f2191ac46e5e6b29b245744e",
+        "dest-filename": "http-proxy-agent-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43",
         "sha512": "9f6858f18768444d62eebe8cd30f43230e468193741b6e4ff332c2450f2b8d7b53537bec345048fef58afd421e13a839314533e9abf000f5e62fa172f43ffdd3",
         "dest-filename": "http-proxy-agent-5.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e",
+        "sha512": "4f58240226180d6631dd5e419b2bbb1dc7dcbcbee652b4d688ceb239f6b73c8a6156227f8053dbbe2750faf7aa48e1dc8bf3f105c0da6de50d0b3a4e3832598a",
+        "dest-filename": "http-proxy-agent-7.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz#642e8848851d66f09d4f124912846dbaeb41b833",
+        "sha256": "f36f87d68baa55f5b0e836d2f359b7143f5c75b261396e9a83e204a55ec7a565",
+        "dest-filename": "http-proxy-middleware-0.17.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.16.2.tgz#06dff292952bf64dbe8471fa9df73066d4f37742",
+        "sha256": "4d83acc1515be9cc19e811efba576e9f03b8b3c8c75761456a326efc89e28d64",
+        "dest-filename": "http-proxy-1.16.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-signature/-/http-signature-0.10.1.tgz#4fbdac132559aa8323121e540779c0a012b27e66",
+        "sha256": "3529d9437e34c26aec2436efde67eebfbefbd1851e6c4487b50acdb258754dc3",
+        "dest-filename": "http-signature-0.10.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf",
+        "sha256": "e14761a7b61ac7e7b32582d62fced7438983e65dd800138e33363d3b78041f15",
+        "dest-filename": "http-signature-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1",
+        "sha256": "66be6d6fddeaf39acc4fb1437af28ff6a0401a740c479f183718f649d03205f9",
+        "dest-filename": "http-signature-1.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5637,9 +11867,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82",
+        "sha256": "a7167e8c8727d753078873d48171aaac4b2bb2c7f1427b87ee445c355c97ee93",
+        "dest-filename": "https-browserify-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz#35f7da6c48ce4ddbfa264891ac593ee5ff8671e6",
+        "sha256": "7ef711ceedbec10f251ea774b4e9a08af0cb17e5d24d1c40f65841cd2086396f",
+        "dest-filename": "https-proxy-agent-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b",
+        "sha512": "3a6bdfa10e7758b8ed03d1de60ff5136b58c273cc0cf524669216bd678a38343d547525a0ffc5b26ad667442089711a95e9f5e49efced8b814f432664cf77412",
+        "dest-filename": "https-proxy-agent-2.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2",
+        "sha512": "124626e4170a50689dbb1cd2b77129a64a3e3e2356344a5ae324a4f6f4c2eb00ec4095bdac749af94846349a11629edbcfa1edd5e69121ae90689a8ee6b0856c",
+        "dest-filename": "https-proxy-agent-5.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6",
         "sha512": "7457008e94d0160a0b3330b657053e0bf09b4bbb912f49569b10c84e6aa6ec2fbb17439d9a3eacf65e9a95973a0042d786b9e080cd827964971c639d5f662dc0",
         "dest-filename": "https-proxy-agent-5.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz#8e97b841a029ad8ddc8731f26595bad868cb4168",
+        "sha512": "c25c298a523b61d8d2916690ffba266013139620dc98237c38b8a13ba23d07cea0d3a94cc80a2a8280e95745eaa1a3ce2a3fb40c8740be7b167f20008668a672",
+        "dest-filename": "https-proxy-agent-7.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5658,9 +11923,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/hyperquest/-/hyperquest-2.1.3.tgz#523127d7a343181b40bf324e231d2576edf52633",
+        "sha512": "7d4b833ab078ecfa8d2bf04030e4b5defe355286aa231a922c75fa0806ce0fb39f4fefc60963b5fef3cb7d336eb4e797aefd6292e699df2bb1fb7dd9f6f87eaf",
+        "dest-filename": "hyperquest-2.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz#31065e6ab2c9272154c8b0821151e2c88f1b002a",
         "sha512": "4f5d2abe4c34cf3e309e6e7ad253848343e8bd5a945ee3858611c0922c70f3fb32732ed326deeffd1ae410a1109c0c36be23d226eea202412bc67cd1d20f0fa5",
         "dest-filename": "iconv-corefoundation-1.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.2.11.tgz#1ce60a3a57864a292d1321ff4609ca4bb965adc8",
+        "sha256": "0e08f35cc8354b00569b5b848b9e4221101e73dfa2c436d343ef47053d7dc976",
+        "dest-filename": "iconv-lite-0.2.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2",
+        "sha256": "bd2600d5a21c46ceca92d5c4b9fdf911f201b301cf70280cc3f60543198b559d",
+        "dest-filename": "iconv-lite-0.4.13.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b",
+        "sha256": "904d81b7ddf639ff4c2736e591e74e41ca8a606107c001f456952c0b31cf187e",
+        "dest-filename": "iconv-lite-0.4.19.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5686,9 +11979,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4",
+        "sha256": "a0dd51ee2de6ab8ad452e829ece19bcfc5fdb796502051ec8d533adc9cba1b31",
+        "dest-filename": "ieee754-1.1.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352",
         "sha512": "75ccaa843bd7d42e3a95765c56a0a92be16d31141574830debf0dfe63b36ce8b94b2a1bb23ab05c62b480beeca60adbd29d5ce2c776ef732f8b059e85509ea68",
         "dest-filename": "ieee754-1.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09",
+        "sha1": "48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09",
+        "dest-filename": "ignore-by-default-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37",
+        "sha512": "9bba3ac6e39a4f56aa85e60729ff16e89e69607f39648f70d3bedeaceccb8dedc9b01d6091a7e40211c7635f5daa3ba5808647166df60a9e6e35981c42a7492b",
+        "dest-filename": "ignore-walk-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ignore/-/ignore-3.2.7.tgz#4810ca5f1d8eca5595213a34b94f2eb4ed926bbd",
+        "sha256": "1deba4ba3d55ec764e9fae1fa1e8f62f9ae7159a16451ade951b44e734f383f4",
+        "dest-filename": "ignore-3.2.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc",
+        "sha512": "7321432aba9cfd875c5859e2261cc8e36f80cd2fa0370994cce485711090630c92b81041cbf2a3bb158b67f147107e8ca2ad4d8b330e056c9372ff0ee0e64832",
+        "dest-filename": "ignore-4.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf",
+        "sha512": "3336d449a8644d6d6eec9a4a2a363b2c20117757d4e56dab2ddc6533891d91acae0b06489a392996e17d08cd5a2dec18260b8f0ea7b02da9b5f18e8053af40f0",
+        "dest-filename": "ignore-5.1.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5721,9 +12056,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66",
+        "sha512": "e9ed6ad5c9d63f64570fdfe47929311d2720e74f02757a975a05816844cd872b81173fa451994a6e887e2122be6d4fbe0e66c78a6541acecffcf33ded2c677b1",
+        "dest-filename": "import-fresh-3.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b",
         "sha512": "bde6188506be0f54012b39ef8541f16fc7dac65af0527c6c78301b029e39ec4d302cd8a8d9b3922a78d80e1323f98880abad71acc1a1424f625d593917381033",
         "dest-filename": "import-fresh-3.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43",
+        "sha1": "05698e3d45c88e8d7e9d92cb0584e77f096f3e43",
+        "dest-filename": "import-lazy-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5735,9 +12084,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/import-modules/-/import-modules-1.1.0.tgz#748db79c5cc42bb9701efab424f894e72600e9dc",
+        "sha1": "748db79c5cc42bb9701efab424f894e72600e9dc",
+        "dest-filename": "import-modules-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea",
         "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
         "dest-filename": "imurmurhash-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea",
+        "sha256": "ac23a031966a7371d192e35c7852ab31c772b7d4e468ddd886ad3c014372cb60",
+        "dest-filename": "imurmurhash-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea",
+        "sha512": "2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c",
+        "dest-filename": "imurmurhash-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80",
+        "sha256": "746430e7c7a14001f625531a581cb6a976bc2e19acf3faaaec690d44149baecf",
+        "dest-filename": "indent-string-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289",
+        "sha1": "4a5fd6d27cc332f37e5419a504dbb837105c9289",
+        "dest-filename": "indent-string-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251",
+        "sha512": "11d0c366ee00d8ec882bb2ebff6cc6fb0e6399bba4d435419c4c11110bc1ceca412640846d16bc1b153596085871a1890a745689b8c35e5abbefd5f5ff2e71c2",
+        "dest-filename": "indent-string-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d",
+        "sha256": "9c34ba36afcc7ae8a40bece80885a306ae85b70c7abba786f856b2e501db2817",
+        "dest-filename": "indexof-0.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5749,8 +12147,36 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+        "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b",
+        "dest-filename": "inflight-1.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/inherits/-/inherits-1.0.2.tgz#ca4309dadee6b54cc0b8d247e8d7c7a0975bdc9b",
+        "sha256": "3cca2b1231e5c1ff3e0edb2b1cd6f7efcdec19c2e857000dd2decbd5f30be109",
+        "dest-filename": "inherits-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1",
+        "sha256": "e0d5493f8142aff09125344665a90a8227b9a3ffa4bb8d086d0fb471c00deb29",
+        "dest-filename": "inherits-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de",
         "sha1": "633c2c83e3da42a502f52466022480f4208261de",
+        "dest-filename": "inherits-2.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de",
+        "sha256": "7f5f58e9b54e87e264786e7e84d9e078aaf68c1003de9fa68945101e02356cdf",
         "dest-filename": "inherits-2.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -5763,6 +12189,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e",
+        "sha256": "c0f6ee998b4397f180d806bfd967a567a93642a9e8b4c1abfe8b2a4f4d16fc37",
+        "dest-filename": "ini-1.3.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927",
+        "sha256": "fe8ebd87cc87404eeb3ec89880bc49d83df337f8b95a504366c4674f3646785d",
+        "dest-filename": "ini-1.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927",
+        "sha512": "45963986e20a08c4560d4a999448bbd9ffe599728cbeeb3370c05dba5890de79d66f1f57fd90503bb0e28cc1184bd1211c16f6a9a71150cb42eecbcbc1ed2573",
+        "dest-filename": "ini-1.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84",
         "sha512": "88aa51a573fe0ab3f68f2af1be0d64314a570f24541435aeaf16e7553d6f40fc7e5b3f6e098b0c22a62e4812d5f8f01a646fddee444b29115cf680ccb07fa615",
         "dest-filename": "ini-1.3.7.tgz",
@@ -5770,9 +12217,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c",
+        "sha512": "255ff2ba0576bb35b988c4528990320ed41dfa7c6d5278de2edd1a70d770f7c90a2ebbee455c81f34b6c444384ef2bc65606a5859e913570a61079142812b17b",
+        "dest-filename": "ini-1.3.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ini/-/ini-3.0.1.tgz#c76ec81007875bc44d544ff7a11a55d12294102d",
         "sha512": "8ade07c950144ca05cea6f1ed625d6bd7493767745ec76dd37bd77fa4bcbaf29b14da538014056ac9e2f128a0ff95edf7b19d50f72ca701b218c618f79f48c51",
         "dest-filename": "ini-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/inquirer/-/inquirer-0.11.4.tgz#81e3374e8361beaff2d97016206d359d0b32fa4d",
+        "sha256": "3d3ce11e341f25aae09cd2fc82965fa7c30c69f49befb1c99ba4a5ddf72bd464",
+        "dest-filename": "inquirer-0.11.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e",
+        "sha256": "228d68926fb5c3abdc7bb22e0bc850ca425a1787660775f95ddc3aca150c3c05",
+        "dest-filename": "inquirer-0.12.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.0.tgz#9e2b032dde77da1db5db804758b8fea3a970519a",
+        "sha512": "ad2742ef37a51dd4501645a786c32edbed923b8d66a6fda8176cf2e2d3219a22d691c29b380b3cedf580261557b6d295c21759bf29af9ee33de44c845e0dbfb5",
+        "dest-filename": "inquirer-7.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5791,6 +12266,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/interpret/-/interpret-0.6.6.tgz#fecd7a18e7ce5ca6abfb953e1f86213a49f1625b",
+        "sha256": "4eb237eb7911fa83640cce8ca0cbde2946cee2d9add95244a955742929dd4da2",
+        "dest-filename": "interpret-0.6.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90",
+        "sha256": "2aa54882dc1ba20aba2bbd979d1c9dabf130a4f1a55e38592c069a250b465032",
+        "dest-filename": "interpret-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0",
         "sha1": "820cdd588b868ffb191a809506d6c9c8f212b1b0",
         "dest-filename": "interpret-1.0.4.tgz",
@@ -5798,9 +12287,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/invariant/-/invariant-2.2.3.tgz#1a827dfde7dcbd7c323f0ca826be8fa7c5e9d688",
+        "sha256": "765ae298edac5178139d43a6cc1d393d1740ba900ec3e4de1f02e022d761e4ac",
+        "dest-filename": "invariant-2.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6",
+        "sha256": "68ca08de61805e195cb73d33803b433469bd5c8006166067a4734c9005effa81",
+        "dest-filename": "invariant-2.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6",
+        "sha256": "ad334f834b1876490ce47e220ff1b712e5b678216552abbd005639c14974d29e",
+        "dest-filename": "invert-kv-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a",
+        "sha512": "cc7b50cc6a236574f06531d0aab6be11329de129f7be08bbb819a53e85d5599a98bee2a6b48d25fd56538ea1a6258f71f3c18639a67df86f444bc842e13e17f2",
+        "dest-filename": "ip-address-9.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.6.0.tgz#e3fa357b773da619f26e95f049d055c72796f86b",
+        "sha256": "25607cf8fffb19e29a1d14e067392eba5d7f9ebfe2c220b77b29959b53a48a2b",
+        "dest-filename": "ipaddr.js-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3",
         "sha512": "d0a23feb4ef1a31493a07ec68cdd457d26cba14d3e6ed4e2723b1049642587f859ca437c2a998c7fbb98c0f5b747e6a467a47fc35f199574870585e26143cede",
         "dest-filename": "ipaddr.js-1.9.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.4.0.tgz#2ca9b033651111855412f16be5d77c62a458a766",
+        "sha1": "2ca9b033651111855412f16be5d77c62a458a766",
+        "dest-filename": "irregular-plurals-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-2.0.0.tgz#39d40f05b00f656d0b7fa471230dd3b714af2872",
+        "sha512": "63be730582e4874949f6ac5e1e532343b6d26f2892a8d5bf50e3d60e6cc2edc5ec90bd617a44884e1d4e73a255d17096599f4313c558481ef5c6870b9378261b",
+        "dest-filename": "irregular-plurals-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-absolute/-/is-absolute-0.2.6.tgz#20de69f3db942ef2d87b9c2da36f172235b1b5eb",
+        "sha256": "cb5f14a44cf1d1516e3c2e6d1f6ccc001097153461f43084db9a998ab75ac5ee",
+        "dest-filename": "is-absolute-0.2.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5819,6 +12364,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3",
+        "sha512": "c4f874466b7c344eb9b0dcefc94996808d6dcf798aabbe25180d262fc2d865ca08cca3b30e1e879ab626dddd7c93ad271deac2f00f4a9bc918bbcef37d21672c",
+        "dest-filename": "is-arguments-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe",
         "sha512": "cbe172c91ff0f2f7c846ae1e41c3351188124e79875cfa9a17e220ce0adacad085ab95e1f259650d598066894f26266db592de15220d3d831a109effbd651ad7",
         "dest-filename": "is-array-buffer-3.0.2.tgz",
@@ -5828,6 +12380,13 @@
         "type": "file",
         "url": "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d",
         "sha1": "77c99840527aa8ecb1a8ba697b80645a7a926a9d",
+        "dest-filename": "is-arrayish-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d",
+        "sha256": "848d15d93e447897263a654c114c8e45c340ce7fdc1bc86e7a44a4c44f27e38c",
         "dest-filename": "is-arrayish-0.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -5854,6 +12413,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898",
+        "sha256": "f4ee9040d06b3e4c014d30cc64d802076db0aa5b8e8cffe9768650c59354d417",
+        "dest-filename": "is-binary-path-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09",
         "sha512": "64c11161eb3aa43c9dcae1a276c7bb3ac1f1b5b23b595794128ce047f83baddd31522998365bd9444fcad8c8194e35b2ef6e487de94b79570433dee69ad4465f",
         "dest-filename": "is-binary-path-2.1.0.tgz",
@@ -5864,6 +12430,20 @@
         "url": "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719",
         "sha512": "80361a2872669e3e1a5b1ca3e981f25d5a5d41ac2d54b1d4e5c6fe7b3b4f19ccdfe9c8ee4ddc2f7b964811f817a87e1ee7b027d43d4029ff02677918ad046a60",
         "dest-filename": "is-boolean-object-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc",
+        "sha256": "148f67a8e67a24bfea56469e8d7e2453efea7c60d7b8b8e13c5ca72ae39ff974",
+        "dest-filename": "is-buffer-1.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
+        "sha256": "3d1ad8c0a086873150d3dc69e6c6e628a3729e04e954f90ba6c0f7407272880e",
+        "dest-filename": "is-buffer-1.1.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5882,9 +12462,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe",
+        "sha256": "4420b4ff39f7b135241b0426243d4edbf02d1f6dd32a4fba68c7f68f0e820e8e",
+        "dest-filename": "is-builtin-module-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2",
         "sha1": "86eb75392805ddc33af71c92a0eedf74ee7604b2",
         "dest-filename": "is-callable-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75",
+        "sha512": "af9a7db3126362702b2e339ba63038c6ee44288dc2b8a1e42573214fb9306e95322050f59f93cc02ca0fbd69efb5988dcfb2e39180d166177b16523478c8a310",
+        "dest-filename": "is-callable-1.1.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5910,6 +12504,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c",
+        "sha512": "b3ab5fb1a41a422dc935c8811fab2156a103be11aeb744945ebdf56a0f0f77c0416d55657067d68693e610ea0ce912794c585bca9bdfe72c91c3f5575b52225a",
+        "dest-filename": "is-ci-1.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c",
+        "sha512": "61f253eeb929401d2ea5db1d1cb196aef84125f71fccd35ac180cd232417273d0856219fef93bc1013ca49dbf0dab17e2c60ac5f8159f2d72bddbd7d2dc66ae3",
+        "dest-filename": "is-ci-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867",
         "sha512": "658bc282b79fc2aa10eb24f26146d0bbae07b084d9dcd7ca5f597368461d9130dc7cacf3088ff0b6145160a91d8c72855603625ca00a9bae59a35a64d9ab3f41",
         "dest-filename": "is-ci-3.0.1.tgz",
@@ -5927,6 +12535,13 @@
         "url": "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384",
         "sha512": "847ac88ef66c7ed3acbca4a7d9345897adf3bf1b201342bed2660ca07ea00f8a264792160762b29e2bc141cce8dfec05d5c0a48f3be9b6723d434b0f53aea297",
         "dest-filename": "is-core-module-2.13.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211",
+        "sha512": "49d34252cdbce21af8d2115314fea5d087d9fd14ab317177aa0a111dddffefdba7513beb14efc9a17c241a6fb927f39edc4fdbe46b271b7df4b94360469bb53c",
+        "dest-filename": "is-core-module-2.8.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5994,8 +12609,43 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.2.tgz#2c132383f39199f8edc268ca01b9b007d205cc4d",
+        "sha256": "f76ce458f80d95626dafb6a0b901ba92670834aabde420c094f710aee564ed51",
+        "dest-filename": "is-dotfile-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1",
+        "sha256": "91c66568d2de605796160ab63b4e856f426ce7a9ef650a34de39ae572dec678e",
+        "dest-filename": "is-dotfile-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534",
+        "sha256": "14c38bccdd723796b71ee84f9c05528bf0e955f4caa262f8f7ad6af570ff98e9",
+        "dest-filename": "is-equal-shallow-0.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-error/-/is-error-2.2.2.tgz#c10ade187b3c93510c5470a5567833ee25649843",
+        "sha512": "20e42ab6cfda1d66e28ac6390ee3c943481c6ef68b1426bb7c16bdc682dfc4166f43e648fd987dc6823b1a4f86eb837415d2b801b89bcad1e1b76b568292562e",
+        "dest-filename": "is-error-2.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89",
         "sha1": "62b110e289a471418e3ec36a617d472e301dfc89",
+        "dest-filename": "is-extendable-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89",
+        "sha256": "eb342b3dbc0586b3b0fecbb75f1758ee70f8c340c3f54ca5e0306d06030fc989",
         "dest-filename": "is-extendable-0.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -6008,8 +12658,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0",
+        "sha256": "473e563bc34d59eac27dfaacaac6c154e3fb4596b2e44e04157ebef4765c599d",
+        "dest-filename": "is-extglob-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2",
         "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
+        "dest-filename": "is-extglob-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2",
+        "sha256": "8c5d4286146ad62fc1096981700ce1c22a167708926fca01f9ca74f9bb50bc19",
         "dest-filename": "is-extglob-2.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -6022,6 +12686,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa",
+        "sha256": "41316f8afebe7d7dbc13338f5496c1edeaa4ba52008a9f6afbf8bcad6fa879d3",
+        "dest-filename": "is-finite-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb",
         "sha1": "ef9e31386f031a7f0d643af82fde50c457ef00cb",
         "dest-filename": "is-fullwidth-code-point-1.0.0.tgz",
@@ -6029,8 +12700,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb",
+        "sha256": "77ed656a130d47cc804c1d8fdae8f0fc4ad355625552fcde37703ca5f8b3686c",
+        "dest-filename": "is-fullwidth-code-point-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f",
         "sha1": "a3b30a5c4f199183167aaab93beefae3ddfb654f",
+        "dest-filename": "is-fullwidth-code-point-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f",
+        "sha256": "4cd0d0edee6bf328b641662054d69e9faf91262beee6f158eb974220ceaba06b",
         "dest-filename": "is-fullwidth-code-point-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -6057,6 +12742,34 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863",
+        "sha256": "e71c2b7aa1b2df462766ed7c7faf786be5dd29945098f17315b1b9f2026790ad",
+        "dest-filename": "is-glob-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a",
+        "sha1": "7ba5ae24217804ac70707b96922567486cc3e84a",
+        "dest-filename": "is-glob-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a",
+        "sha256": "fdd426d093d5a70ce42f94a5e11383a31e8780362b57a5b0ff0a9d4235c94614",
+        "dest-filename": "is-glob-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc",
+        "sha512": "e46d2d2ad05314898ea839cb076846e81a76a9c28415dba8e2d66ef4c4ff1fa350bff821872df4a39e6e7da7f127f2dd1fbf4b2ecd8a7eb9fce532cac80ec152",
+        "dest-filename": "is-glob-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
         "sha512": "c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a",
         "dest-filename": "is-glob-4.0.3.tgz",
@@ -6071,9 +12784,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80",
+        "sha1": "0dfd98f5a9111716dd535dda6492f67bf3d25a80",
+        "dest-filename": "is-installed-globally-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5",
+        "sha1": "3d9877899e6a53efc0160504cde15f82e6f061d5",
+        "dest-filename": "is-lambda-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5",
+        "sha512": "cfb08c14636b10dab988507d06aa3ae1793a63db20f9ea6ad66c8871d1da1a76cc4d83b1bf3b04b5d62a414ca507b2f17e4be0aeb8cfdf64fa6307228a8f5421",
+        "dest-filename": "is-lambda-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127",
         "sha512": "70e645410a334e16b57f83312c5ce580a60f4f28f6ea989c7594f1f3685b73f5dfe0afed64e39748290cbd4e292a2a115c60cb2519f418ced4a5eee447bdb5ca",
         "dest-filename": "is-map-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824",
+        "sha256": "5ffa08e4ea7c36daf2ab805d31f678457823c347262856f9d819b5d99ee53e24",
+        "dest-filename": "is-my-ip-valid-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693",
+        "sha256": "b7fb9f06d965e71c54758db493e2706f94c020364969d3f3f15f5effc638e55c",
+        "dest-filename": "is-my-json-valid-2.16.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz#6b2103a288e94ef3de5cf15d29dd85fc4b78d65c",
+        "sha256": "dd131be0a73be818faf69066230c9f85156f91d3ce156986e62019e939dddbeb",
+        "dest-filename": "is-my-json-valid-2.17.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6085,6 +12840,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4",
+        "sha1": "f2fb63a65e4905b406c86072765a1a4dc793b9f4",
+        "dest-filename": "is-npm-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-npm/-/is-npm-3.0.0.tgz#ec9147bfb629c43f494cf67936a961edec7e8053",
+        "sha512": "c2c8a00ebd4a92c721a76a290b81b7c80eabf4481503a3634695b3222f5ac57a9e21a0004cf449738b8bba35dedcd77db8ef0aa03c80e0c0fa69949e5d300384",
+        "dest-filename": "is-npm-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.6.tgz#6a7aaf838c7f0686a50b4553f7e54a96494e89f0",
         "sha512": "6c454eaa245cbe8df33b5f86da554ccbe8249049bd621edc0cc46eb0a2aee5924a3d46122702024ca66b34a1c0d846d23f44eed3ee81fde9ac60d1d9ca7e8af2",
         "dest-filename": "is-number-object-1.0.6.tgz",
@@ -6092,8 +12861,29 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-number/-/is-number-0.1.1.tgz#69a7af116963d47206ec9bd9b48a14216f1e3806",
+        "sha256": "7696094470a7d6ceaadfd355dd75fde5a37557fe2e44f7b40a4dea63db33fb08",
+        "dest-filename": "is-number-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f",
+        "sha256": "22a39e192bea7e2300aa808aa1d47b2d24ff8071cbea69864b389ab5c7a7671f",
+        "dest-filename": "is-number-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195",
         "sha1": "24fd6201a4782cf50561c810276afc7d12d71195",
+        "dest-filename": "is-number-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195",
+        "sha256": "c4ad5fbaebeb2e367b73366a71016c31d7f0554a955f0017127e749f4b5c37a7",
         "dest-filename": "is-number-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -6113,9 +12903,86 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f",
+        "sha1": "3e4729ac1f5fde025cd7d83a896dab9f4f67db0f",
+        "dest-filename": "is-obj-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982",
+        "sha512": "76ba831b771b733c7110946839770e8ed769d49fe5ca9d66367d316b39d1b3cfa6b8186041cae76eca68c795f97cec341e73276df0f3be710c12da83109128f3",
+        "dest-filename": "is-obj-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-observable/-/is-observable-2.0.0.tgz#327af1e8cdea9cd717f95911b87c5d34301721a6",
+        "sha512": "7e1059bf77852946f21d7675a07ba3768dad67e08d6dda5dcf39443600866540bc91ea06c547b0da36052d8714078aa8ecb0c3d37a3828ad759bf4180fb9048e",
+        "dest-filename": "is-observable-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24",
         "sha512": "3938a2c60a59013d4ce0d1e04b9220b85a7f573d9523753b1a8878fc703569db70c8bb5206bc5895c498921a40134eece1f284723ac5c72bed401343e2f150c9",
         "dest-filename": "is-odd-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d",
+        "sha256": "88720c3785a799a3934131ed544cddb0689eb0896b160b12aba5ab9a20f1ca27",
+        "dest-filename": "is-path-cwd-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb",
+        "sha512": "c3de366d372287c7dd24f266407173912efa3443fc2b3cef9b0f76717b1acdbf229edc0ba8f89b3cf7577f800d74a577ad832eb90606216b6fcfd262941dcd15",
+        "dest-filename": "is-path-cwd-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz#6477582b8214d602346094567003be8a9eac04dc",
+        "sha256": "00b7b6f74f9dbd864da7c25b5cf11e1afc154b2836d54e32f529cfc4513dffaa",
+        "dest-filename": "is-path-in-cwd-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz#bfe2dca26c69f397265a4009963602935a053acb",
+        "sha512": "acda1c5c7822a4efabbe73fa764df3236d11a4eb6b00cfe4cdb076e7c530e415abdd3a578bceb5cb38e8d7a0e7e21528c74ee2c3903278c2c75acba3923cef45",
+        "dest-filename": "is-path-in-cwd-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.0.tgz#fc06e5a1683fbda13de667aff717bbc10a48f37f",
+        "sha256": "656edd1d881a5aee839e913a4c3ead8db3e918653c49c920d12d682496912c6a",
+        "dest-filename": "is-path-inside-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036",
+        "sha1": "8ef5b7de50437a3fdca6b4e865ef7aa55cb48036",
+        "dest-filename": "is-path-inside-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036",
+        "sha256": "0ea771d8e4ea66e6df26bdde2938af36576f2e5ac377cfb938d7bcacf617db75",
+        "dest-filename": "is-path-inside-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-2.1.0.tgz#7c9810587d659a40d27bcdb4d5616eab059494b2",
+        "sha512": "c22ca14f37c35acbf0016e77381585e73baf68e1a567a3f063101b3d50e1a66fa0334f712901a306affcb98375d9a0ef3319c09eadddc53ca84a844d9a0e5816",
+        "dest-filename": "is-path-inside-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6127,6 +12994,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e",
+        "sha1": "71a50c8429dfca773c92a390a4a03b39fcd51d3e",
+        "dest-filename": "is-plain-obj-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677",
         "sha512": "8793e98179168ad737f0104c61ac1360c5891c564956706ab85139ef11698c1f29245885ea067e6d4f96c88ff2a9788547999d2ec81835a3def2e6a8e94bfd3a",
         "dest-filename": "is-plain-object-2.0.4.tgz",
@@ -6134,9 +13008,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.0.tgz#47bfc5da1b5d50d64110806c199359482e75a928",
+        "sha512": "b59229a1f47e3f4e64f00a1ca7b508ff65136bd95325279b097a4516847d6a26e9a240e3fee5c1b09f25b94bb4b535582a4314e9444352e39f259ee4a1ec17be",
+        "dest-filename": "is-plain-object-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4",
+        "sha256": "838c5047b9fcc7be55608f41a5ca56615ea900108f1f483f60fb1f66d2e4df07",
+        "dest-filename": "is-posix-bracket-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5",
         "sha512": "6c261e440dab5626ca65dfacdbadb98069c617fb7b0d2a83b3874fec2acb0359bb8ca5b3ea9a6cd0ba582c937c43ae07b663ca27586b3779f33cd28510a39489",
         "dest-filename": "is-potential-custom-element-name-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575",
+        "sha256": "cd2ec246afcd04c30e433ad494cd108915f1686983aff94ddbc845ec1cd7a7e8",
+        "dest-filename": "is-primitive-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa",
+        "sha1": "79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa",
+        "dest-filename": "is-promise-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84",
+        "sha256": "34b46bc9b66b67a542928517b96b2d84e4ca9baf5b58826e221eeb6e26020870",
+        "dest-filename": "is-property-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24",
+        "sha1": "1d03dded53bd8db0f30c26e4f95d36fc7c87dc24",
+        "dest-filename": "is-redirect-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6151,6 +13067,34 @@
         "url": "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958",
         "sha512": "92f45dc43b31663873517d3b6672f27734b54d4fd32654d41c763860b2fcededfba14038f437e42ea832f958c5a1ca30cb6f5c2af7128aefa422fef6f234d356",
         "dest-filename": "is-regex-1.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-relative/-/is-relative-0.2.1.tgz#d27f4c7d516d175fb610db84bbeef23c3bc97aa5",
+        "sha256": "3f54807dec2f23c02d313adca8ab0a22c5a155b7d1ee799ee782c89f13f30bb2",
+        "dest-filename": "is-relative-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62",
+        "sha256": "19fad36b0e3a57e2cdec624172b4bbdb286be84df0feb8ee27318ccbb9ad73bf",
+        "dest-filename": "is-resolvable-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88",
+        "sha256": "072de53a3829b28758b46f8555847bc866e3ae5690002797d68dc50fb066ff87",
+        "dest-filename": "is-resolvable-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4",
+        "sha512": "4546d478ac2f9b75c6d9561a9a124bd71164b608ef3f32f41eaf02fbacab588b300f2dc12171aa0b187191cdf437d8ea2b7d75815535dfb2bc122e79ff354946",
+        "dest-filename": "is-retry-allowed-1.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6178,6 +13122,13 @@
         "type": "file",
         "url": "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44",
         "sha1": "12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44",
+        "dest-filename": "is-stream-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44",
+        "sha256": "9dd833c75e16693641970a1c2c0aa6dd5f5da392424e23494ed9ba20311c381f",
         "dest-filename": "is-stream-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -6225,6 +13176,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38",
+        "sha512": "1d2f1b67da31eb4c8224b1fdb27069230bfda5850091cb8b852035a1eae8d54079cbd6a2429440f32d9ec7de3900eb4264bd652437889371b92ed86cc08e3a2f",
+        "dest-filename": "is-symbol-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937",
         "sha512": "3b08a385a45282abe19bfd19740717359b7d95874a1697110d3e542d4b985cfa13efde1434e754fa0a53e91ce8edbe15d87525fe8a7a1aa63cf78019c2ff5f69",
         "dest-filename": "is-symbol-1.0.3.tgz",
@@ -6242,6 +13200,48 @@
         "url": "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.12.tgz#d0bab5686ef4a76f7a73097b95470ab199c57d4a",
         "sha512": "675e1317624d1bc2ecb39fc732ab74fff4fd25e1d7b6d5f2e691ff0c1538be2f7ca333b66edc73abd3306036589cac14f2746ccfff865455510eadc3915b923e",
         "dest-filename": "is-typed-array-1.1.12.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a",
+        "sha1": "e479c80858df0c1b11ddda6940f96011fcda4a9a",
+        "dest-filename": "is-typedarray-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a",
+        "sha256": "0d5c97ab733832aa006929b933decd71af74d92dcc857637840cb47496c83845",
+        "dest-filename": "is-typedarray-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-unc-path/-/is-unc-path-0.1.2.tgz#6ab053a72573c10250ff416a3814c35178af39b9",
+        "sha256": "c85ccbb943e916f9c8555ef4d06925a83b27fb1b0037794bf9a3bd22a195619d",
+        "dest-filename": "is-unc-path-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52",
+        "sha512": "213bc68a6f058518987b8210e6e1d2923ee955a3c3ac24e435ddf2ab7715ee26407097474d430f3041dca923b2f7167da857a7402be2fb6c231fd6b59d7a87c3",
+        "dest-filename": "is-url-1.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72",
+        "sha1": "4b0da1442104d1b336340e80797e865cf39f7d72",
+        "dest-filename": "is-utf8-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72",
+        "sha256": "842b40f45caefe6d44673cb105ca8f852fa57fce75ee2db7923e414d43d65674",
+        "dest-filename": "is-utf8-0.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6267,6 +13267,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c",
+        "sha256": "57cc682480be26122f522194d7105410cad7c20cfcf0b32e6e32ad27987bbe31",
+        "dest-filename": "is-windows-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9",
         "sha1": "310db70f742d259a16a369202b51af84233310d9",
         "dest-filename": "is-windows-1.0.1.tgz",
@@ -6288,8 +13295,36 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232",
+        "sha512": "56349e6ff9479a4a3277caf23d520abce0a7e03d64a0ca98fafab28e351f737c722ad3f87583b1338e2c66b9ea412cd276cdf1c8ead44cb4c2f4b5425602e783",
+        "dest-filename": "is-yarn-global-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf",
+        "sha1": "8a18acfca9a8f4177e09abfc6038939b05d1eedf",
+        "dest-filename": "isarray-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf",
+        "sha256": "3e8444020696800aed92a09d4c52602adc76140a39b6c8e94fe7c89cf70a9f0a",
+        "dest-filename": "isarray-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11",
         "sha1": "bb935d48582cba168c06834957a54a3e07124f11",
+        "dest-filename": "isarray-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11",
+        "sha256": "e23c76f14f5222e07e39d89858b61e8e33f96956de9e0df3659cbdf8db950c87",
         "dest-filename": "isarray-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -6305,6 +13340,13 @@
         "url": "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723",
         "sha512": "c478e10ebddc3412b40737542523d7667b50531fe6c0c4b9470e00ee53c9f745c600ee8848ffde3c336ea34be1a8e654f940f9268a1dc02000a1941ddc57802b",
         "dest-filename": "isarray-2.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.2.tgz#4a3e974ec0cba9004d3fc6cde7209ea69368a621",
+        "sha256": "204e50f422b270437878281339db3c83e5b38b67bbddeae4c36f1c218ee26da7",
+        "dest-filename": "isbinaryfile-3.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6330,8 +13372,36 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
+        "sha256": "47cfe872e088e28c53b736fef305324b57cc1cfc9f72a9b0f769f92731cb8359",
+        "dest-filename": "isexe-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
+        "sha512": "447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+        "dest-filename": "isexe-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d",
+        "sha512": "2e907fe7807eff627986a43b8a66477dd537d4e96042ac7b6627159649bd93383dff0f0628b11c15f265fedec30840ee78ec81003eb3082c133ba173b3436811",
+        "dest-filename": "isexe-3.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89",
         "sha1": "f065561096a3f1da2ef46272f815c840d87e0c89",
+        "dest-filename": "isobject-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89",
+        "sha256": "626c7518d53309aa1e0ef7cdb5f27bbc4fa80b3158074140a2157e26af0eae91",
         "dest-filename": "isobject-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -6344,6 +13414,34 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0",
+        "sha512": "4bfd9f179c07f12240fe49b0afa1d884afd123f3a4843f3893c9ed6a5a348898d98a482ad5716f47933c34f4f5c7917b7c1c021b7a877e7cde3ff561fd9c4250",
+        "dest-filename": "isobject-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a",
+        "sha256": "79ae4378a2a3446fb72177b57138c1382565ad75e50baba2909731ebb5c90b44",
+        "dest-filename": "isstream-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz#4113c8ff6b7a40a1ef7350b01016331f63afde14",
+        "sha256": "9716fe76039737274a5d24f01f31fb2c2df5fa810df81c1f0bc72fec151e2d54",
+        "dest-filename": "istanbul-lib-coverage-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49",
+        "sha512": "f1a5f39ee10f089bc69cc4917ede2e743443b5bd55de991090c308e4b23ee87b90cf9a10e09d94167d47f36ada037a89b7238b924c15a880814248e71ad9f998",
+        "dest-filename": "istanbul-lib-coverage-2.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec",
         "sha512": "522508ab1320443113e9e47ea391db7d160fd65d21aa458eb3bbcdc42fe6820bad08c508856326f200076fcb479727c3dff97aae580d03970a743cc401fea112",
         "dest-filename": "istanbul-lib-coverage-3.0.0.tgz",
@@ -6351,9 +13449,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz#189e7909d0a39fa5a3dfad5b03f71947770191d3",
+        "sha512": "78e789e411c298762f40aef1b7d1a4747bb3b82192d58ea0f46be7c77626df77f3fc7a4b458c624b4c0736bfa6fcc042f01eb8ed7b7ad3cbc20c4be197d73a33",
+        "dest-filename": "istanbul-lib-coverage-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756",
         "sha512": "3bc769b05fabd1657ff0c35129f9e6aed09686e2a3c6bab6c3e8e9cc12f95192938b62de5569d63a6591c4595eb0938d99cfb02c01af29064439a9e4a342c54e",
         "dest-filename": "istanbul-lib-coverage-3.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b",
+        "sha256": "00c34b56cdef4c818bd85877112b8ba9cc76005cf16d9754362840b2e72be8ba",
+        "dest-filename": "istanbul-lib-hook-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz#c95695f383d4f8f60df1f04252a9550e15b5b133",
+        "sha512": "beb473b54f55451143c82f9a9257cba1e5f235d4df81ad84237b9d0c69f8719e9fa525e91cb57d5fa087bdfa0c08fb60820f33bc30e60b86fdc5fbb4cfafe594",
+        "dest-filename": "istanbul-lib-hook-2.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz#84905bf47f7e0b401d6b840da7bad67086b4aab6",
+        "sha256": "6ac2325e74171e0927bae2a12b94c8c89d552f0b07875c27920dd3ca391bdf5d",
+        "dest-filename": "istanbul-lib-instrument-1.9.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz#a5f63d91f0bbc0c3e479ef4c5de027335ec6d630",
+        "sha512": "e679c8378be8e714191dd5e7a3f6035c9d06f88ddd026e178337d25533cb4298ffcc0576755e89bb2d3269fd74ff3ac9389787a0dddfada15ef9746ad9b15564",
+        "dest-filename": "istanbul-lib-instrument-3.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz#7b49198b657b27a730b8e9cb601f1e1bff24c59a",
+        "sha512": "733c14cf9db9ae43850c9c5f28aea661f22cf7304a20bcab650c63cf700186341785b845b126e8d475bf04572c0e77c9609580ead851479fd3518daab395bdf5",
+        "dest-filename": "istanbul-lib-instrument-5.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6372,6 +13512,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz#2df12188c0fa77990c0d2176d2d0ba3394188259",
+        "sha256": "093842555565cfa23352ddd1c2e077d8c9b4a71a37af9566d3dfc4abbeddd7f5",
+        "dest-filename": "istanbul-lib-report-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz#5a8113cd746d43c4889eba36ab10e7d50c9b4f33",
+        "sha512": "7c705e1b9ef71088a18406e5c20c6b49e9e9d036f2ead24c151fc7be57ab06cac24c3e5b914ba836d9f7815876f59092f36e1c18604f9fb4a0edc364fb6c54b1",
+        "dest-filename": "istanbul-lib-report-2.0.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#7518fe52ea44de372f460a76b5ecda9ffb73d8a6",
         "sha512": "c1c762fae00acdf8864f669b3e9299d21494d6b1908d44272efb58e4ca50ed00936a10f754e0e172ee3071f63562d9066830f9caec9d38b20d5ec7dbbacf513b",
         "dest-filename": "istanbul-lib-report-3.0.0.tgz",
@@ -6379,9 +13533,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6",
+        "sha256": "2a937f6012cccb2c7c4bc2f12d78b52c36c032fa0205542b3d7d56893c22dd15",
+        "dest-filename": "istanbul-lib-source-maps-1.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz#284997c48211752ec486253da97e3879defba8c8",
+        "sha512": "478ecacccb43247e97e3f616f574f1fa3acb9d99ec716e15a4d37ed4f5624984de8cb54f5afee8a2ff83b9ff184123f255152fb9e42acf54dcb02ea6a286535f",
+        "dest-filename": "istanbul-lib-source-maps-3.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz#75743ce6d96bb86dc7ee4352cf6366a23f0b1ad9",
         "sha512": "735e8ba4546447cbd05f21d9e672e9637e4966dce3d4f418d626667ac51b7f51591db22ea5c59f8e0397058f581e42c443aa6ecf5bb80e08faaa653f0e2b2b66",
         "dest-filename": "istanbul-lib-source-maps-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.4.tgz#5ccba5e22b7b5a5d91d5e0a830f89be334bf97bd",
+        "sha256": "b4170c9a6ff558e0bcd369791fa26a3f70eba791ddae98f2fe947964f6080181",
+        "dest-filename": "istanbul-reports-1.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.6.tgz#7b4f2660d82b29303a8fe6091f8ca4bf058da1af",
+        "sha512": "48a8b8ae73322c129ed09cb6b94771dbc87ca06ee98763cfb903ef200877d5df828be952884bb80be877a013ee27dfa63ca84ec96d0cf2063853934cd562de5c",
+        "dest-filename": "istanbul-reports-2.2.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.4.tgz#1b6f068ecbc6c331040aab5741991273e609e40c",
+        "sha512": "af5fc3b2137829213bc561249d92cb2cb0e7e422726d5de7c34d554e4a7a0f98f32ee10b95c6ee75f8ff792405beb2ac26e4d50869de3ceee1a3cd8dc3dcf37f",
+        "dest-filename": "istanbul-reports-3.1.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6400,9 +13589,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.1.2.tgz#eada67ea949c6b71de50f1b09c92a961897b90ab",
+        "sha512": "91698b2a7dad46d7d8305fc16a48a155547304a3b1cf88093222f6463f755a7001e533d9ba6487f7d47f61fd6a135bb8b918a6bc24897e6ea19f1a215de1178d",
+        "dest-filename": "jackspeak-3.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.0.tgz#a75763ff36ad778ede6a156d8ee8b124de445b4a",
+        "sha512": "255621427379f4b54f14211c55ad82dc2ac429869cbe345fa88425fa1f288bdd5a2d841559161bc633dcbf56d4894cbf90b99068036b61f34c08ede4b840c77f",
+        "dest-filename": "jackspeak-3.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jade/-/jade-0.26.3.tgz#8f10d7977d8d79f2f6ff862a81b0513ccb25686c",
+        "sha256": "ea314287eb192b6987f7bb9d7010bf2c35ff6288f125fa00796ad93bdba14d0b",
+        "dest-filename": "jade-0.26.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jake/-/jake-10.8.7.tgz#63a32821177940c33f356e0ba44ff9d34e1c7d8f",
         "sha512": "6438b768ff9f1bf2dc87207350cf34e158dd767c1f49fb1d798930b7c35c6ca46fa38ac592386ce39ea22c59f79366545af35ee22e3c5800836f36bc7e1ab6fb",
         "dest-filename": "jake-10.8.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.5.0.tgz#61e8d0a7394c1ee1cec4c2893e206e62b1566066",
+        "sha512": "04658a23b13a391a9b179bac175a00e1fb5b92155956b5ebf23074fc1ad4e93027de47ce5705f6671ea92885d8bad27ea8d1234fc0dafe019a9346a3c9afd2b4",
+        "dest-filename": "jest-changed-files-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6414,6 +13631,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.5.0.tgz#fcff8829ceb2c8ef4b4532ace7734d156c6664b9",
+        "sha512": "f8d3ddd4ec6900760a8db5bc7602f486e1609ad65129250a79efd4b518192447c0c42780d7677bb29d1ca21e441830695b87c29353dc89aff6746fa3e8142f77",
+        "dest-filename": "jest-circus-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-circus/-/jest-circus-29.7.0.tgz#b6817a45fcc835d8b16d5962d0c026473ee3668a",
         "sha512": "dc4d6708c822a5c4e40a8705c0cf745d741a6fd6d2f8632c8dda663eb95e95ac700fddc077c8951235ffbef1cf74b3e715ff8be34bbee7e8aeb51740d4df66cb",
         "dest-filename": "jest-circus-29.7.0.tgz",
@@ -6421,9 +13645,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.5.0.tgz#06557ad22818740fb28481089a574ba107a8b369",
+        "sha512": "f4036cefd1a8cf550b2ad1bb1c39bf17fff813af6ff0414e2d74481e6782fde2b5c5351e406954e973f4670b2ddfceac29a281e0eeb4aa1598fd4693052d8c2c",
+        "dest-filename": "jest-cli-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.7.0.tgz#5592c940798e0cae677eec169264f2d839a37995",
         "sha512": "3955686f0d88b9b37f19262cc444e2fa039eeca6b9f4414c47fb70394dc96f61a728a78c189079486514ac4cf7485566240494759533cbcdec2cd350da066c96",
         "dest-filename": "jest-cli-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-config/-/jest-config-27.5.0.tgz#d96ccf8e26d3f2f3ae6543686c48449c201bb621",
+        "sha512": "78e229be95c5cf9587b88619375426bc12c48ec4a4df0f88002ff68c1a590a56e9ac5e77063f6678132001b135e434a469a2410c59a15d77752f67822da5b143",
+        "dest-filename": "jest-config-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6442,9 +13680,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.0.tgz#34dc608a3b9159df178dd480b6d835b5e6b92082",
+        "sha512": "cf3b6f1c30aafd070056ffa8eabb6cd2b7aea523b1cab5fe28b40438c5825b6b6b660701160a7fa132bb849086a57bc422a2ab433c9095a3ca9fd5b4e3e20c42",
+        "dest-filename": "jest-diff-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a",
         "sha512": "2cc220888ae18a098faecd37247a71521db22122b7bcb14f900a1d3dea34f81b85ef003616841b904835bbc8016014e19dcbbb7b5a040d47c85d5b93a8b4548f",
         "dest-filename": "jest-diff-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-27.5.0.tgz#096fa3a8b55d019a954ef7cc205c791bf94b2352",
+        "sha512": "53832d2607599f6c7e8e93f377b34062f0e6809000e61f50c55030b32b87ec8ca61b363c5461e10241dc2063a6b66742eb53912f109b1218fa7c226c6825b35c",
+        "dest-filename": "jest-docblock-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6456,6 +13708,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-each/-/jest-each-27.5.0.tgz#7bd00a767df0fbec0caba3df0d2c0b3268a2ce84",
+        "sha512": "dafa5a8d2743319980c6348fd5fe011bd28a76ec07b6e688d30ebaa2a2d491f686514ec8c7f5be77c056d21dff4042627b0ee14741926e5a9d1704c411b84177",
+        "dest-filename": "jest-each-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-each/-/jest-each-29.7.0.tgz#162a9b3f2328bdd991beaabffbb74745e56577d1",
         "sha512": "827b3e12bd78f99ac4a02e5f84e7d8098d4b3871ebd1323ead0507652f13b70da5ee097ef3478773f8057f62ad930d3e4880020d3796be915cbf7074e157a66d",
         "dest-filename": "jest-each-29.7.0.tgz",
@@ -6463,9 +13722,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.5.0.tgz#6d22d9b76890e9b82c7e1062a15730efb3fb7361",
+        "sha512": "b17e3d37cae3a7a1d21de1a93602e4ea6b4745dd483c09c4feeef02d091be93cffd44d3c43ef98f1993f21ba5575c172c1bcc7d62705a84b83b8727aa3eb975e",
+        "dest-filename": "jest-environment-jsdom-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz#d206fa3551933c3fd519e5dfdb58a0f5139a837f",
         "sha512": "93d8906ec7fd3b239f773587f070e6ad14f481221c5fe14b356ec842af78b455f48329cfc2a0d35b41e8ea23153631b3fe76fe97fbd6ddd58cd9b6cb2e991b5c",
         "dest-filename": "jest-environment-jsdom-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.5.0.tgz#1ab357b4715bff88d48c8b62b8379002ff955dd1",
+        "sha512": "ed4ce2b0c31f1b2ad44614bf7946bba7b9a06aa3776a31f296c8ce81f727d1c68d798459ab82c72992df031acf337e0358b9c165c46ea44265a50b22cdd494b3",
+        "dest-filename": "jest-environment-node-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6498,9 +13771,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.0.tgz#861c24aa1b176be83c902292cb9618d580cac8a7",
+        "sha512": "569e8ef1ae7633f75a857446fc4d0426e59044ea6cda60d0d2c2583e03bc1ec92174bc23f5a8e09e0cb6380a99815e9efd1714ebb5941eae9381fbc96fc7e56c",
+        "dest-filename": "jest-get-type-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1",
         "sha512": "cebb5e5e7a98c5f421ee5e451f22f7f232f7f5d8bc1fcac7a1e70b1f724dc47dc1c0eac1b0d79a6dd6a9e5ed08db7943e071c8f16e5514166a1b811aab92cd73",
         "dest-filename": "jest-get-type-29.6.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.5.0.tgz#7cc3a920caf304c89fbfceb5d5717b929873f175",
+        "sha512": "d0a7dc912044295f83e9ed2da179888f8cf3a7bd848819ef902d0bfb16317a790b840764a76ffcb727b8020333cfb16a6f5afc496b73efeb355102ebc4c05a9e",
+        "dest-filename": "jest-haste-map-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6512,16 +13799,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz#5b7ec0dadfdfec0ca383dc9aa016d36b5ea4c728",
-        "sha512": "91803c20971262d493d8163d23e48c0b7da70e9053dc9d8dbd6271f3e242b82765fc247523810a50944e88ff17b42731aa04d304624d75b07503c5d129b4deb7",
-        "dest-filename": "jest-leak-detector-29.7.0.tgz",
+        "url": "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.5.0.tgz#589d6574d1318d3fb41b3fc368344117ec417dcc",
+        "sha512": "5fbb13dc72cd8e3ac111ea62971ccfc8d84d772ba768505ea68d4bdd3fdfbd86fdb5bf166fca98e7bea0c086be49972a614a8003bfdb4f7129648e25029d107b",
+        "dest-filename": "jest-jasmine2-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.3.0.tgz#86eda98d5af3aed687aebf11dbab3ca0f8fe66ff",
-        "sha512": "2e4f9ac043ee233d0f484447b67b17c8c54bbdfff8999dec641123286e6c247bdecb6fe2d897d09a66ff3478626a531b1d76482c1391cee1fae185e158694bb1",
-        "dest-filename": "jest-localstorage-mock-2.3.0.tgz",
+        "url": "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.5.0.tgz#c98c02e64eab4da9a8b91f058d2b7473272272ee",
+        "sha512": "024de4f830f76a8e5de3fcf326bc40439515e70882ae9e3b8c7f78643e3fbd74b342013a5815437e0f3756d72e94b20b3bb63afd0ffbcb3292aed37d35af25b8",
+        "dest-filename": "jest-leak-detector-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz#5b7ec0dadfdfec0ca383dc9aa016d36b5ea4c728",
+        "sha512": "91803c20971262d493d8163d23e48c0b7da70e9053dc9d8dbd6271f3e242b82765fc247523810a50944e88ff17b42731aa04d304624d75b07503c5d129b4deb7",
+        "dest-filename": "jest-leak-detector-29.7.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6540,6 +13834,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.0.tgz#d2fc737224fb3bfa38eaa2393ac5bc953d5c5697",
+        "sha512": "e6bbb2cd63066f58a50960fa102c0d74e85005e2170231e61dde5cdee3baaae47b4483073d13f6b9c39a7a3cf68fed11d0aa3819a9d633a4aa5c0785f2760de6",
+        "dest-filename": "jest-matcher-utils-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz#ae8fec79ff249fd592ce80e3ee474e83a6c44f12",
         "sha512": "b01903f978bd0ed70286c2372f7bb4f8dd28a603d89c244fb4671062b817991fa19adfdf61f5802f4c515d853c79639d7ee2e005ed18096dc016d9d12da82afe",
         "dest-filename": "jest-matcher-utils-29.7.0.tgz",
@@ -6554,9 +13855,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.5.0.tgz#654a781b38a305b1fd8120053c784c67bca00a52",
+        "sha512": "95f6d64614ed9993041cf02d9744abbcdccad45e149d534c1ce9624504f6049e2c045cc86f480108703879b583e28ea5d5f532bc33f1334d4af4e20c41301d43",
+        "dest-filename": "jest-message-util-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3",
         "sha512": "181115e064400de3feaad076fbabbad6cb5e6bc98670e4f8982b6b608499c1fbbdfc8487149ff9cce31761ba4113d46c4b9f866fadc35b81609a7289efd29feb",
         "dest-filename": "jest-message-util-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.5.0.tgz#1018656fe6bcd0f58fd1edca7f420169f6707c6e",
+        "sha512": "3c796e1ba3091a783cdbfb3187c3a207d7e7c73367ddc6b371e4870809802ace20e6b3217371190ab257bfee30eb5ac0d9619a80c523ed02cbac0d52465169cd",
+        "dest-filename": "jest-mock-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6582,9 +13897,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.5.0.tgz#26c26cf15a73edba13cb8930e261443d25ed8608",
+        "sha512": "7bd2ea49de87b03b2a77b292deb37263099001a1bd8eae14dcb6e7c15c4dff2de73650f39b6385b39f7aba8f73ad463e015d68a57abaa267bbf2d4435024567c",
+        "dest-filename": "jest-regex-util-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.6.3.tgz#4a556d9c776af68e1c5f48194f4d0327d24e8a52",
         "sha512": "289241b110b2c8b35608d04ebd9c910e70087d489127cbfe84e0506069fc803c85dd47a0c223f8830451dff4836b8da0d586d5c9c4e2754177aca8f22c50d66e",
         "dest-filename": "jest-regex-util-29.6.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.5.0.tgz#8e3b15589848995ddc9a39f49462dad5b7bc14a2",
+        "sha512": "c50b32ec29ab4f8089c5d35411dcd953633fbfa626b50fe990933eb31ed3035b221b5cdfb19ba8efc3d9bf3825c1131016bf3c7f74aee0e9bc38404089cf9233",
+        "dest-filename": "jest-resolve-dependencies-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6596,9 +13925,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.5.0.tgz#a8e95a68dfb4a59faa508d7b6d2c6a02dcabb712",
+        "sha512": "3e40e9604195fe716a4e19c8ae53ed8fca13c72015de2bae4baa2bedd658c9459a1ebfedcb255be6a7c19994ba144afba33047823ac5d5b81c80879f9e589c6f",
+        "dest-filename": "jest-resolve-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-29.7.0.tgz#64d6a8992dd26f635ab0c01e5eef4399c6bcbc30",
         "sha512": "20e561652ae0f94bd502c843483b47c8508205497f43700026ff2267a6639d9ef8c73bf0bb32d789df482083e04e763ad922637eeba930a66c65046c0afc4480",
         "dest-filename": "jest-resolve-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.5.0.tgz#b5747a4444b4d3faae019bd201943948882d26c3",
+        "sha512": "44ccd786424b2ce28a8143d8dadae9c950628da166b3032d828082064d8f4154470baca8d6f2ddd7f8e614fdfdb393975e7b7bae7b6ecca498bf197e41489ba9",
+        "dest-filename": "jest-runner-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6610,9 +13953,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.5.0.tgz#2497116742b9e7cc1e5381a9ded36602b8b0c78c",
+        "sha512": "4fb00fc423e3377a7778f70bbb2a5b5ad0f45191f201dbc800367d00123fb0567db7f45fdb121477a0fb4736485feba77b0251a285465ab803220794ba3d0e50",
+        "dest-filename": "jest-runtime-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-29.7.0.tgz#efecb3141cf7d3767a3a0cc8f7c9990587d3d817",
         "sha512": "8149cb8e0c1d1aa5bb0782ef38891b2acf5619b9fe40ba91410f63b82e879dd78389ecc8c210cffa684cc0758211c7d0e515176ba38f9c517c049879c5e830c1",
         "dest-filename": "jest-runtime-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-27.5.0.tgz#439a110df27f97a40c114a429b708c2ada15a81f",
+        "sha512": "6920c5a909555ed047f996f9765f660af4d216469b8b193ff4ff5ca6780be3224aa66122f544b17c384e34533326bb5fb4fbd9c373dc96d5159ad1594c1f77ae",
+        "dest-filename": "jest-serializer-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.5.0.tgz#c5c4c084f5e10036f31e7647de1a6f28c07681fc",
+        "sha512": "700263d79baa58692ba346df72ffc482eb019ea3600a946bb85419821b0c613ab8166da593f56101ff03811afcc2f851e947b586478bf2d9fbd02c38b7cc7fe4",
+        "dest-filename": "jest-snapshot-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6624,9 +13988,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-util/-/jest-util-27.5.0.tgz#0b9540d91b0de65d288f235fa9899e6eeeab8d35",
+        "sha512": "15452a3b1d20033272df2b5ab53d52b37ef633592685cce7f31eda134fbed75a0f196d45c83ff936360123cc3528e5c59ba2158ed6999b6b337c924bf821ecd2",
+        "dest-filename": "jest-util-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc",
         "sha512": "cfa11b29a8c8a6a18a539eb2e4a054832d5db758a18502605b352564702b03ff97d9a77b09be6217e00ad445952ff068ed1cfdbaeae9ab0e9288109e7d46c218",
         "dest-filename": "jest-util-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.5.0.tgz#b3df32372d2c832fa5a5e31ee2c37f94f79f7f1f",
+        "sha512": "d9767341636b63d629a35d669b865e563bebfbe0901bfe395e7980d9a5b0c75e79953c32d4918523c2e943674109201e3b6d68a2a83f14222fbfd5b07e73c294",
+        "dest-filename": "jest-validate-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6638,9 +14016,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.5.0.tgz#ca11c3b9115c92a8fd2fd9e2def296d45206f1ca",
+        "sha512": "32121e22f11de9d9e7b2913439f62ba873807d965dc85ab1fe4f14da7bd515290b61fdb6a8015fc8d58f55061cc2a2953686dc3a12684f4915fe744719ba8af0",
+        "dest-filename": "jest-watcher-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-29.7.0.tgz#7810d30d619c3a62093223ce6bb359ca1b28a2f2",
         "sha512": "e3d160ed65e4537565da1e8b6cbb4c43f1f207aad74885fb4aabc12d09acb1104637d2343cdbcf980982592398e923afae3848fc5eff6c602ff51b67b0f034de",
         "dest-filename": "jest-watcher-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.0.tgz#99ee77e4d06168107c27328bd7f54e74c3a48d59",
+        "sha512": "f0e10788f34e3d37da5a72764941ccf1f9a0786ab7eeeb86b1006f18a4099757fee96232ea0ec6ddf136aee239dbde1b50a508f456825ade610ef3bc1d2c2c4a",
+        "dest-filename": "jest-worker-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6655,6 +14047,13 @@
         "url": "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.7.0.tgz#acad073acbbaeb7262bd5389e1bcf43e10058d4a",
         "sha512": "788cf69ac2ff1332fd5054c5171ee305391e65f92ed32500c99659989f771f64d8122ae8231d8f42311773062d625f335c2c5bf8f02603684b22dffa64490f1f",
         "dest-filename": "jest-worker-29.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest/-/jest-27.5.0.tgz#2c04ff88754e42e9fc5240840b91f9a9a8990875",
+        "sha512": "b0231984bf73cb47e215ce07d1c2a55eaec172084c4b19b966713268f593b5e02b5398b1e898ce2b23974940462d34029ade64b97f7312f43d052b211ce3c1dc",
+        "dest-filename": "jest-27.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6680,8 +14079,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef",
+        "sha1": "e2625badbc0d67c7533e9edc1068c587ae4137ef",
+        "dest-filename": "js-string-escape-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b",
         "sha1": "9866df395102130e38f7f996bceb65443209c25b",
+        "dest-filename": "js-tokens-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b",
+        "sha256": "85ce7a76734264e093bcb1dbbe6d4d4130ee0a7fa562e7608693ee8c3c197d19",
         "dest-filename": "js-tokens-3.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -6690,6 +14103,20 @@
         "url": "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499",
         "sha512": "45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29",
         "dest-filename": "js-tokens-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/js-yaml/-/js-yaml-2.0.5.tgz#a25ae6509999e97df278c6719da11bd0687743a8",
+        "sha256": "aa921bbb4364458a6be0f774239eed02e39c4619161387a1601384baaeee96fa",
+        "dest-filename": "js-yaml-2.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc",
+        "sha256": "291c8ae9f474f106414f00a231d4bcd8b8b4f7582d72ab25fdc8792aa3d1e683",
+        "dest-filename": "js-yaml-3.10.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6708,9 +14135,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482",
+        "sha512": "ff821b21e1dc0fd54c1c5a8347f810ec475974b8a63af5b60dd731163772c99f4db1b4be71cad7a95583b5a6ff95197902552a9a9071f0484f69647e3ad635ec",
+        "dest-filename": "js-yaml-3.14.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.4.5.tgz#c3403797df12b91866574f2de23646fe8cafb44d",
+        "sha256": "b7557fd5206d7959ae8ca4352f9ff76d006bfd2e87fb616e87d9714413ad1028",
+        "dest-filename": "js-yaml-3.4.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30",
+        "sha256": "352129b2f057fbcdd24e53549fc071c35f3e4d4cd75059a63232fdef198885dd",
+        "dest-filename": "js-yaml-3.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.3.tgz#33a05ec481c850c8875929166fe1beb61c728766",
+        "sha256": "965a6f687178aebbb5a06e974b298f019c08db6cf8f69b543b67fc1deb4440c7",
+        "dest-filename": "js-yaml-3.8.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602",
         "sha512": "c29c59b3d368c596891122462194f20c4698a65d0529203e141f5a262c9e98a84cc24c5083ade1e13d4a2605061e94ea3c33517269982ee82b46326506d5af44",
         "dest-filename": "js-yaml-4.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513",
+        "sha256": "5ac44bc9490a2d7da45ebb7028ff9b86bf17944741e7c449573d7a147ae72323",
+        "dest-filename": "jsbn-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040",
+        "sha512": "e1b61557768032d0d34eee3ec6c0d86bab32f46c89ebdfda9acbbdb18176cea8e2128640e71262dc1adf5f7b98fbf21e908bbb33074e6dd6c35a9a19741bf7fc",
+        "dest-filename": "jsbn-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6722,6 +14191,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jsdom/-/jsdom-16.7.0.tgz#918ae71965424b197c819f8183a754e18977b710",
+        "sha512": "bbd4a67361b55124ad33eb3fc75aeee52c6b97a98f6026c1c86d54fe1526a9a56c9b8b5b3724bb0a270e491cae190619853bb487ce2a919650fc8f9dce2cd257",
+        "dest-filename": "jsdom-16.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jsdom/-/jsdom-20.0.3.tgz#886a41ba1d4726f67a8858028c99489fed6ad4db",
         "sha512": "498841bd387cf6d4df083fc245d48e9b5de63816b8da24da4f27f211605d29c19d3f13ed2c5057b8747c5c76f7dd835868ffa52db992bc14ec9e87ac08d244b1",
         "dest-filename": "jsdom-20.0.3.tgz",
@@ -6729,9 +14205,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d",
+        "sha1": "e7dee66e35d6fc16f710fe91d5cf69f70f08911d",
+        "dest-filename": "jsesc-0.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d",
+        "sha256": "3e9a10467c80fe53f193fab92ae0ea5efd58decaa9a97f540fba18fd242f6674",
+        "dest-filename": "jsesc-0.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b",
+        "sha256": "104abc400e260c6f53c22af36e2349e772fcd09cf71735a53ab5e2532f7825a1",
+        "dest-filename": "jsesc-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe",
         "sha1": "e421a2a8e20d6b0819df28908f782526b96dd1fe",
         "dest-filename": "jsesc-2.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4",
+        "sha512": "398bbb5c4ce39024370b93ecdd0219b107cda6aa09c99640f7dc1df5a59dd39342b42e6958e91284ada690be875d047afc2cb695b35d3e5641a6e4075c4eb780",
+        "dest-filename": "jsesc-2.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jshint/-/jshint-0.9.1.tgz#ff32ec7f09f84001f7498eeafd63c9e4fbb2dc0e",
+        "sha256": "c94f41e031ee600229f2afb6280200ff38c7c532c08b13fc268f01736cdcba51",
+        "dest-filename": "jshint-0.9.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898",
+        "sha1": "5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898",
+        "dest-filename": "json-buffer-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6757,6 +14275,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340",
+        "sha256": "42e2cd66a58b0eef52156985138c363704602c391f1d4a1962b5daa1b95ddcf1",
+        "dest-filename": "json-schema-traverse-0.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660",
+        "sha256": "f735add93641842e13096c8b3239f54e9b0b10e8ffd8a377400f4d61eabec065",
+        "dest-filename": "json-schema-traverse-0.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660",
         "sha512": "c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
         "dest-filename": "json-schema-traverse-0.4.1.tgz",
@@ -6771,9 +14303,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13",
+        "sha256": "e3163c53fbc030cb6ac9bd9652f20a62d3d0580e4eeafe9cb36571ca2bee933f",
+        "dest-filename": "json-schema-0.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651",
         "sha1": "9db7b59496ad3f3cfef30a75142d2d930ad72651",
         "dest-filename": "json-stable-stringify-without-jsonify-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af",
+        "sha256": "70e228b750bf40ab69dda437f284992f1ea4c4bf9e788dc7fc586a6956256150",
+        "dest-filename": "json-stable-stringify-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6792,9 +14338,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb",
+        "sha256": "b7fbbf65c0bff6d47f516c98638229dff0e981d0edfffecbcf971d7fe361928a",
+        "dest-filename": "json-stringify-safe-5.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1",
+        "sha256": "703e754f648282fa455bd84a347d4105c9bb521c80983d54ec9f35f994558b5e",
+        "dest-filename": "json3-3.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821",
+        "sha256": "5ea33801efe139c4303996569bcf62e37dcc100cc0575c6e7b22554133fbe61e",
+        "dest-filename": "json5-0.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593",
         "sha512": "83531630b062cfc14a8b57b8c3453254bdf0fa225c7960050406819e718a3a935ae5ff132e4b646eb7b5facea8202c9d5809be1d15064e623efffc6fda1bd760",
         "dest-filename": "json5-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6",
+        "sha512": "97edc75c3d06108de1b86ab59e3baab7360af0e609c9732438bb50e77a635a1f3db6f592da1ea5fb5ccc9185aa95be7bf92890a1d299caf30415bd97f8aac585",
+        "dest-filename": "json5-2.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6827,6 +14401,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8",
+        "sha256": "fc9541cb2b3f7f0a9ea2b8a06a1f34c72cbf48eea43bd752cb0df0728cb45a73",
+        "dest-filename": "jsonfile-2.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb",
         "sha1": "8771aae0799b64076b76640fca058f9c10e33ecb",
         "dest-filename": "jsonfile-4.0.0.tgz",
@@ -6841,9 +14422,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae",
+        "sha512": "e5d8277563ab8984a6e5c9d86893616a52cd0ca3aa170c8307faebd44f59b067221af28fb3c476c5818269cb9fdf3e8ad58283cf5f367ddf9f637727de932a5d",
+        "dest-filename": "jsonfile-6.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73",
+        "sha256": "030f926cb3d18933c9bce7fe3d1dddbde73b91532dc4cada98214337e811c89c",
+        "dest-filename": "jsonify-0.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978",
         "sha512": "dbf2a2d06726baa4ab805c9e950abd334e72ecf4b4984c2e233adfddfd5f3ea9150d546f66b3d9b5548c1f1760a3c02ad2cc4039bfdcaf66aaa80dcb7961d53e",
         "dest-filename": "jsonify-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsonist/-/jsonist-2.1.2.tgz#c1377311e8fc857abe7aa3df197116a911f95324",
+        "sha512": "f32aa6589002d95698a1229001bb1f802a46639a3fd5eb56cf1e99c5a66b0b8886687ac7519128f9ad8cc85f30fb6b936af4e51dd2d6699528475f547c1b2dc5",
+        "dest-filename": "jsonist-2.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9",
+        "sha256": "69c908187bf390ec6d68f0376308800c28856417a21d2434843235c70371413b",
+        "dest-filename": "jsonpointer-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2",
+        "sha256": "1df307cc675650ee56c4a5f7c87860dd56d7e42f6350e715c1a92a280322ec46",
+        "dest-filename": "jsprim-1.4.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6883,9 +14499,72 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/karma-mocha-reporter/-/karma-mocha-reporter-2.2.5.tgz#15120095e8ed819186e47a0b012f3cd741895560",
+        "sha256": "5393db5621373a93d6776a45096893b38fe9b9e24b94479f1f01fd354223c38b",
+        "dest-filename": "karma-mocha-reporter-2.2.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/karma-mocha/-/karma-mocha-0.2.2.tgz#388ed917da15dcb196d1b915c1934ef803193f8e",
+        "sha256": "870255369d9553dd5814952164e52369d20af7aa9449ee3dd57d4d742936674a",
+        "dest-filename": "karma-mocha-0.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz#d23ca34801bda9863ad318e3bb4bd4062b13acd2",
+        "sha256": "8ea10a759ac2760abadb7285bb3d676f355675d5b2bfae86b0b06727c8bc6c71",
+        "dest-filename": "karma-phantomjs-launcher-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/karma-sauce-launcher/-/karma-sauce-launcher-0.3.1.tgz#fa41f6afd1ad6cb7610885da83cbc9921a4d334c",
+        "sha256": "43ef38941871af50bc4ab8318d52865c446210efd65a401c9de5d3980d5aafd3",
+        "dest-filename": "karma-sauce-launcher-0.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz#91322c77f8f13d46fed062b042e1009d4c4505d8",
+        "sha256": "05d3a1fef54c2ddca95ea5b0260bc2c8b7cbdf26d63b0f026788bf09c47bc2f1",
+        "dest-filename": "karma-sourcemap-loader-0.3.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-1.8.1.tgz#39d5fd2edeea3cc3ef5b405989b37d5b0e6a3b4e",
+        "sha256": "03a3cae28586c6f590ececf099177cef60da4a9fb214875a9bb564b468eb644e",
+        "dest-filename": "karma-webpack-1.8.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/karma/-/karma-0.13.22.tgz#07750b1bd063d7e7e7b91bcd2e6354d8f2aa8744",
+        "sha256": "32a0d38a16780918806c0d00821979df297e3cc0f8cc0d22014b72ba502d273a",
+        "dest-filename": "karma-0.13.22.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b",
+        "sha256": "f3b4b73e9a71f4f5489d99303d7a2a58b3478fca4f0cdff4b0cc0707172b60b9",
+        "dest-filename": "kew-0.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/keytar/-/keytar-7.8.0.tgz#28cf5ceeb1275350888870022869b8b4fe6a87f9",
         "sha512": "991f81aad00e216f23f93e45b4b57272409bbd1396403fb81733de14cba4e678c46645cba553c2185dba637993cb130000bd5709fb3047b4ba9087fe4c749114",
         "dest-filename": "keytar-7.8.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9",
+        "sha512": "f72909ff8e9237ff4a3ccfec89c87343b3af5f218360a19368394a306080960d942bc291cb88dbd1df2c15cfb44edd186274e1abc5f645980283be113f181c54",
+        "dest-filename": "keyv-3.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6904,8 +14583,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47",
+        "sha256": "524223ae7697fed4b12780cdf115c0c4d65d1471fc8aa9b37a9e22e9f892e4e2",
+        "dest-filename": "kind-of-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64",
         "sha1": "31ea21a734bab9bbb0f32466d893aea51e4a3c64",
+        "dest-filename": "kind-of-3.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64",
+        "sha256": "78a42e34fb8ba2b9459207e6003bd3cb082333591b488f2071c5d93086b65d47",
         "dest-filename": "kind-of-3.2.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -6918,9 +14611,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57",
+        "sha256": "d5c72f5a2a7a520b74e67779387d75ce6d7ed16cf0c9931303f4e4038079dc29",
+        "dest-filename": "kind-of-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d",
         "sha512": "346104ae71fa176bd4b970e1f8e95b70a5bbff039c7dd447699ed55ada82ced7c7ae2ffef982a63f9d4e7567863eea8239b6ba924d8e4dee5dd365664c1f343f",
         "dest-filename": "kind-of-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051",
+        "sha512": "b3990b39c9c7d17a833be16fb9a2d7f030e3675f0218593b572807e3442828f510856e1edabbccd2bc14ab4b7c2100cec1849e2cad3553dd0e8f305399ed90a8",
+        "dest-filename": "kind-of-6.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6942,6 +14649,13 @@
         "url": "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c",
         "sha512": "9c87ae552cdd082b3a4c33d3a88f30d58adedf8b12abb024678077b1f3816c8d82815481e03bb868b4228c5536fa5840142c2df7ee361de97a950348bfa027b5",
         "dest-filename": "klaw-sync-6.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439",
+        "sha256": "5f22cf9a810f184ff33bdf4edb8e9020a1f4001b1413081d2d9cb90380784def",
+        "dest-filename": "klaw-1.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6981,6 +14695,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15",
+        "sha1": "a205383fea322b33b5ae3b18abee0dc2f356ee15",
+        "dest-filename": "latest-version-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face",
+        "sha512": "c1e4feaf491391141d09d60236d90cc165d04cc12cc0aac50649b872440e315861aa120c235513da1323fb58a28088604999b98139ab45704da06520693635c4",
+        "dest-filename": "latest-version-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e",
+        "sha256": "95c934b514416958916f168f9e83717eaf4b8138625f27fd5b46ad8d3be19cbf",
+        "dest-filename": "lazy-cache-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264",
         "sha1": "b9190a4f913354694840859f8a8f7084d8822264",
         "dest-filename": "lazy-cache-2.0.2.tgz",
@@ -6991,6 +14726,27 @@
         "url": "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.5.tgz#6cf3b9f5bc31cee7ee3e369c0832b7583dcd923d",
         "sha512": "d3f06718209fc943240697838168a16a720017d2666611c1814844ab3bdff9a7613462e83fa4da888e6817ca326f7238e4ff8f727aea8a149fd353349741b9f9",
         "dest-filename": "lazy-val-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lazystream/-/lazystream-0.1.0.tgz#1b25d63c772a4c20f0a5ed0a9d77f484b6e16920",
+        "sha256": "c1d7ede10ee8e11975a97727b8d99aac4ad8ae7a7877a8d1a352e3af271bfafe",
+        "dest-filename": "lazystream-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835",
+        "sha256": "4c49d600aaa40a822928c13fae5575bb2debc38a3e8f7877d290cc9ff2d24c43",
+        "dest-filename": "lcid-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3",
+        "sha256": "0a160e03f49a562ed63687cd4e6322042922654647a56cdaf3d0fed7ea34ab04",
+        "dest-filename": "lcov-parse-0.0.10.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7009,6 +14765,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/levn/-/levn-0.2.5.tgz#ba8d339d0ca4a610e3a3f145b9caf48807155054",
+        "sha256": "e10bc12c0f793b19d863e6b97bdf7d76b3910aa6bb76c3991436a3e39fab77e6",
+        "dest-filename": "levn-0.2.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee",
+        "sha1": "3b09924edf9f083c0490fdd4c0bc4421e04764ee",
+        "dest-filename": "levn-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee",
+        "sha256": "ba013e858d85b00ef45b1aabce921710f02df0fb36000dc17e63cac168719624",
+        "dest-filename": "levn-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade",
         "sha512": "f9b4f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029",
         "dest-filename": "levn-0.4.1.tgz",
@@ -7019,6 +14796,13 @@
         "url": "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a",
         "sha512": "51a88c27379646512e8f302ec392e8918d4be5e70d41864a7e6c99f4bef00c76ffa797ad29ac5786884172bc341186f2f86fcd039daf452378377f5dc47008c1",
         "dest-filename": "lie-3.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/liftoff/-/liftoff-2.3.0.tgz#a98f2ff67183d8ba7cfaca10548bd7ff0550b385",
+        "sha256": "a9b27a4fc8895c995610eff5234116591334a6eedffeb2ffb45ade8a378163f9",
+        "dest-filename": "liftoff-2.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7037,6 +14821,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/livereload-js/-/livereload-js-2.3.0.tgz#c3ab22e8aaf5bf3505d80d098cbad67726548c9a",
+        "sha256": "66302bdf6432d0cdf5b34a81126849b117772ea304cdc85eca4446b600d1afc0",
+        "dest-filename": "livereload-js-2.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0",
+        "sha256": "edf8d9c1a69850f6efd099390ce2c3b50edb9ac99b997e957bbb2f947d145d7e",
+        "dest-filename": "load-json-file-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8",
         "sha1": "7947e42149af80d696cbf797bcaabcfe1fe29ca8",
         "dest-filename": "load-json-file-2.0.0.tgz",
@@ -7044,9 +14842,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b",
+        "sha1": "2f5f45ab91e33216234fd53adab668eb4ec0993b",
+        "dest-filename": "load-json-file-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/load-json-file/-/load-json-file-5.3.0.tgz#4d3c1e01fa1c03ea78a60ac7af932c9ce53403f3",
+        "sha512": "70918fe3425cfd55d4b29f3f3ab9f22b24d9d72eaffdda619b76e2a12f91aca5e32b6041eb01d477a269b591050c68066a1313f889e764ee62d448bd9a90bc07",
+        "dest-filename": "load-json-file-5.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384",
         "sha512": "f76fa1bafc4cbd894ccccb748883ae91cc18045a64609769976c6c67b2eb95ac8eec4f123aff8925410ad7b07f74920700e2cc7e1d9d659fd8d7c5a0986b5837",
         "dest-filename": "loader-runner-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348",
+        "sha256": "8cf201e34312fe64704da3619a07dd6deb6da8dab490f8b050187df86c16683c",
+        "dest-filename": "loader-utils-0.2.17.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7072,6 +14891,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e",
+        "sha256": "b1ab0fff582a3a7098905544c47221ee52088be97e9cec4f8fd44c2ea7fa72c2",
+        "dest-filename": "locate-path-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e",
+        "sha512": "ec03bbe3cc169c884da80b9ab72d995879101d148d7cf548b0f21fc043963b6d8099aa15ad66af94e70c4799f34cb358be9dfa5f6db4fe669a46cade7351bae4",
+        "dest-filename": "locate-path-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0",
         "sha512": "b7b870f6923e5afbb03495f0939cd51e9ca122ace0daa4e592524e7f4995c4649b7b7169d9589e65c76e3588da2c3a32ea9f6e1a94041961bced6a4c2a536af2",
         "dest-filename": "locate-path-5.0.0.tgz",
@@ -7086,9 +14919,191 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz#76e7b7c1f1fb92547374878a562ed06a3e50f6e1",
+        "sha256": "b750bd3fcc5905aea417ea84b463f601e6187446b84ac547145c6cea26c11dd7",
+        "dest-filename": "lodash._arraycopy-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz#bab156b2a90d3f1bbd5c653403349e5e5933ef9e",
+        "sha256": "74448e8e5a42450cb5e3e588e8acb9c3898818e667cbda5b5296f01688cb4c91",
+        "dest-filename": "lodash._arrayeach-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz#1a8fd0f4c0df4b61dea076d717cdc97f0a3c3e66",
+        "sha256": "afd54248b98653fea52bcdbddd615c3e9c9d48e4dfb4263689bca2c4d3682720",
+        "dest-filename": "lodash._arraymap-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e",
+        "sha256": "f513588149ee66607a65beb30c582a2fbb37eea9c6454915c9a7726aa9322c81",
+        "dest-filename": "lodash._baseassign-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz#303519bf6393fe7e42f34d8b630ef7794e3542b7",
+        "sha256": "142694d9d3d2363c823f6ceabe91dffdbce912f001d29730c37b1c3ac8976549",
+        "dest-filename": "lodash._baseclone-3.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36",
+        "sha256": "b46e3f6ba799fd933efac3690a7ac4f1ecf3e5f02627e2ed0f60c011406d2745",
+        "dest-filename": "lodash._basecopy-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821",
+        "sha256": "05bf75a9a338b28e18ef8cc0b109ba7275faba21bbda6c47d72e059e04d8ba83",
+        "dest-filename": "lodash._basecreate-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz#f2c204296c2a78e02b389081b6edcac933cf629c",
+        "sha256": "35517275083bc5ea7f8b2401a8b0e022f4a40428893e2acc4fcce864d384a500",
+        "dest-filename": "lodash._basedifference-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz#0770ff80131af6e34f3b511796a7ba5214e65ff7",
+        "sha256": "3e1aa3090abb3d52ac794aeee59522ce8255560e6f4ce0ad220d1b09d62c2502",
+        "dest-filename": "lodash._baseflatten-3.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._basefor/-/lodash._basefor-3.0.3.tgz#7550b4e9218ef09fad24343b612021c79b4c20c2",
+        "sha256": "d8313873edaa9f19ae2b7318d0e28bce5d16de5692eee524926478de09da7efb",
+        "dest-filename": "lodash._basefor-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c",
+        "sha256": "9e851d51bc12f4066423bbc389c8453fd7df3071ef7589d3ce83eb1c93975e39",
+        "dest-filename": "lodash._baseindexof-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz#d1861d877f824a52f669832dcaf3ee15566a07d5",
+        "sha256": "cbb06e5bafe5ffee0f648e28d4ab5957ed86eb7b1a0b4ffa7d80c9a17efb4b7a",
+        "dest-filename": "lodash._basetostring-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz#5b775762802bde3d3297503e26300820fdf661b7",
+        "sha256": "68612514fe6e9d044b34b3213643a549deae028706903b5f50f4a91158044b1a",
+        "dest-filename": "lodash._basevalues-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e",
+        "sha256": "371426b8517aef4eff43b6444a88d2966d22f3063bc63915d5e07a12aaf2ddea",
+        "dest-filename": "lodash._bindcallback-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92",
+        "sha256": "175ad0ff8a9124e3e7fb1fd822fc9d0d8a9d6754436ab4a727dd82d1477699c0",
+        "dest-filename": "lodash._cacheindexof-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz#838a5bae2fdaca63ac22dee8e19fa4e6d6970b11",
+        "sha256": "a0aee59fd72b141a9b3660b31373bbf3ba7b5b9bc662af5875ace74ce99c5225",
+        "dest-filename": "lodash._createassigner-3.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093",
+        "sha256": "a592f442337402bd8aac36e84628b7c17d1b0eff12c93ceacee3b41ba08728c2",
+        "dest-filename": "lodash._createcache-3.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5",
+        "sha256": "f7f340113f502cda9a64d98ad1c4f9fd054e30b425f973c9b95d31798fb77960",
+        "dest-filename": "lodash._getnative-3.9.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c",
+        "sha256": "7dc287b30c352680f37bff907befbcffd007f6ef15fef224bdc633dfa88eb43b",
+        "dest-filename": "lodash._isiterateecall-3.0.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz#1f898d9607eb560b0e167384b77c7c6d108aa4c5",
+        "sha256": "4883e11b3345ba08dc5258978d5cdebeef474ee9519b9ec06d6e7a1835b53bbe",
+        "dest-filename": "lodash._pickbyarray-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz#ff61b9a017a7b3af7d30e6c53de28afa19b8750a",
+        "sha256": "042c667983302c50d1c85410aa325680fb80d3524c7fff25561e5413d008a045",
+        "dest-filename": "lodash._pickbycallback-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._reescape/-/lodash._reescape-3.0.0.tgz#2b1d6f5dfe07c8a355753e5f27fac7f1cde1616a",
+        "sha256": "fbced53d672b9e13a051ac55bbf1ad83e5a7d04b52e197d11e2281ef635a74c4",
+        "dest-filename": "lodash._reescape-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz#58bc74c40664953ae0b124d806996daca431e2ed",
+        "sha256": "b70d4f6e7da7689a259b763aecf7d677439eebe17e513ced80fab368517adf20",
+        "dest-filename": "lodash._reevaluate-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d",
         "sha1": "0ccf2d89166af03b3663c796538b75ac6e114d9d",
         "dest-filename": "lodash._reinterpolate-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d",
+        "sha256": "9cc35683a3eaee3bd5a2f5d00a75848f7892642afd79921cff40c152da8f29c0",
+        "dest-filename": "lodash._reinterpolate-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692",
+        "sha256": "bb5c01a55f74f3f2168f471bc1003f35905d0861d0c7d5e6d2e628d3af7b5b91",
+        "dest-filename": "lodash._root-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-3.2.0.tgz#3ce9f0234b4b2223e296b8fa0ac1fee8ebca64fa",
+        "sha256": "a16e67223e62181e75495d21aa65178ea4207bee667c591610415936e128683d",
+        "dest-filename": "lodash.assign-3.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7100,9 +15115,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz#127a97f02adc41751a954d24b0de17e100e038eb",
+        "sha256": "0de5b815b2980a653b7e0009147ea37f2b12641ca8590cdb213aac4d5f0664f4",
+        "dest-filename": "lodash.assignwith-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6",
         "sha512": "4f0b849c29f16dcdeb02f85ffcb6c6eed2540f386a5f2167bf776dccb38f8021bf84e0cbed6167b1bc24b640fbc9457446bade3ff9753c02eafd84a0e95be394",
         "dest-filename": "lodash.camelcase-4.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz#a0a1e40d82a5ea89ff5b147b8444ed63d92827db",
+        "sha256": "996ea51db08b11f5e51e1ea0119dcd8aa2f1692d7c77d9e19697858c22ed87ae",
+        "dest-filename": "lodash.clonedeep-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef",
+        "sha1": "e23f3f9c4f8fbdde872529c1071857a086e5ccef",
+        "dest-filename": "lodash.clonedeep-4.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7",
+        "sha256": "047e51fd80f6cce3fb289bcffc7f334304edf43668cc68ff88696dd0a4650c80",
+        "dest-filename": "lodash.create-3.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7114,9 +15157,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-3.2.0.tgz#995ee0dc18c1b48cc92effae71a10aab5b487698",
+        "sha256": "42b3f7c12278a9f4f37a58c789acccb1b4cb99f021d4ddc1020c1308b96fc721",
+        "dest-filename": "lodash.escape-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f",
         "sha1": "f31c22225a9632d2bbf8e4addbef240aa765a61f",
         "dest-filename": "lodash.flatten-4.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2",
+        "sha1": "fb030917f86a3134e5bc9bec0d69e0013ddfedb2",
+        "dest-filename": "lodash.flattendeep-4.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7128,9 +15185,93 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a",
+        "sha256": "2b97d3842f26884f3aa1063436239c606161f6c2741c635180f76c2eae8ff117",
+        "dest-filename": "lodash.isarguments-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55",
+        "sha256": "1df330af1d6e85919f05b7510a3a26559f5a336b7cf0e2a13450b64c458102bd",
+        "dest-filename": "lodash.isarray-3.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e",
+        "sha256": "431f5d9878d6581534e0e0f6b4916442535d1a81736eabd828608878d97b5b48",
+        "dest-filename": "lodash.isempty-4.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.islength/-/lodash.islength-4.0.1.tgz#4e9868d452575d750affd358c979543dc20ed577",
+        "sha1": "4e9868d452575d750affd358c979543dc20ed577",
+        "dest-filename": "lodash.islength-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz#9a8238ae16b200432960cd7346512d0123fbf4c5",
+        "sha256": "679deebd6adf2d6bc62a207e4942b8e0ee2d7ab0272875a04d634285596e1f3c",
+        "dest-filename": "lodash.isplainobject-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb",
+        "sha256": "986420e1ce139727af84069d7b88912facac64e5ca1281efd9f55b228fad72d0",
+        "dest-filename": "lodash.isplainobject-4.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb",
+        "sha512": "a125f3696ca908c1e43c2dcdbc111a3c77f42ac0399af3eb38f810583b1b83c9fba2b676f743340660bf8e0459e2f709e834c0863aec49881db16fc5f8c14e04",
+        "dest-filename": "lodash.isplainobject-4.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451",
+        "sha256": "45fd48aeca41f05f44fd413471f254c472e1e7a811ab84ea41448d2e7155cd5f",
+        "dest-filename": "lodash.isstring-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz#c9a477498607501d8e8494d283b87c39281cef62",
+        "sha256": "acd0edd74f8cea64de0bebed3365f5b613aa91ebecd5684e4cd100f1f334d10d",
+        "dest-filename": "lodash.istypedarray-3.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36",
         "sha512": "37c5d14c830caaa0e04b2e152ca3e727ffa1a4664df8f1d08899d27a762a3da555fcd0aa1288139c07592d08862a1c57f890acf30696ab6b755c758a3a6958f2",
         "dest-filename": "lodash.kebabcase-4.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a",
+        "sha256": "3baf1f23fd7c9163bd41643a2994fb5e5c68161caa32741265903960a643293e",
+        "dest-filename": "lodash.keys-3.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.keysin/-/lodash.keysin-3.0.8.tgz#22c4493ebbedb1427962a54b445b2c8a767fb47f",
+        "sha256": "2d9ebdff65429b2f0170417d30d1593e87d0b736f9023f9efac4684c23c32747",
+        "dest-filename": "lodash.keysin-3.0.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c",
+        "sha256": "c614c87f558519951a81bb98c84ffc7596ab24899d0a3a0b444c8ad28e9d51e7",
+        "dest-filename": "lodash.mapvalues-4.6.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7142,9 +15283,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-3.3.2.tgz#0d90d93ed637b1878437bb3e21601260d7afe994",
+        "sha256": "0ba02a0587b74578a7d20d0cbfab3ea81a0d76a8e8a2bb248419e6544949b193",
+        "dest-filename": "lodash.merge-3.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a",
         "sha512": "d0aa63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321",
         "dest-filename": "lodash.merge-4.6.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-3.1.0.tgz#897fe382e6413d9ac97c61f78ed1e057a00af9f3",
+        "sha256": "bbb3af4c21d0e5b5347d62a8a9e5b4e7b0f8d0addfe8b7471d5054b50d029a08",
+        "dest-filename": "lodash.omit-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.pad/-/lodash.pad-4.5.1.tgz#4330949a833a7c8da22cc20f6a26c4d59debba70",
+        "sha1": "4330949a833a7c8da22cc20f6a26c4d59debba70",
+        "dest-filename": "lodash.pad-4.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e",
+        "sha1": "53ccba047d06e158d311f45da625f4e49e6f166e",
+        "dest-filename": "lodash.padend-4.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b",
+        "sha1": "d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b",
+        "dest-filename": "lodash.padstart-4.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3",
+        "sha256": "c13f5f12eddf84ccd53ce756459daca225dbd5511820981f7e12f43316880442",
+        "dest-filename": "lodash.pick-4.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805",
+        "sha256": "b8d564f2c62eadb48a1d09f0ac15bdd96f26af4ec216435cbb24e00ac58d0247",
+        "dest-filename": "lodash.restparam-3.6.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7156,9 +15346,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438",
+        "sha1": "edd14c824e2cc9c1e0b0a1b42bb5210516a42438",
+        "dest-filename": "lodash.sortby-4.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.template/-/lodash.template-3.6.2.tgz#f8cdecc6169a255be9098ae8b0c53d378931d14f",
+        "sha256": "2539467f23f310a6899f35b53ec5bf4d2a40df221beb0bacfbcddb16a8d6fee3",
+        "dest-filename": "lodash.template-3.6.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0",
         "sha1": "e73a0385c8355591746e020b99679c690e68fba0",
         "dest-filename": "lodash.template-4.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz#fb307844753b66b9f1afa54e262c745307dba8e5",
+        "sha256": "e807fa7fcb565779f47980e9341a22838d66f0d734dedfb28c7b869a88cdaad1",
+        "dest-filename": "lodash.templatesettings-3.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7170,9 +15381,79 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz#28790ad942d293d78aa663a07ecf7f52ca04198d",
+        "sha256": "42ca086d27ff89d4b6d981d29a18e40887cebb93e1f58b886c1bf92ed79c28e6",
+        "dest-filename": "lodash.toplainobject-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773",
+        "sha1": "d0225373aeb652adc1bc82e4945339a842754773",
+        "dest-filename": "lodash.uniq-4.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce",
         "sha512": "b1178a39824825fef876124e3615387b4fec8738b5b6b55b4960ce84a604e575763be1fb49bd838a1c2e73bc56c5597e0e014fc93a88377ccc7d3f5cab98960e",
         "dest-filename": "lodash.upperfirst-4.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash/-/lodash-0.9.2.tgz#8f3499c5245d346d682e5b0d3b40767e09f1a92c",
+        "sha256": "5de5d9cd57fcea2fc73a943653a694620cf705c89bd816e4d05b01fc0d08c663",
+        "dest-filename": "lodash-0.9.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551",
+        "sha256": "744c854a5eb85dd39b83fb3c6a830203c276846ea50425be4a633146db1e556f",
+        "dest-filename": "lodash-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e",
+        "sha256": "898a0d54ebf3fa063e4d18afa295b4a70c8faf77323ad063d9a2c7d7c94efa60",
+        "dest-filename": "lodash-2.4.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6",
+        "sha256": "4578a0a45fae7bfc8f0ea464e9ca3b1330ad6d2c4696d61dc7e7afdcf4e2c925",
+        "dest-filename": "lodash-3.10.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash/-/lodash-3.2.0.tgz#4bf50a3243f9aeb0bac41a55d3d5990675a462fb",
+        "sha256": "2e499c91f38df622e5de1ff1a642ecd9e0d39f6b8ffd92e4b1f347cfbb5b3c55",
+        "dest-filename": "lodash-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash/-/lodash-3.9.3.tgz#0159e86832feffc6d61d852b12a953b99496bd32",
+        "sha256": "3be5c822f9dd3df55a5aff9e61627e6b25e835b459fb3ad9925eff77034d2800",
+        "dest-filename": "lodash-3.9.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548",
+        "sha512": "f3139c447bc28e7a1c752e5ca705d05d5ce69a1e5ee7eb1a136406a1e4266ca9914ba277550a693ce22dd0c9e613ee31959a2e9b2d063c6d03d0c54841b340d4",
+        "dest-filename": "lodash-4.17.15.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52",
+        "sha512": "3e585d15c8a594e20d7de57b362ea81754c011acb2641a19f1b72c8531ea39825896bab344ae616a0a5a824cb9a381df0b3cddd534645cf305aba70a93dac698",
+        "dest-filename": "lodash-4.17.20.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7184,6 +15465,48 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae",
+        "sha256": "f14bfa44822bd45ec6ae995f8c5a0067cfddc680e74f105b03c8e28a9104c59d",
+        "dest-filename": "lodash-4.17.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511",
+        "sha256": "ab20a32e64c8c7f631635460f1874e7dd622abd6c1cb7daef2957daa18bc1afe",
+        "dest-filename": "lodash-4.17.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056",
+        "sha256": "a7636c561eda3ce34006d93c00fd677d5dc316ac9f1594244a55a59511577995",
+        "dest-filename": "log-driver-1.2.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a",
+        "sha256": "cdc8ff339ae6d9da1b309faae4de9b0feb7efc88048b1e5d1cbb51a7021b9c0b",
+        "dest-filename": "log-symbols-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a",
+        "sha512": "55e20016c97221eac424b5c7ce279da366dab0a6cc2ad4f0def7e7e48cc6d174e38405442723479cbda9eef73ec010d2750b94a4dc37336bbac5bf50b0063912",
+        "dest-filename": "log-symbols-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/log4js/-/log4js-0.6.38.tgz#2c494116695d6fb25480943d3fc872e662a522fd",
+        "sha256": "b73f5bb32b1afcbd81ad321d169738372b68721360de3b9a971acc57ce113dd7",
+        "dest-filename": "log4js-0.6.38.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/logform/-/logform-2.4.0.tgz#131651715a17d50f09c2a2c1a524ff1a4164bcfe",
         "sha512": "08f489c387ed8dfe75ec48576461af4c71e46286e8ed909cd24bf05283987237d1d9456b23ae911e3f0c0ab7c07448ad76616a6eed8161d62cf051c76526fa8b",
         "dest-filename": "logform-2.4.0.tgz",
@@ -7191,8 +15514,29 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/loggly/-/loggly-0.3.11.tgz#62c1ec3436772f0954598f26b957d2ad2986b611",
+        "sha256": "cd413a76b41bfa0dd5a4ceba06a853ddafe7d822ca85ce69c5bd4fb4d42a6325",
+        "dest-filename": "loggly-0.3.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097",
+        "sha256": "a615736b976e8e5cf340fb5b07c461ad8f8c40aafafdbdfa95c5788535f91b33",
+        "dest-filename": "longest-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848",
         "sha1": "d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848",
+        "dest-filename": "loose-envify-1.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848",
+        "sha256": "fb526ac195ab33e34c3a5fc5a4f68ae865de3310209191c2f5ab56d9631ce088",
         "dest-filename": "loose-envify-1.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -7205,9 +15549,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f",
+        "sha1": "5b46f80147edee578870f086d04821cf998e551f",
+        "dest-filename": "loud-rejection-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f",
+        "sha256": "ec9e1633627a5cd6f38737ac3f92dda1331248e6ca062e5c8b7d40b1f411c3fa",
+        "dest-filename": "loud-rejection-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-2.2.0.tgz#4255eb6e9c74045b0edc021fa7397ab655a8517c",
+        "sha512": "4b415ac8c5e4bbcd2da1ae6c67a468e02facf84b450c2b3224d1bf03314c7d7dc0c43e528b8759b20ce6fe42a76cec479790aff230659e8f3edd7608876a4d8d",
+        "dest-filename": "loud-rejection-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28",
         "sha512": "edf9b797734017d59f37a5b724e99fe5daf0a55a97efc26da0627703a5b46ba66795d338d70d9f5790f8f74a6c2854e931db3c4c9b1efde1cb145b0d1c78c782",
         "dest-filename": "lower-case-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f",
+        "sha512": "1b62e3eb5b570e754514e8bc55976cf92a108ed402ddd82890a7431b69939b5b71e26e743541c1399481c10407cb2d15d760342531b889c7d9407fb13f287c54",
+        "dest-filename": "lowercase-keys-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7219,9 +15591,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-1.0.6.tgz#aa50f97047422ac72543bda177a9c9d018d98452",
+        "sha256": "f3a419d4989d9db292a7207f04b6108eed6d8316553d888a462cccd4c9e8855e",
+        "dest-filename": "lru-cache-1.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878",
+        "sha512": "f61a77569dbf845414888c0aa3c5c2785567ae0f0f9374d834f211eed2400ca8b961f705eef11a2bb6af1474e54b2de438a61a25069a95f128e98b9775c78139",
+        "dest-filename": "lru-cache-10.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952",
+        "sha256": "1f45ca9d889474ce77abe6d76acb01ec0c3a3bf226215aa59a3c483dfd2ef273",
+        "dest-filename": "lru-cache-2.7.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55",
+        "sha256": "de7068efeec994c1bbd013276acccd5cfb35d18acf6577abd27944977e2e9f62",
+        "dest-filename": "lru-cache-4.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55",
         "sha512": "ab8b297b82937ec012d525072ced30cfc422c9fd7ebcc2008294588a81580cc36a29f1d06e0f805431f78b87efa65ef5fcfd4bd1d065f9f422f8fdfb5187f47b",
         "dest-filename": "lru-cache-4.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd",
+        "sha512": "b166656c43f63ac1cd917acc97919893f8ca93bd0c06783a514e1823fa860d86e07fa61b3f812f9aa2126d70a826244ab3ed5b4a9147560431bc9d7b176962e6",
+        "dest-filename": "lru-cache-4.1.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7240,9 +15647,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c",
+        "sha512": "db0df547b489b6278926742d19ced154bd92b4cdaf19855fa943af503c47e9b0ba6894f13f14c5d069c8802caeeed8e872489458061045bc5aeef2a7df8b39b1",
+        "dest-filename": "make-dir-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5",
+        "sha512": "2d2f57f9d73c28bc5709bf1d9e2efd7cb208500e55c99a328d2302c1396e697034a36edc08ad1b857929830fac4d75693f2fe548ee7b8a5462c6a934bc39ad44",
+        "dest-filename": "make-dir-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801",
+        "sha512": "82b3490e16fc6f5266d6a7aa5b947f3badf0528e145e8dafd8732273a613f62fc706517ddd2f2390c807ef2ba0bd8f400434a11f8559327f08f94f3e7c235e83",
+        "dest-filename": "make-dir-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.2.tgz#04a1acbf22221e1d6ef43559f43e05a90dbb4392",
         "sha512": "ad828004abad5daeaf5d35e1a15d7c70113b3da7b03d71defc176ae2ff992cc8716d6029905169953d0b71b316fba05b8e7417cd9fec02f484fc9760b80a46e7",
         "dest-filename": "make-dir-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f",
+        "sha512": "83715e3f6d0b3708402dbffa0b3e837781769e0cded23cfbb5bceb0f6c0057ea3d15e3477b8acbfb22b699dd09fdf8927f5b1ad400e15ea8b9fa857038cfde1b",
+        "dest-filename": "make-dir-3.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7257,6 +15692,20 @@
         "url": "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2",
         "sha512": "b3c52194d7bbbcf2a8990842d6a15e94ca24aff49cdc080d6eca379fbe2654f0392d3670901f4d9577f85cf6a62f1244f21d2087bdeb33de31bf0453d825489f",
         "dest-filename": "make-error-1.3.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz#273ba2f78f45e1f3a6dca91cede87d9fa4821e36",
+        "sha512": "70a4d415cfeb6ca51dffd99e3af82ba49d96acdcf29adea37d10ddc20e540a7573bfd753a448fd252e66df0b738975428e5b885f22fca5c6ae918a9ecc8cd940",
+        "dest-filename": "make-fetch-happen-13.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c",
+        "sha1": "e01a5c9109f2af79660e4e8b9587790184f5a96c",
+        "dest-filename": "makeerror-1.0.11.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7278,6 +15727,34 @@
         "url": "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
         "sha1": "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
         "dest-filename": "map-cache-0.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
+        "sha256": "41c29927cd11bedb0b997af2117d65842f22287db9c4da9c13f4848e7c004f3d",
+        "dest-filename": "map-cache-0.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d",
+        "sha1": "d933ceb9205d82bdcf4886f6742bdc2b4dea146d",
+        "dest-filename": "map-obj-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d",
+        "sha256": "8358d2d331c9668909dfb4fe639ed2fbf3bfbd6b2161973db40d06a5656ab3e5",
+        "dest-filename": "map-obj-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9",
+        "sha1": "a65cd29087a92598b8791257a523e021222ac1f9",
+        "dest-filename": "map-obj-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7324,6 +15801,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/matcher/-/matcher-2.1.0.tgz#64e1041c15b993e23b786f93320a7474bf833c28",
+        "sha512": "a3e9d9afebed26d80f3649727942a4907e363ac2bc5807dd81a244d853717232cf83ee506de1284fabd18fc5eafe2bf5f09950f5c98ab04bb46fde22c567f561",
+        "dest-filename": "matcher-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/matcher/-/matcher-3.0.0.tgz#bd9060f4c5b70aa8041ccc6f80368760994f30ca",
         "sha512": "3a478368067f6d00b1785028ccce793ca70a534c8930f1a27cbc15e108238adbbee4ca007d240de25b0b25e5d9d5bf30d31fbf12675ae8c6605d2d63bec6a99e",
         "dest-filename": "matcher-3.0.0.tgz",
@@ -7338,6 +15822,48 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/maxmin/-/maxmin-1.1.0.tgz#71365e84a99dd8f8b3f7d5fde2f00d1e7f73be61",
+        "sha256": "8ed90d1b2e0ce7596fa7ad88de1609835d7edbc975250a4742c9e1546c2db11b",
+        "dest-filename": "maxmin-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/md5-hex/-/md5-hex-1.3.0.tgz#d2c4afe983c4370662179b8cad145219135046c4",
+        "sha256": "007a399a5ad2148651c04538ff2cdddf8aa7b808e1977da7f5c29c6db0c20a13",
+        "dest-filename": "md5-hex-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/md5-hex/-/md5-hex-2.0.0.tgz#d0588e9f1c74954492ecd24ac0ac6ce997d92e33",
+        "sha1": "d0588e9f1c74954492ecd24ac0ac6ce997d92e33",
+        "dest-filename": "md5-hex-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/md5-hex/-/md5-hex-3.0.1.tgz#be3741b510591434b2784d79e556eefc2c9a8e5c",
+        "sha512": "054891b53b55dfd2c82708a75818ea56c53dc61767cfbfe2f3cf55f39f48045a6ea86023e8bb8ebc7bf95cb6e067647ba6d26825a11cc64bfcf3f876e53ec28b",
+        "dest-filename": "md5-hex-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3",
+        "sha1": "822bccd65e117c514fab176b25945d54100a03c3",
+        "dest-filename": "md5-o-matic-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3",
+        "sha256": "af13f2f634ddc288ea9d05bdbda59474cd2503464404b8d860a763b3b2c6f1ff",
+        "dest-filename": "md5-o-matic-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e",
         "sha512": "fec2a540908161563d12bb3d86accaa2ee07e95e5459cfcce7d4c7d9dbe4b7ef388ad7e7abbb8538c2e93a2392e2e8ef1cfe1eb659f5f1f988c40e51e5f965d2",
         "dest-filename": "mdurl-1.0.1.tgz",
@@ -7348,6 +15874,20 @@
         "url": "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748",
         "sha1": "8710d7af0aa626f8fffa1ce00168545263255748",
         "dest-filename": "media-typer-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748",
+        "sha256": "2dfad81441b4f9225bdc15c3739b49bc4fdb80187989dcf35a4086645bab741f",
+        "dest-filename": "media-typer-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76",
+        "sha256": "24f11e05dee731f86fe35d75013d6bf1b2901c31e9e636e33a58183badea3792",
+        "dest-filename": "mem-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7373,6 +15913,48 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.2.0.tgz#f2bb25368bc121e391c2520de92969caee0a0290",
+        "sha256": "0f2f394dfba510d247f0f5c4c7b9efbf11264c3d074c112a1ee7fbe5cf396e29",
+        "dest-filename": "memory-fs-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.3.0.tgz#7bcc6b629e3a43e871d7e29aca6ae8a7f15cbb20",
+        "sha256": "d1ee971fe956595c709c1182689ab6c677c41a6c861b42946433491035be0f9f",
+        "dest-filename": "memory-fs-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552",
+        "sha256": "2bd91d722af49b652d69c466dba2a3fcf935e35a40b69e1043a20054e61d46df",
+        "dest-filename": "memory-fs-0.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/memory-stream/-/memory-stream-1.0.0.tgz#481dfd259ccdf57b03ec2c9632960044180e73c2",
+        "sha512": "5a6d7755cb0f20c746f7a77320b7e28f4f4fbee4b700fb5c28d87b336f05b0203fc3afb59a347b8613e67c53688a55fdc54ef04dd86c1f9949026e9737376dc3",
+        "dest-filename": "memory-stream-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb",
+        "sha256": "1da41d32f668f2fca8dece3f5ec404d0ffe57d170df3f4c231f1739d80d19f0d",
+        "dest-filename": "meow-3.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4",
+        "sha512": "09b4ea614d7b00168b79f3bcbc2535e77659969aca6160e58dc9dd28a0c215c610213cd6097640564e1030564f82fceb9d4437b88b67204fcba143b0ad3d7922",
+        "dest-filename": "meow-5.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61",
         "sha1": "b00aaa556dd8b44568150ec9d1b953f3f90cbb61",
         "dest-filename": "merge-descriptors-1.0.1.tgz",
@@ -7380,9 +15962,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61",
+        "sha256": "880a3b47ccffbacb13d305f808be60bb48a772828a36b6f6188c911f1f76a409",
+        "dest-filename": "merge-descriptors-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646",
+        "sha256": "13e9a21251cc07d266d34a4c856e3547808b234f687db6a8b078dd23507fd9d3",
+        "dest-filename": "merge-source-map-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646",
+        "sha512": "424729ecfdb2824b6930f87698241969fde384de83dd9fea5591d2756bd0fb611fe4781100f04ee7b03befe10d9b408fc76fb509efcc60a8b7ca6a9d7eeaa26f",
+        "dest-filename": "merge-source-map-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1",
+        "sha256": "bb39d30804117c82f9c1d85638bb8ae8448cb4e62f2129dd71e559392830db6a",
+        "dest-filename": "merge-stream-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60",
         "sha512": "69bbffa8e72e3df9375113df0f39995352ca9aec3c913fb49c81ef2ab2a016bc227e897f76859c740e19aac590f0436b14a91debb31fa68fcba2f6c852c6eddf",
         "dest-filename": "merge-stream-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81",
+        "sha512": "da3e0301d9413a4892648b1a5e4e264c4dec452d36c811c0b5fcb5dbbc515776d0505a979231c21cb5ba49cbfb0f03516c858d1c7f33a67cfdccc68a5c876f63",
+        "dest-filename": "merge2-1.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7401,9 +16018,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee",
+        "sha256": "dfd206d1c4023f131d2edc0f79ee54f3abc31f3a001b10039e2823f64064a03c",
+        "dest-filename": "methods-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565",
+        "sha256": "8af65fec82ef6400964362eb43ce88d4957c4f6aa34881363f01ea6361e0e4bf",
+        "dest-filename": "micromatch-2.3.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23",
         "sha512": "3168a4825f67f4cdf0f9ba6c6371def0bfb0f5e17ddf7f31465f0800ee6f8838b3c12cf3885132533a36c6bae5a01eb80036d37fcb80f2f46aaadb434ce99c72",
         "dest-filename": "micromatch-3.1.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259",
+        "sha512": "cbb1691d26cc50ca323db6144b33ba3da67a17246740ea47b8ac1ba351be2a7724f795d553840088a7461278f9c30a12ecf94e82d857ff4f6ee62149f9a61fe5",
+        "dest-filename": "micromatch-4.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7422,6 +16060,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/mime-db/-/mime-db-1.12.0.tgz#3d0c63180f458eb10d325aaa37d7c58ae312e9d7",
+        "sha256": "a05d14054d5782b00a411c28762736ad1781a47d01bef218eb9db52cf4b95d1c",
+        "dest-filename": "mime-db-1.12.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db",
+        "sha256": "937420f33b7c3beccba66e48d8b3a48a02d5b8006478a94c54a9a4d0cfbc9559",
+        "dest-filename": "mime-db-1.33.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad",
+        "sha256": "899c6f3cac1c5251c99b360b51866c94fc4d7fcb581bcada1cd55f50c33104c7",
+        "dest-filename": "mime-db-1.38.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70",
         "sha512": "b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be",
         "dest-filename": "mime-db-1.52.0.tgz",
@@ -7429,9 +16088,51 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/mime-types/-/mime-types-2.0.14.tgz#310e159db23e077f8bb22b748dabfa4957140aa6",
+        "sha256": "a427b1331104ccc6643758a6995deff6c178f84d7c361001873de55af3462348",
+        "dest-filename": "mime-types-2.0.14.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8",
+        "sha256": "aea571e6a1f2b6b42fea40e670c704883639928e15d6ff8961e832dfbee474b4",
+        "dest-filename": "mime-types-2.1.18.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd",
+        "sha256": "a81ab95d97bee24455b67401020ab4988f444f8fe1dff567df224ebfb8693caf",
+        "dest-filename": "mime-types-2.1.22.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a",
         "sha512": "64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b",
         "dest-filename": "mime-types-2.1.35.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime/-/mime-1.2.6.tgz#b1f86c768c025fa87b48075f1709f28aeaf20365",
+        "sha256": "7460134d6b4686d64fd1e7b878d34e2bdd258ad29b6665cf62e6d92659e81591",
+        "dest-filename": "mime-1.2.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6",
+        "sha256": "bd7568ce30be73f166e7cfbb65a6cabf641a82fd67b2cedac8c1f22416e5d130",
+        "dest-filename": "mime-1.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1",
+        "sha256": "215210390e617ac355b422692c7096476e3fe648176cb72b40075a03c9cc379a",
+        "dest-filename": "mime-1.6.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7446,6 +16147,20 @@
         "url": "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367",
         "sha512": "5123e431e113df5ace3226abb013481d928b1a0bca73f2eb8e87c09c194eb6d7f96a346faa2440f10b1e9db728a1cb4ae9de93b3a6aa657040f976e42ad86242",
         "dest-filename": "mime-2.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022",
+        "sha256": "b1931fd7a65dd3298684adfa6e213c9907ad01c3a81278f1fa3bd06b4cc66b3a",
+        "dest-filename": "mimic-fn-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022",
+        "sha512": "8dff38bb1cf08ae88854a88e2e97d893b378e934b2f2e6d3a279a7798f6fae91cd027a74401b76071595f5d3b7fe3f81a1501bf9ae46e980cf5b73391ce74c59",
+        "dest-filename": "mimic-fn-1.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7492,6 +16207,55 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-0.0.5.tgz#96bb490bbd3ba6836bbfac111adf75301b1584de",
+        "sha256": "063694baa9f9ab077e687ff59031f461998ef38fda656ec7c3475931177ccf36",
+        "dest-filename": "minimatch-0.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-0.2.14.tgz#c74e780574f63c6f9a090e90efbe6ef53a6a756a",
+        "sha256": "682d80dd599fbaedee51cc1dee54fc77f810ab0715e0deec3687e8de537e337e",
+        "dest-filename": "minimatch-0.2.14.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-0.3.0.tgz#275d8edaac4f1bb3326472089e7949c8394699dd",
+        "sha256": "6dd0b072cb5d5686836bb93578cc6e92f2b92cc21aa80de713644895057527c8",
+        "dest-filename": "minimatch-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7",
+        "sha256": "39c0bf1bd23c4bcb561b6ead6569116302a1b4f2c793fd25f9cd4bc7029edefd",
+        "dest-filename": "minimatch-2.0.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774",
+        "sha256": "bcd13daf575da13da23d57b170d33b3d7d80e7ea319d8cba2bea5b842b2a5d81",
+        "dest-filename": "minimatch-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
+        "sha256": "426a24d79bb6f0d3bb133e62cec69021836d254b39d931c104ddd7c464adea71",
+        "dest-filename": "minimatch-3.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
+        "sha512": "c891d5404872a8f2d44e0b7d07cdcf5eee96debc7832fbc7bd252f4e8a20a70a060ce510fb20eb4741d1a2dfb23827423bbbb8857de959fb7a91604172a87450",
+        "dest-filename": "minimatch-3.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b",
         "sha512": "27ba7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f",
         "dest-filename": "minimatch-3.1.2.tgz",
@@ -7520,9 +16284,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51",
+        "sha512": "2aa5a1f957217f170c3510098e3dad9ec48974d6c7b1582790185336b5bb023568e8ebcbb71c3ccdf4fda0bc35252a21945cc9f230a84e06a85ef27e907b7a7f",
+        "dest-filename": "minimatch-9.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954",
+        "sha512": "17206b4ff774778fae89945bab39cf5eac372296591b7825df0296897efce05c9c50a57006dd2e2c116442bb44e2d64eae0a3bf27669da39cacf72fae53e4b75",
+        "dest-filename": "minimist-options-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf",
+        "sha1": "de3f98543dbf96082be48ad1a0c7cda836301dcf",
+        "dest-filename": "minimist-0.0.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf",
+        "sha256": "73e03ee5fba64f3ee864fa90aacd4fc799e427a0555e27b41dd1988a35ffcb76",
+        "dest-filename": "minimist-0.0.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d",
         "sha1": "857fcabfc3397d2625b8228262e86aa7a011b05d",
         "dest-filename": "minimist-0.0.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d",
+        "sha256": "7953afa208b921faf59c1fa5693764ca2be03e261ef91c88717ef20c8c474a33",
+        "dest-filename": "minimist-0.0.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284",
+        "sha1": "a35008b20f41383eec1fb914f4cd5df79a264284",
+        "dest-filename": "minimist-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284",
+        "sha256": "ec0d0bdf71837612eea9fa61e5689e14856807946d499ce6ebf062ba09a5f270",
+        "dest-filename": "minimist-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602",
+        "sha512": "14cf6735462b4410042d9413df179943b7e630e060ea758d989293720b0979a2ecb4ffd43835691acaf93a15e185783a7feaad27cba267e3d4c640d67202172f",
+        "dest-filename": "minimist-1.2.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7541,6 +16361,62 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c",
+        "sha512": "db2c8047ca8190ddd8ba17896a7529582e54ddb6f9a2c0f2c0d07c4730d5943c031dba1c009bdeaaa8f5bbcf92543ee39164f8cafb070a95aaa96a80c5bd3308",
+        "dest-filename": "minimist-1.2.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-2.0.1.tgz#1621bc77e12258a12c60d34e2276ec5c20680863",
+        "sha512": "0fb57c3cef686b3ecf5862db0800ae235a843acabb50a7cba2dc7f0b401eb78ddf09407fc1f43b0d87aada847fb2f1491980c73ebdfc48701379a8ff6682872b",
+        "dest-filename": "minipass-collect-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-3.0.5.tgz#f0f97e40580affc4a35cc4a1349f05ae36cb1e4c",
+        "sha512": "d8df1e943400b529c55740e4ee0b75e4a1ec4b4172cfa09b619dfad21d164d85754f2e3a962deb01754e423d531cc34b766ac3f55b79a413ed5ad564a70181aa",
+        "dest-filename": "minipass-fetch-3.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373",
+        "sha512": "266412618a4f52a5f92729f5997691c0e75ad6e43c1cfe4a013fe80d22c2cedd41611850534fe10edb01d6e7d97c4133319f5a0159ac070f3e156b085e50a55b",
+        "dest-filename": "minipass-flush-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz#68472f79711c084657c067c5c6ad93cddea8214c",
+        "sha512": "c6e22aedc20eb74f513d1275f60762e1bf9188dbc31587b9247fa080dbc1a86aa941772bbb73dc466399b8704a58ad53c5ff7e710f8731537877acf8e8b64fec",
+        "dest-filename": "minipass-pipeline-1.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minipass-sized/-/minipass-sized-1.0.3.tgz#70ee5a7c5052070afacfbc22977ea79def353b70",
+        "sha512": "31b9104360938813250360e6ff9718fbd49614437ca73cce5e2eab94ce57c6ad18a9b75ae59432f6c53be5aebbdc513d64ad19b1bafa63988feaef6792d7e0da",
+        "dest-filename": "minipass-sized-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minipass/-/minipass-2.2.1.tgz#5ada97538b1027b4cf7213432428578cb564011f",
+        "sha256": "76e7e2fa1628a85836ca7b5f806b7c2bb1dab53ceaff5a3cb98629f7d9eb7ce2",
+        "dest-filename": "minipass-2.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minipass/-/minipass-3.1.6.tgz#3b8150aa688a711a1521af5e8779c1d3bb4f45ee",
+        "sha512": "aedcb9929c3dff3f125fd766c5b94503a79d22d526c0980c7980d946bc25215376ee2f20cac19bce7270520830d95fc556a1520dd5b2d38d193d2f35d43600a9",
+        "dest-filename": "minipass-3.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a",
         "sha512": "0f188d89dc5210afad1c6eb3388925bcd3b09b786f0ab6d4addb7363be14e87293271bc80df3942f95b93f61a17770d392184a3d81aa78d508879a9c3386017f",
         "dest-filename": "minipass-3.3.6.tgz",
@@ -7551,6 +16427,13 @@
         "url": "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d",
         "sha512": "dc59e362e7a1bfd93aa2f3846f23acc1a7420cf5f5a6209f855f2772662d1ce8ee3f0ca5556b208532e8eeb69b8c2dd1c79c43e070f1f169b5c67305ed2e6a15",
         "dest-filename": "minipass-5.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707",
+        "sha512": "a8e3b34b57014d6605e011fc7d578f0c138ef62a6d327194119c0d73f70c5a74d5da754b67b56835610f1e461ccd9034a5da00edd97a7bb14beb9f675fd4b66b",
+        "dest-filename": "minipass-7.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7569,6 +16452,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566",
+        "sha512": "591a039fffe65c1889d47e34aea6b7bc7d2da1e3f04ac19be398889d6953c926be52ee24ded6144b16b6bf52aa0222edbe5ad2cda131a92d60b64f7a03dcef10",
+        "dest-filename": "mixin-deep-1.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113",
         "sha512": "80a2dc444321b6e651c1101fa8fdd1156f932b826a029541b4e21fb55823b8006902da7184f19a0dc7ef6e136f0f407c883d6852bfedc57df936371a63a36cfc",
         "dest-filename": "mkdirp-classic-0.5.3.tgz",
@@ -7576,8 +16466,29 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e",
+        "sha256": "708366e3a89c976ae8418056f2c5f784147b9310e8093f9bb7246d2f55f7c27d",
+        "dest-filename": "mkdirp-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12",
+        "sha256": "5b1612f3e278be6dce7cada0a6591492cb249725c731e52b3ae44500808f02cd",
+        "dest-filename": "mkdirp-0.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903",
         "sha1": "30057438eac6cf7f8c4767f38648d6697d75c903",
+        "dest-filename": "mkdirp-0.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903",
+        "sha256": "77b52870e8dedc68e1e7afcdadba34d3da6debe4f3aae36453ba151f1638bf24",
         "dest-filename": "mkdirp-0.5.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -7597,6 +16508,34 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/mocha-qunit-ui/-/mocha-qunit-ui-0.1.3.tgz#e3e1ff1dac33222b10cef681efd7f82664141ea9",
+        "sha256": "b12e1a0d2e6564240ff2a0036ad08b78c6f99833abc2af36042c0ba1efee402f",
+        "dest-filename": "mocha-qunit-ui-0.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mocha/-/mocha-2.5.3.tgz#161be5bdeb496771eb9b35745050b622b5aefc58",
+        "sha256": "13ef37a071196a2fba680799b906555d3f0ab61e80a7e8f73f93e77914590dd4",
+        "dest-filename": "mocha-2.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d",
+        "sha256": "ac31a50b8f90b6d353c452d1d81cf291670d21444d0c1a96fd47e3a8079327c3",
+        "dest-filename": "mocha-3.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/modify-babel-preset/-/modify-babel-preset-2.0.2.tgz#bfa509669fe49f4222c0ce171ba44ed0e81551e7",
+        "sha256": "f1d769594eb3f7e6464535fa9c4d5292b00ad456efe27ba2eed0986437708d50",
+        "dest-filename": "modify-babel-preset-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/mri/-/mri-1.1.0.tgz#5c0a3f29c8ccffbbb1ec941dcec09d71fa32f36a",
         "sha1": "5c0a3f29c8ccffbbb1ec941dcec09d71fa32f36a",
         "dest-filename": "mri-1.1.0.tgz",
@@ -7611,8 +16550,36 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098",
+        "sha256": "75ed26e71fdd1d8747b15516c9e36459ee459a7c5653cf4ee2a6da1cdde8f9ef",
+        "dest-filename": "ms-0.7.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765",
+        "sha256": "4fdc14e963913ad66571ec3753d2169abbb41ca25f1d92b26efe46afee85e435",
+        "dest-filename": "ms-0.7.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ms/-/ms-0.7.3.tgz#708155a5e44e33f5fd0fc53e81d0d40a91be1fff",
+        "sha256": "b198dc696b23bd67661abc284ee85888d5898fa13d73850db6ecd6f467a8cc7f",
+        "dest-filename": "ms-0.7.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8",
         "sha1": "5608aeadfc00be6c2901df5f9861788de0d597c8",
+        "dest-filename": "ms-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8",
+        "sha256": "362152ab8864181fc3359a3c440eec58ce3e18f773b0dde4d88a84fe13d73ecb",
         "dest-filename": "ms-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -7632,9 +16599,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/multipipe/-/multipipe-0.1.2.tgz#2a8f2ddf70eed564dff2d57f1e1a137d9f05078b",
+        "sha256": "9d91ef41db8e98e854f9d0ace71006d6a6b7d26c0ee03e033a3f913fccc82c6d",
+        "dest-filename": "multipipe-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0",
+        "sha256": "f96fc19ff69e91905b9bd0b54605aa9589da4ab84ff6f3f636483f14f0c8bdde",
+        "dest-filename": "mute-stream-0.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d",
+        "sha512": "9e76d658e9285b252c4e32ab8600f475ccf6da67644a7a58a9b123226da787086ec654a4a72c09981a3c87466a25d929ef799bf744acb0790de2bb1168101f00",
+        "dest-filename": "mute-stream-0.0.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f",
+        "sha256": "600305681aa0bdebcffc5b89529f39bcf2d56f953b8c50f54226d0ca78ba1b84",
+        "dest-filename": "nan-2.10.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nan/-/nan-2.20.0.tgz#08c5ea813dd54ed16e5bd6505bf42af4f7838ca3",
+        "sha512": "6e4de05c16431882eeba8ffab0ab6bd034264938581cbb4d09d49d5e4f589310ff8cae97daf982cb25c1071caa6785dc9f34f260401385f5f70c21272dfea283",
+        "dest-filename": "nan-2.20.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nan/-/nan-2.9.2.tgz#f564d75f5f8f36a6d9456cca7a6c4fe488ab7866",
+        "sha256": "e99f3ea473c7f7f101389c49bfcb9d97f5aa775bb6211eb74f2fdd1eb103cd7f",
+        "dest-filename": "nan-2.9.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c",
         "sha512": "04672a30c26e4e817b8b5aedfb63d648d567588906094efc8c11b74713bf6d996764f2b60a68b641a7dfc463bfd91bd68bdb0bf850224625cc82ccb14350c80c",
         "dest-filename": "nanoid-3.3.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119",
+        "sha512": "7e9a1ed93d116c7c014c150e7ed01f04f683122d3ab9f6946a2d2613a627d6469c7374a74c4adf6ff87e5fde155f323ae2b2851d82265d2bddc061829b03aa08",
+        "dest-filename": "nanomatch-1.2.13.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7653,9 +16669,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806",
+        "sha512": "38d99152a2bbce3ec3597d03f400ded37c1bc0e059c4d01f176d0f9467c2590703dfefcc6a44a1207accab1f58c0f4dfc43745d732de2fe44666247d90630b76",
+        "dest-filename": "napi-build-utils-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31",
+        "sha256": "5dcef0ce3b2319ce23f04d3c7a14602ec291f044e0f8846ee5f33144726bc990",
+        "dest-filename": "natives-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7",
         "sha1": "4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7",
         "dest-filename": "natural-compare-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9",
+        "sha256": "214b1105689db8e4f6cc7b0df8b871db310fe7eb3ed32560ce21b5236ffae90e",
+        "dest-filename": "negotiator-0.6.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7667,9 +16704,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c",
+        "sha512": "8b26a6f1f06e094a5678a3c6a5a34c7ad12870cb77eb8aa40ac7cbf49ba18d75fa7519e0b9154e7e4d8665a0e93e370e2a289708f20d642d4673343b893ab767",
+        "dest-filename": "neo-async-2.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f",
         "sha512": "61ddd4112e665824aa47ea8d4fddd2dd4a18524a8067d94b83c6bb83dae29ac5a66062bc7154e8038fec17746bb21772577b0018c5d5526a4c60ec3e74ba4ebb",
         "dest-filename": "neo-async-2.6.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61",
+        "sha512": "00ef35bec20ed64d6c33866b77a1eeeeb7a09893753528808dad7481ce1b5f7174c1dfbdad099cb8741a1d5402608102f221579c4fa66af876dc63adef0060ba",
+        "dest-filename": "nested-error-stacks-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c",
+        "sha1": "ca86d1fe8828169b0120208e3dc8424b9db8342c",
+        "dest-filename": "next-tick-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7695,9 +16753,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/node-abi/-/node-abi-3.62.0.tgz#017958ed120f89a3a14a7253da810f5d724e3f36",
+        "sha512": "08f31c19afb2df7c6e2f51344dc348bb86326990b19e7be455a117aeca2c47717137e7d5f31bdbeccce96fb2202a57abd74a9e32413af83a7ca89869cddab7e6",
+        "dest-filename": "node-abi-3.62.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/node-abi/-/node-abi-3.7.0.tgz#ed980f6dbb6db9ff3b31aeb27d43cd9b096f6e9e",
         "sha512": "dc9f94e02bf154d124f7e94674992661b37c7083741cc4c34fd4747b35fba66a7b683e8168ab1f007c159f722f560ea9608454b90fa01d6d5e6b0aefcb09d241",
         "dest-filename": "node-abi-3.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-abi/-/node-abi-3.8.0.tgz#679957dc8e7aa47b0a02589dbfde4f77b29ccb32",
+        "sha512": "b73b9af6a5968bb896e08e36bd43ca33e49f685d2f4122c09b8c8ee49f37992c01ec67a85ab0ca0bf2bef180a760dc2a3f976ec1acdbc365fd9789bc482d9c53",
+        "dest-filename": "node-abi-3.8.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7730,9 +16802,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/node-api-headers/-/node-api-headers-1.1.0.tgz#3f9dd7bb10b29e1c3e3db675979605a308b2373c",
+        "sha512": "b9c416f926d80943dfa6bbe6cc1b278d3d37e081910765caf2b45cefc0608cd2a14dd14a800c009a05bbd386ca20199c616e3c8add06923a64777f40cebc2abb",
+        "dest-filename": "node-api-headers-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd",
+        "sha512": "f1d1b81f9ba37ef162a83995bbd7d0e5b387502d7924c8cc63f66e9afdbaa0ebef5498ccebb285f24a0258869b290d462486bdaf698c66c701abf4db74e72634",
+        "dest-filename": "node-fetch-2.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6",
         "sha512": "0c99bf0899199118ca2a3e198b806c295661dd56a5579211e6cecb5599d6fba60c8745b505f340f174ace832cc1989487791772a703bd2ebb6a9ea5c474f10aa",
         "dest-filename": "node-fetch-2.6.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-gyp/-/node-gyp-10.1.0.tgz#75e6f223f2acb4026866c26a2ead6aab75a8ca7e",
+        "sha512": "0782793357000713dce4fc1f8e16d5e61a32d833fda7c9455c04a710dea1ba05ce6bad78d7ab674d9dbdc7db12c00774a3df57348729bc30f2d6cc00131b1528",
+        "dest-filename": "node-gyp-10.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-int64/-/node-int64-0.3.3.tgz#2d6e6b2ece5de8588b43d88d1bc41b26cd1fa84d",
+        "sha256": "75993b49bd4d0e84a0dae540c4f966835e16ac9c4f82c14e6d8a5b53c9686502",
+        "dest-filename": "node-int64-0.3.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7751,6 +16851,34 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-0.7.0.tgz#3e272c0819e308935e26674408d7af0e1491b83b",
+        "sha256": "a7d69c4ff23663cbd9498eb8e45fb66f8cc69f2dec1abf285cf3917daa1cf836",
+        "dest-filename": "node-libs-browser-0.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-ninja/-/node-ninja-1.0.2.tgz#20a09e57b92e2df591993d4bf098ac3e727062b6",
+        "sha512": "c0cb56b06d90648d59e55ec67225fd388d83553d0fb834480d07dedcbdeb26c435a8dd469b741086836d6f83cc462ee0ab8072bc4218b4fc070bb61b11fe72c7",
+        "dest-filename": "node-ninja-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649",
+        "sha256": "6e30e2fc489a6f597935e3917b8ba05becdfc5e11ec606f8e450cdc3d16d01bd",
+        "dest-filename": "node-pre-gyp-0.6.39.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5",
+        "sha512": "0aacb337acfb43a68c785fe4b5c3154f38401c21297fc48e6abc29ce97fca4d058da4e7fa0cdf850795d530a7c54a23bbb172dd87c5245d26305a65e112cdcc4",
+        "dest-filename": "node-releases-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.13.tgz#d5ed1627c23e3461e819b02e57b75e4899b1c81d",
         "sha512": "b98afb277eda7bf39159d65e435c713097b736d766a8c0bf2592be81ea1f0eb90b500a4a4473ddd7cfd3c6d04e278034ffeb942258a8acdadf615eacd5bd3679",
         "dest-filename": "node-releases-2.0.13.tgz",
@@ -7765,9 +16893,72 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907",
+        "sha256": "4ab4ea4442a4849ec6ed1e420816413450334070a7e81240a70f4bd87e6cf4a4",
+        "dest-filename": "node-uuid-1.4.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nodeunit/-/nodeunit-0.7.4.tgz#c908def7f299fbe65ff7ac888782955c46aae9f8",
+        "sha256": "b6d2268f87209b99b0bdac8acf468f498a26e49878197a463d79ae740dbc6f9f",
+        "dest-filename": "nodeunit-0.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2",
         "sha1": "94a2b1633c4f1317553007d8966fd0e841b6a4c2",
         "dest-filename": "noop-logger-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2",
+        "sha512": "ea433c08b5efb96e5cad3c6c02dbdad982eb46b0da89322421e3d6b3d9a82c7a9b1564fde16a4d163c12ff975f2df1028398bf9649b0ddaa2a562771b76dd311",
+        "dest-filename": "noop-logger-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee",
+        "sha256": "426562943bfbbfc059eac83575ade5b78c6c01e5c1000a90a7defecfe2334927",
+        "dest-filename": "nopt-1.0.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9",
+        "sha1": "c6465dbf08abcd4db359317f79ac68a646b28ff9",
+        "dest-filename": "nopt-3.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9",
+        "sha256": "e460b4eb93f4f6cda338f57d8f74d85589334c5a2207e95c631adb96ae9ea9a8",
+        "dest-filename": "nopt-3.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d",
+        "sha256": "a700f2b6615e0825409dd5e83e5f200847fa84ad2b71cf083bd51b926ed5f8b7",
+        "dest-filename": "nopt-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nopt/-/nopt-7.2.1.tgz#1cac0eab9b8e97c9093338446eddd40b2c8ca1e7",
+        "sha512": "b5a336e158a28a64ff5e7b716cfc89433086fa9e0428ea600f79b11705b7f261a3554adf11140e798e040c78dd9e9b6db5f1ee1d05c5c7e9533f4f10fa62daff",
+        "dest-filename": "nopt-7.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f",
+        "sha256": "95d71abd1850913e09421b69fbe2786938299be5b616f275f8eaa8259a52465a",
+        "dest-filename": "normalize-package-data-2.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7779,9 +16970,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8",
+        "sha512": "ff908c3774f44785d38f80dc19a7b1a3eae8652752156ff400e39344eae3c73086d70ad65c4b066d129ebe39482fe643138b19949af9103e185b4caa9a42be78",
+        "dest-filename": "normalize-package-data-2.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9",
+        "sha256": "920110b8616e904bbfaaa5546a7f47ee69f3ed3e5393f52746f3618fb19702b5",
+        "dest-filename": "normalize-path-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65",
         "sha512": "e9e66ce4bb375ad0a2b075a9f52d86532f1daa4a468b80554b3dc66aa884e9ecee6f4e75d844b3b57530501e82e8829b4246363e76ff983e166288c24707302c",
         "dest-filename": "normalize-path-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129",
+        "sha512": "dace3bcb353175ec5fd4e872462e049bcde2424d1a3efc1375db45cf8867492c3d74212c2c419fe92c083bcb2cff5f52f6205be6c25a3ae4ef4c60de648d3405",
+        "dest-filename": "normalize-url-4.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7793,8 +17005,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64",
+        "sha512": "205b23d11f42ed9751e5c3fe113df8daaefbb9245db563a55a98a1e5e0be96edbdb480db3448036f3815279505bd81d68710d9e5316425a7c58a83b4a4f4230b",
+        "dest-filename": "npm-path-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f",
         "sha1": "35a9232dfa35d7067b4cb2ddf2357b1871536c5f",
+        "dest-filename": "npm-run-path-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f",
+        "sha256": "656d56148ba099836db1bc2bd397fd8a385bd63708f9bca79458217dc770e1f7",
         "dest-filename": "npm-run-path-2.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -7814,9 +17040,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa",
+        "sha1": "9225f26ec3a285c209cae67c3b11a6b4ab7140aa",
+        "dest-filename": "npm-which-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/npmlog/-/npmlog-2.0.4.tgz#98b52530f2514ca90d09ec5b22c8846722375692",
+        "sha1": "98b52530f2514ca90d09ec5b22c8846722375692",
+        "dest-filename": "npmlog-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b",
+        "sha256": "6812a94724c1379c7d57500949afa319d26baa1ee777325f472571d965770759",
+        "dest-filename": "npmlog-4.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b",
         "sha512": "dae52a6b3b8a95369223f742f00ce2714724efe22b11a3a737f7b48dddd7b6dd4a706a70c77d2fe7498bee83f2aff87d6cbdc4e1a65c715c29c0ffb95bd56392",
         "dest-filename": "npmlog-4.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/npmlog/-/npmlog-6.0.2.tgz#c8166017a42f2dea92d6453168dd865186a70830",
+        "sha512": "fef06fcf925fafd753fda15677414845ff93fd0d9606c2c437281468552ab2daacc9c99900ffede41bc52532b4be2166494c6250a4d4a655b2e6fb7eaef288c6",
+        "dest-filename": "npmlog-6.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/npmlog/-/npmlog-7.0.1.tgz#7372151a01ccb095c47d8bf1d0771a4ff1f53ac8",
+        "sha512": "b89d18164fe6090a4b06df9bc4df3c00a77e832a99bd90dbb6237193a59aa9c8f668f4727d5c7c2136b09324329f151a8089e37584f5faa8f835f039289254c6",
+        "dest-filename": "npmlog-7.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7835,9 +17096,79 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d",
+        "sha256": "896ec5dd2269a0f219b0e46dd24b5532cdfd1648f1e5156078854b912d619f3c",
+        "dest-filename": "number-is-nan-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nw-gyp/-/nw-gyp-3.6.6.tgz#0231d603d09665053ea48843d6888d13a4b92fb1",
+        "sha512": "15e327a45416b4410c27506b49f2b74fad828eec5a365d26347a9daf115c205e5741d0b781a6585b89feefb9502e4f0f1375297e49e497d551a3a803289207b8",
+        "dest-filename": "nw-gyp-3.6.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7",
+        "sha512": "87601ab5dc181fe247899a6fee9b7f8125f55e84466fb2ffa9221ebaa03a1b062817dc35bcfd5cc38d933b4688da9372b2144ae7cf7784d4a5fb5fffbc72bb85",
+        "dest-filename": "nwsapi-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.7.tgz#738e0707d3128cb750dddcfe90e4610482df0f30",
         "sha512": "b9be44e3e1413cac00671d14c0840e8d85861d312ae6c3ea1d035137c67d7b803bbb74e3d7078b26c2f9f721fdbe6bea12d04768e993e9c61028864ec69df915",
         "dest-filename": "nwsapi-2.2.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nyc/-/nyc-11.4.1.tgz#13fdf7e7ef22d027c61d174758f6978a68f4f5e5",
+        "sha256": "371428ed99f32475f291847996fe3c19c6a98e3f3aa801f37f03b840ea72063f",
+        "dest-filename": "nyc-11.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nyc/-/nyc-14.1.1.tgz#151d64a6a9f9f5908a1b73233931e4a0a3075eeb",
+        "sha512": "388d2f9ba646527a0666ffed2dd6767ac495cc3c140bcf1236cfba26848e315c40fa028c07c4e4ee307081e98bc783b8d25861bd9095c350be3982ce04e3d75b",
+        "dest-filename": "nyc-14.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.6.0.tgz#7dbeae44f6ca454e1f168451d630746735813ce3",
+        "sha256": "c65cb1a7171fd76431924441157ed6def7f417082167531f5be8ad4815b0ca40",
+        "dest-filename": "oauth-sign-0.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43",
+        "sha256": "231d83cb7925718cae32662f274a4c753644b45e1a4f90f3844f7ce234a37eba",
+        "dest-filename": "oauth-sign-0.8.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455",
+        "sha256": "0016af1761003d0c45eb7bdc965561b518c1c1c6b8885d4967fd1ab4afa0d9bc",
+        "dest-filename": "oauth-sign-0.9.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2",
+        "sha256": "de389d90b75f4f48b1692d1bfecd445165bce463858962222a515253c102ac59",
+        "dest-filename": "object-assign-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0",
+        "sha256": "1668347179346d6d742f3894e5436f8e0b6c1a7f135bd0a4e79c17d0991d693c",
+        "dest-filename": "object-assign-4.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7850,8 +17181,22 @@
     {
         "type": "file",
         "url": "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863",
+        "sha256": "782d726a263ba7b26cced612af97b80035516df4b0cd788524e7b2cebc4e29ed",
+        "dest-filename": "object-assign-4.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863",
         "sha512": "ac98134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52",
         "dest-filename": "object-assign-4.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291",
+        "sha256": "a572129322f0da49d174dd1f074b70f8ef20a9084cefe93eaa5442e854d6af95",
+        "dest-filename": "object-component-0.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7884,6 +17229,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b",
+        "sha512": "189cdf059e838030269ee68cdf5d388d1e2cd4ccb1af7637cdf232378cf751da8debda1245a70d2bc5219e86c3742fbb2760070a31b0c50b9b3497c4ef44975d",
+        "dest-filename": "object-inspect-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67",
+        "sha512": "6bba441dd875c4a200813c9250680b331ff1c0366c90dd5477a7a061837711d456e1930f3440d44c5fa1c32d8b502f8197e4b22d700d9f0cff8f287faaeb4a53",
+        "dest-filename": "object-inspect-1.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6",
+        "sha1": "0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6",
+        "dest-filename": "object-is-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e",
         "sha512": "36e00449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c",
         "dest-filename": "object-keys-1.1.1.tgz",
@@ -7894,6 +17260,13 @@
         "url": "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb",
         "sha1": "f79c4493af0c5377b59fe39d395e41042dd045bb",
         "dest-filename": "object-visit-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da",
+        "sha512": "7b11c97aaea404a8f9f26a86c9343d0c5beb642fde47a3b0c73a0cf58468181aab5d8a27685c8688532e73d559ad77fb0daaeb784c0ca6eac6ddd77e08dc96e7",
+        "dest-filename": "object.assign-4.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7954,6 +17327,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa",
+        "sha256": "9aff227cc24ca40f1c928197ab0b010caa791eb39be2cebeb60bd7279d84d2ff",
+        "dest-filename": "object.omit-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
         "sha1": "87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
         "dest-filename": "object.pick-1.3.0.tgz",
@@ -7964,6 +17344,13 @@
         "url": "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a",
         "sha1": "e524da09b4f66ff05df457546ec72ac99f13069a",
         "dest-filename": "object.values-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object.values/-/object.values-1.1.0.tgz#bf6810ef5da3e5325790eaaa2be213ea84624da9",
+        "sha512": "f267f49ca2c0a055fa5653557611a3df549562968d16d527ba83975b2144b2db1646053cdfb00af8960cd22031c244b31916f09fc71b16681bcb18f58f855b5e",
+        "dest-filename": "object.values-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7982,9 +17369,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/observable-to-promise/-/observable-to-promise-1.0.0.tgz#37e136f16a15385ac063411ada0e1202bfff58f4",
+        "sha512": "72a9c652b36c13abdd5434cf017f7f59e573c32ff3dfbbddc6ea5d41753cbe04d74451fbd8a09989981af1a71adae9513c879e9bc5b7bd6f6b4070707c897658",
+        "dest-filename": "observable-to-promise-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947",
+        "sha256": "a9640d8669cd8de27158f39364a8ef98296b15e4eca861a9214f81e98696616b",
+        "dest-filename": "on-finished-2.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f",
         "sha512": "a15973920dc4340842936cddbfb209c1dfd0503e33d91c51c2991c198f29b0255c09864dab8c189d55802c733e6ebb6e26378f5a2605fc2966b83afc0a1e7e92",
         "dest-filename": "on-finished-2.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7",
+        "sha256": "6dd7b2cc5d0a216dacb847ef96cfdefbcd9ade76eee3fbd67d21927df14d7b74",
+        "dest-filename": "on-headers-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20",
+        "sha256": "8ac84fb4ee8df51cc2605a32f248d834aa489ed79b0e3290b37b794c776da9a6",
+        "dest-filename": "once-1.3.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7996,9 +17411,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf",
+        "dest-filename": "once-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45",
         "sha512": "e435ce8912b0b9211c43f974906085e90de37000c5bf9b52991689724fceaa454570eceeb41d77e0a4527c5d310eb2f7f4c367ab16c705b51472364885381bda",
         "dest-filename": "one-time-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789",
+        "sha256": "cf1994153a4fe1fff2090fa34e54fccf198d1380052925142d3ad23f1cb1651a",
+        "dest-filename": "onetime-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4",
+        "sha1": "067428230fd67443b2794b22bba528b6867962d4",
+        "dest-filename": "onetime-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5",
+        "sha512": "e4d71290f1e1c1354521037e4d4a97a12e7e7651251d7769016bbd2341cfdb460eb488be699d02b7cda376520b0f18cb1005b0be6faa8f59ba684b6c0d59a6e9",
+        "dest-filename": "onetime-5.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8017,6 +17460,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/oop/-/oop-0.0.3.tgz#70fa405a5650891a194fdc82ca68dad6dabf4401",
+        "sha256": "329884659eca508971d922946c07fcb904aed4b4e68c52aaa4fbea5b2db645d7",
+        "dest-filename": "oop-0.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/open/-/open-0.0.5.tgz#42c3e18ec95466b6bf0dc42f3a2945c3f0cad8fc",
+        "sha256": "f5e85c2037b9355b7acbdc7459030027555bf08b01cb6d4db6712655dd39060a",
+        "dest-filename": "open-0.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321",
         "sha512": "3151dd743570797645ddac2d9404beea980a2e59bf260c59f74fbf341bab06841cb5538e07fcc37558dcc8fcd0fb495a0c66ec5a0ad191f948eb9b1078e813f5",
         "dest-filename": "open-7.4.2.tgz",
@@ -8031,9 +17488,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8",
+        "sha256": "3641d8e77a36dfdebb65be9b0cbde26dcd63d82b23e77c9c4dd066cd04a4a6a7",
+        "dest-filename": "opener-1.4.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598",
         "sha512": "babe5421dcb0e58ef2123f702f386a5e2cba199dccc31d32188fb9b0c9f6af4374bf770a26f526147e723cff965e1f5ed317f2cf2257f790fc974f3c0cd163ec",
         "dest-filename": "opener-1.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686",
+        "sha1": "da3ea74686fa21a19a111c326e90eb15a0196686",
+        "dest-filename": "optimist-0.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686",
+        "sha256": "56425fd38177f312912848ff242a684e0c69a03a4c370f49269e1411e031a1a5",
+        "dest-filename": "optimist-0.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/optionator/-/optionator-0.5.0.tgz#b75a8995a2d417df25b6e4e3862f50aa88651368",
+        "sha256": "8ecd554006a55223812d83c7cb0084fcb6ead85bc27fedc4e6077ad849ac21d9",
+        "dest-filename": "optionator-0.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/optionator/-/optionator-0.6.0.tgz#b63ecbbf0e315fad4bc9827b45dc7ba45284fcb6",
+        "sha256": "cb0011d73591e856ac65ac5c1f7894fa8b80049974c7ffac808f846d39ca5981",
+        "dest-filename": "optionator-0.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64",
+        "sha256": "cf995ea05edbf5f9f9659d97e1dd8f132a821ea6999f3d35b067e3774b02a61d",
+        "dest-filename": "optionator-0.8.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495",
+        "sha512": "f885bda4009d9375d69a64d71bc9b7ba919426cb795d11b3c4c4635f302e2755e720536f7e18e322e6240efcac9cf43bab3a95ccbb7bf010abba7b6a4615906c",
+        "dest-filename": "optionator-0.8.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8045,9 +17551,121 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f",
+        "sha256": "be210071b7379743c05248d3aa918ae91fde9c648c1d554fabc0ce45015ec9f2",
+        "dest-filename": "options-0.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ora/-/ora-3.4.0.tgz#bf0752491059a3ef3ed4c85097531de9fdbcd318",
+        "sha512": "78dc07b9d35b3b57e89413f726c675f6ff5acd75ad4198c809daf74344c33c869e050de65cbae1e78c0cf9eaf4fa14a9f9d58a7fe67c28ce7c098cc4c8863162",
+        "dest-filename": "ora-3.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/orchestrator/-/orchestrator-0.3.8.tgz#14e7e9e2764f7315fbac184e506c7aa6df94ad7e",
+        "sha256": "ea5be5e9e396c6bb17dc9f56233f640e66e29abd34ba5e7484ae1fe60baf53d2",
+        "dest-filename": "orchestrator-0.3.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz#fd565a9af8eb4473ba69b6ed8a34352cb552f126",
+        "sha256": "1378e84d68005373510560ada20813bc2b84727eac2d56421519eaf21eaf7655",
+        "dest-filename": "ordered-read-streams-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/original/-/original-1.0.0.tgz#9147f93fa1696d04be61e01bd50baeaca656bd3b",
+        "sha256": "49da8d0374c2328dbc9d7fe388343131b604680e51feb9ef4086f9001c722ef8",
+        "dest-filename": "original-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f",
+        "sha256": "3881aacbedfa1ea8b8419c4d502a3787f2da91b9a7dc282d7e02a868559aefa5",
+        "dest-filename": "os-browserify-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3",
+        "sha1": "ffbc4988336e0e833de0c168c7ef152121aa7fb3",
+        "dest-filename": "os-homedir-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3",
+        "sha256": "0ee885c8afec352b70b7b65f7ab8e54a912f8ba4c309ae1c106aa4b67cb24475",
+        "dest-filename": "os-homedir-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2",
+        "sha256": "a1dd0708b2b7bc893de98a70cbf7668b5e98639de2a47b2f004c9b91476c5674",
+        "dest-filename": "os-locale-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274",
         "sha1": "bbe67406c79aa85c5cfec766fe5734555dfa1274",
         "dest-filename": "os-tmpdir-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274",
+        "sha256": "13e722c2d777c084983e2e1e1150a496aa25685791a71244e61a605ec892ad89",
+        "dest-filename": "os-tmpdir-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410",
+        "sha256": "7d19469a119cf35262531ed0729a67a0eacb55baea57f257e7f2801341516448",
+        "dest-filename": "osenv-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410",
+        "sha512": "d0259c08409d315736470dd4e70f598ea5fa81aeae6e4d710d52b1b4140f2bbc22b3fd05dabf53ea4e3274662179c97b614071055c612f9a22b0fb0dc403deda",
+        "dest-filename": "osenv-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-1.1.2.tgz#d0a33eefe61a205facb90092e826598d5245ce76",
+        "sha256": "20f4bb4307241ed130460d0bf6fbba7489e8f698becc3cdcbe4dc000a78eb51d",
+        "dest-filename": "output-file-sync-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/own-or-env/-/own-or-env-1.0.1.tgz#54ce601d3bf78236c5c65633aa1c8ec03f8007e4",
+        "sha256": "01983a5903b65def844fa40b3a6b8c02618a5fbb23a6fd11255a5b9c3df3353f",
+        "dest-filename": "own-or-env-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/own-or/-/own-or-1.0.0.tgz#4e877fbeda9a2ec8000fbc0bcae39645ee8bf8dc",
+        "sha256": "70cbdd2a72e380ba53dc05d1ce4575dfcf1f8d04574ae901e976936611513dd6",
+        "dest-filename": "own-or-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc",
+        "sha512": "b3bdd7c4e678ce9b7579d658673be1a856babaf41cd6fc146b42b405db4866040c0098fd21b79b1fe26480a65cf61f81d393ca1cb3939786a31b506636b55997",
+        "dest-filename": "p-cancelable-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8073,6 +17691,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae",
+        "sha256": "effd84e09e1330542a84a243f1f4da21a700d459b83761eaca16070eb1fb8841",
+        "dest-filename": "p-finally-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e",
         "sha512": "6375b4c2544f2bc64c45b36af7b978339a2d8a8780e659b5cfb6e4364c4291af0748f8d1d314569a90a673dbad89a2cff496f5783f0181e2314d6e00205e393e",
         "dest-filename": "p-is-promise-2.1.0.tgz",
@@ -8087,6 +17712,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c",
+        "sha256": "893b57bd69a090311445b16d732e17bb6180ca1c8dea49e72041820b5267d78b",
+        "dest-filename": "p-limit-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8",
+        "sha512": "bef717b0b009f43af9ad038f93bb68650649029065d8ae09e9d00d4ac12e87a408e3525872c4bfaa14c66bd12b2145202b758d428258bf2971be3aa68aa100f5",
+        "dest-filename": "p-limit-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2",
         "sha512": "a596d3269a14b02cd5e3c31cf4d879d556f03b45fd72e3c513c818c31f414c2b7d485f3f6fb6658ddd9f5603b184817f1c34ca829573b3e18f87229f8cb2c545",
         "dest-filename": "p-limit-2.2.0.tgz",
@@ -8094,9 +17733,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537",
+        "sha512": "f394e4fbdd140955af6c36af08b28f38b0bdbef63c3b0117fd1b4a17eff53800c93159457c41ce88c4cf572c60ee693f74a6be8a97479b4394913bc2a4c4eec2",
+        "dest-filename": "p-limit-2.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e",
         "sha512": "58647ec4779c293afb11b5048722d28790ee6def49b5d886efcb9f69e2f14e0a6e75fff6d0aab2322a085192407b3953222e9ebf1ba852cf585dcd75714fb2cd",
         "dest-filename": "p-limit-2.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1",
+        "sha512": "ffff3c985592271f25c42cf07400014c92f6332581d76f9e218ecc0cbd92a8b98091e294f6ac51bd6b92c938e6dc5526a4110cb857dc90022a11a546503c5beb",
+        "dest-filename": "p-limit-2.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8115,6 +17768,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43",
+        "sha256": "07c74b4f9a9800bf5b4eb14775b34a460ca83c25b6d1558e9dabf33a8f2afb46",
+        "dest-filename": "p-locate-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4",
+        "sha512": "c7ed76c3f4e8fb81857e0261044a620dc2e8cd12467a063e122effcf4b522e4326c4664dc9b54c49f5a3f5a267f19e4573b74150d24e39580fbf61fb230ba549",
+        "dest-filename": "p-locate-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07",
         "sha512": "47bf5967fd30031286bb7a18325cfc8f2fe46e1b0dad2ed2299ecfc441c1809e7e1769ad156d9f2b670eb4187570762442c6f3155ec8f84a1129ee98b74a0aec",
         "dest-filename": "p-locate-4.1.0.tgz",
@@ -8129,6 +17796,34 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175",
+        "sha512": "cb76fc2a977c380378e388717c16c57e3d4563f463b5377cb73630854a8d617c747d7c76897e2668fe10afaaa120a6d05c8d36c132c075ae1f6146c36a04d417",
+        "dest-filename": "p-map-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b",
+        "sha512": "fdb8ceaa68044c1601e41a0478655e6bc766bc76f69bd18bcb513d5b8df27b27cfe9040264614d6be5d171e244b8307aceaafe80aa4802694b79b329ca4c3f31",
+        "dest-filename": "p-map-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3",
+        "sha1": "cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3",
+        "dest-filename": "p-try-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3",
+        "sha256": "99fed4a8c1a77b52c3ca3fed495182ec87b98f82125161ee56bfe359c40254de",
+        "dest-filename": "p-try-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1",
         "sha512": "84ca74a270ca21a8c77c891d464dcfe02742984ae4600c710ed3f75b1ff89d9dda1a56aed952a1de666972e1641f6ed64242ffdd60423ce92dcc0f593809cc41",
         "dest-filename": "p-try-2.0.0.tgz",
@@ -8139,6 +17834,55 @@
         "url": "https://registry.yarnpkg.com/p-try/-/p-try-2.1.0.tgz#c1a0f1030e97de018bb2c718929d2af59463e505",
         "sha512": "1f6472209efe037ae3930282da5e461ad5381f5be4c4a0801ac59ab0d55dd127adfba8b8ce7c5b5b2ebf8f5e980cf2435b186c81988a02cb4c10ff3009d4a98c",
         "dest-filename": "p-try-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6",
+        "sha512": "4789cf0154c053407d0f7e7f1a4dee25fffb5d86d0732a2148a76f03121148d821165e1eef5855a069c1350cfd716697c4ed88d742930bede331dbefa0ac3a75",
+        "dest-filename": "p-try-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/package-hash/-/package-hash-3.0.0.tgz#50183f2d36c9e3e528ea0a8605dff57ce976f88e",
+        "sha512": "94eb66ba430356fb642fce2b24723b7694d8abed2b962f0ddb0967a94701b835827d585151f3a69d1f52b281c530ba400af115eb4757eeb774ac56980d923e14",
+        "dest-filename": "package-hash-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/package-hash/-/package-hash-4.0.0.tgz#3537f654665ec3cc38827387fc904c163c54f506",
+        "sha512": "c217643c8a284aefdb01282067de81595bd94d130e1719f2506e4f9d34862a8244da077999b54d991d8d8f6d10173c58620017a68a82f80897ce5f9431187bcd",
+        "dest-filename": "package-hash-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed",
+        "sha1": "8869a0401253661c4c4ca3da6c2121ed555f5eed",
+        "dest-filename": "package-json-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/package-json/-/package-json-6.5.0.tgz#6feedaca35e75725876d0b0e64974697fed145b0",
+        "sha512": "9376dd9b69f6e6d932c5c8d22b3079c7c91f57194c760b1b3ebd069197301ec2e96dae9c063a82b752a570284a12fc4721c4c1d4554cbb0a228d9dbac5ec7931",
+        "dest-filename": "package-json-6.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/package/-/package-1.0.1.tgz#d25a1f99e2506dcb27d6704b83dca8a312e4edcc",
+        "sha256": "ac690349429d4db7876f62a94b0c69dfab4c83321a6c4d7397c4061303c5a3a6",
+        "dest-filename": "package-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75",
+        "sha256": "4a9319f1b7d155022ae088ff67d4bb739f81d29c8f82b7e6bde6bce461c3cd9f",
+        "dest-filename": "pako-0.2.9.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8178,9 +17922,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-1.0.1.tgz#159d6155d43904d16c10ef698911da1e91969b73",
+        "sha256": "74bde9b6bdb288807a850ec1a164805aa7ffbf113b641c98a94aadc3de0e667b",
+        "dest-filename": "parse-filepath-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c",
+        "sha256": "b0764545e030134c4bd7322c0c43b817416c427e98b92a698a84b6f91d5746de",
+        "dest-filename": "parse-glob-3.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9",
         "sha1": "f480f40434ef80741f8469099f8dea18f55a4dc9",
         "dest-filename": "parse-json-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9",
+        "sha256": "8bb1291c36fff54df555487976888dad81666a05291e6b6ddc5d2dc74d9f6ed5",
+        "dest-filename": "parse-json-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0",
+        "sha1": "be35f5425be1f7f6c747184f98a788cb99477ee0",
+        "dest-filename": "parse-json-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8192,9 +17964,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d",
+        "sha512": "907b7b9332e84bd54165f52c88a8efe379abf7579af94d391322a412daa9eef35b1f199a56e12a37b5f17845671ab32d60e0311ab0c49528bde8aec480ed7308",
+        "dest-filename": "parse-ms-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6",
+        "sha256": "dcd6323a1511c012304cf77a7c7a86b3ef0d85ad4c3530d33b7e1735d5d289f3",
+        "dest-filename": "parse-passwd-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b",
+        "sha512": "39f9ff0931734464d3c70a4d12cf4f3fdde05d2847713ab6e799f345848a7bc024569658eded5fa664df3b2a08be33f91c6ed9d9933b552f4f3e14065b6a4ea7",
+        "dest-filename": "parse5-6.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz#0736bebbfd77793823240a23b7fc5e010b7f8e32",
         "sha512": "0b38f559a495a5aa23d306e13332e6583ebd6a7a76587ec55cc07d9f54b2f3f64517d8e895241532ed488f9588c8699c066864ec43a77693b8988a62855a805f",
         "dest-filename": "parse5-7.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parsejson/-/parsejson-0.0.3.tgz#ab7e3759f209ece99437973f7d0f1f64ae0e64ab",
+        "sha256": "04004802c6bfa78db649eea0eaee35344f66b4c8bbb477cf5531b70a16896625",
+        "dest-filename": "parsejson-0.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz#d5208a3738e46766e291ba2ea173684921a8b89d",
+        "sha256": "f2767d4ee289349508759f351f895ced76e2a14c4394a6a19ff22fc9671326b4",
+        "dest-filename": "parseqs-0.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.5.tgz#80204a50d4dbb779bfdc6ebe2778d90e4bce320a",
+        "sha256": "e0413c7762bb405c8c2ac641476f77f404ef6aa4e6317d9db60ab7f46c312c3f",
+        "dest-filename": "parseuri-0.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3",
+        "sha256": "efa980cc77ab05b3bec372855209c51dcdf618640780938b16e0684981707e93",
+        "dest-filename": "parseurl-1.3.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8227,8 +18048,43 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/path-array/-/path-array-1.0.1.tgz#7e2f0f35f07a2015122b868b7eac0eb2c4fec271",
+        "sha1": "7e2f0f35f07a2015122b868b7eac0eb2c4fec271",
+        "dest-filename": "path-array-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a",
+        "sha256": "0b5e658c29cd602879ea50a9edae38e392fe8de5a5600da39be114f69dd0d2f5",
+        "dest-filename": "path-browserify-0.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0",
+        "sha1": "cc33d24d525e099a5388c0336c6e32b9160609e0",
+        "dest-filename": "path-dirname-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
+        "sha256": "fa338f850c34beea601a2680566bbcf095611f003934b47f0e71deb2c06aa889",
+        "dest-filename": "path-exists-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515",
         "sha1": "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515",
+        "dest-filename": "path-exists-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515",
+        "sha256": "d7f78752dc75e2f8a3a232b064fd099330334997413ded8296c7ad5d8d06322d",
         "dest-filename": "path-exists-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -8248,8 +18104,36 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+        "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c",
+        "dest-filename": "path-is-absolute-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53",
+        "sha1": "365417dede44430d1c11af61027facf074bdfc53",
+        "dest-filename": "path-is-inside-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53",
+        "sha256": "88ef3e87ca1c89673a00c9a1ef3a2b0ebd7248f9911d2183527fcf7215a24d9d",
+        "dest-filename": "path-is-inside-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40",
         "sha1": "411cadb574c5a140d3a4b1910d40d80cc9f40b40",
+        "dest-filename": "path-key-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40",
+        "sha256": "ee71986a430792b5bf7e0c398355215b534d3eaec9cde73879db69fd58b14ef0",
         "dest-filename": "path-key-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -8269,9 +18153,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1",
+        "sha256": "7bcf82ceab94ec610b0242df2e33f132c8d0595ae7122bf8e72fc1fd23cadc03",
+        "dest-filename": "path-parse-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c",
+        "sha512": "19298e4f611b1eb20d05ff5247b08310bc2527c004364dd09fb3a290ae2715802edceb5edbe258355be4a401109b7fd32cd109143ff16498f3cb183728158ecf",
+        "dest-filename": "path-parse-1.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735",
         "sha512": "2c32733d510410f47ecb8f33f7703411dd325dbf29001c865a8fe4e5861d620a58dbfd84b0eb24b09aeaee5387c6bcab54e9f57a31baa00a7c6a1bce2100fcb3",
         "dest-filename": "path-parse-1.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-root-regex/-/path-root-regex-0.1.2.tgz#bfccdc8df5b12dc52c8b43ec38d18d72c04ba96d",
+        "sha256": "a54ce961c3510932daed7d04cdbdf3dca4767b4248adc0438af1669c04e211af",
+        "dest-filename": "path-root-regex-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7",
+        "sha256": "8d8e8f8814faa9e5ee92f47d418a7efe17525c03317fa8f1254359d29d7ab283",
+        "dest-filename": "path-root-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2",
+        "sha512": "5dae0dc35ec54bd02940527dba62e2252e28ac68e6ed9cf052bc1a99c190b874b30f2b61f5ba0a0dac9c61d0dc643baa6004d7c381c55e06aa59372d5bfbf51c",
+        "dest-filename": "path-scurry-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8283,9 +18202,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c",
+        "sha256": "de5462f169a8975b74b0fbb63bd6a4de62516a60f9de7075b5cd3fa882c98f36",
+        "dest-filename": "path-to-regexp-0.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441",
+        "sha256": "c6910e17a214f4edb0f4b04f6f9c74300d4bf2d587756eafdade29d33d9fb13b",
+        "dest-filename": "path-type-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73",
         "sha1": "f012ccb8415b7096fc2daa1054c3d72389594c73",
         "dest-filename": "path-type-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f",
+        "sha512": "4f6654b1d6451e0037bb87b93df3db8ddec70c3a713e741be633744ab0ec8cd4ae5571c9aadc139d6a86d01d6366b82627fee58f51265480725add60c46916be",
+        "dest-filename": "path-type-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8297,9 +18237,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d",
+        "sha256": "d37b84046db0c28c9768be649e8f02bd991ede34b276b5dba7bade23b523235e",
+        "dest-filename": "pause-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz#b6e0c8fa99494d94e0511575802a59a5c142f288",
+        "sha256": "ea539b5726c652c017510472a60fcabb2ece47466806341c7c02f1b578bcf2c6",
+        "dest-filename": "pbkdf2-compat-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50",
         "sha1": "7a57eb550a6783f9115331fcf4663d5c8e007a50",
         "dest-filename": "pend-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50",
+        "sha256": "a12f279b25a9df710b52a9892bad00bdeeb862a9b5d1e4f4db77131129436d7f",
+        "dest-filename": "pend-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5",
+        "sha256": "41193d639761077b384832fa53a3d9e4d36008afe7588894ff80059fda75de08",
+        "dest-filename": "performance-now-0.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8311,9 +18279,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b",
+        "sha256": "068f99ddeff11741bd1ebbbe3ee4c6f782731bd9ae0a2d598536cce74e289045",
+        "dest-filename": "performance-now-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz#efd212a4a3966d3647684ea8ba788549be2aefef",
+        "sha256": "b01b1769405da5df6c3be9ea39398c71f4e6f7b7b41ddeee317209ace38f3969",
+        "dest-filename": "phantomjs-prebuilt-2.1.16.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c",
         "sha512": "d5fca0ae84cb947bbaeb38b6e95a130eff324609b415c71e72cb2da3e321b19d03fc3196dac9bc13c0235bb354e5555346de46c5b799e6a06e26bf87c8b6248d",
         "dest-filename": "picocolors-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.1.tgz#ecdfbea7704adb5fe6fb47f9866c4c0e15e905c5",
+        "sha512": "398332aa42b32bb6e558effe5d960feb0f211f42c3be406f76f2ae92d8beee4a98142884024fa02370d69ebc9aa5cd036aed39ba0193cb47e843a9aa9f800760",
+        "dest-filename": "picomatch-2.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8339,9 +18328,93 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c",
+        "sha256": "74a52c931eea5d226f6a04deb6e138f1a9896abcc64fc1c597f83d19a7b20530",
+        "dest-filename": "pify-2.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176",
+        "sha1": "e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176",
+        "dest-filename": "pify-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231",
+        "sha512": "b81f3490115bfed7ddebc6d595e1bd4f9186b063e326b2c05294793d922b8419c86914d0463a9d252b082a438fe8e00815b8fb18eadcb9d739a4d8d9fa0795da",
+        "dest-filename": "pify-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa",
+        "sha1": "2135d6dfa7a358c069ac9b178776288228450ffa",
+        "dest-filename": "pinkie-promise-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa",
+        "sha256": "92b6c810617351cb03c62b39fa6241003e5da043074561448b9f08ff4f93ad14",
+        "dest-filename": "pinkie-promise-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870",
+        "sha1": "72556b80cfa0d48a974e80e77248e80ed4f7f870",
+        "dest-filename": "pinkie-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870",
+        "sha256": "79a858c25e63ade9eb3e65b2aa2a491cc9e1d2fe671c0168f9291b3ba7da3d83",
+        "dest-filename": "pinkie-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b",
+        "sha512": "f15f7e1d03eea67697300db773986f97af735ef4f04f3c8061ab2791bd13b6ce17bcee02962a8e34c3a7be5ab6eab9212c2de758314125fef72d4d5ed5564b69",
+        "dest-filename": "pirates-4.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9",
         "sha512": "b1a2ec1fb59e6183e20f6e4b0ee2d1458fe2fba1da3d8afa1b539494ddfda2dce4493c4a9ee6d1f514f14b7fca939d2cd60d894e01705900d0ca9942e7f48766",
         "dest-filename": "pirates-4.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pkg-conf/-/pkg-conf-3.1.0.tgz#d9f9c75ea1bae0e77938cde045b276dac7cc69ae",
+        "sha512": "9b43936d1ff954f34fa8ed6987a16a6e3ec7bfa414ee047fb505b8d19aab2f5ae380253ce56e82d5b267d0122db89aa747df0f5b3c3b67c847782843d56ae075",
+        "dest-filename": "pkg-conf-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4",
+        "sha256": "862c533c020b507154c4714e615e4809ca8dbe8f1854eded17e6592c295555b3",
+        "dest-filename": "pkg-dir-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b",
+        "sha1": "f6d5d1109e19d63edf428e0bd57e12777615334b",
+        "dest-filename": "pkg-dir-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3",
+        "sha512": "fc4e7b018928790db9aa4c4c8f93c1395805f0a8aefe1edc612df4679f91ed66a208205f2eae7c648fdd49e68429bf565495799ffd37430acddc8796205965bf",
+        "dest-filename": "pkg-dir-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8353,6 +18426,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.2.3.tgz#7239c42a5ef6c30b8f328439d9b9ff71042490f8",
+        "sha256": "0685c2cd94db8515a95b8127d1ab4e2a82d37deb4f808b41c9e0c033e34fe77f",
+        "dest-filename": "pkginfo-0.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff",
+        "sha256": "be42fb1f557824e0feae25c5c25b4948ae974af4e4a7d032522a55fbc77b1a28",
+        "dest-filename": "pkginfo-0.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/plist/-/plist-3.0.6.tgz#7cfb68a856a7834bca6dbfe3218eb9c7740145d3",
         "sha512": "5a2215632ae9f130f8c3cc82bf2788afe9649ab191779bb455b46753eb4ffda44bc4ffd869d25460e31927fea121ade8532542b32717bed35181de5704921b88",
         "dest-filename": "plist-3.0.6.tgz",
@@ -8360,8 +18447,29 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/plur/-/plur-2.1.2.tgz#7482452c1a0f508e3e344eaec312c91c29dc655a",
+        "sha1": "7482452c1a0f508e3e344eaec312c91c29dc655a",
+        "dest-filename": "plur-2.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/plur/-/plur-3.1.1.tgz#60267967866a8d811504fe58f2faaba237546a5b",
+        "sha512": "b75031f0a52f577145208f25b5cccf9f6b49763a9b775b08ceeeade092fb9d0dc4c9e2ff953ae3e4f58a6f4ea2739ffa5d80ebeb9ad0e2ecd010637bd3fe97e7",
+        "dest-filename": "plur-3.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45",
         "sha1": "d1a21483fd22bb41e58a12fa3421823140897c45",
+        "dest-filename": "pluralize-1.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45",
+        "sha256": "7237b0f5b656dffe17994e2f98d2591231ea190046b440a41bc0aad2e482f130",
         "dest-filename": "pluralize-1.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -8451,6 +18559,34 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.2.tgz#a5fd9986f5a6251fbc47e1e5c65de71e68c0a056",
+        "sha512": "5273647b72106fab206ab71920353781b31e4e9ffd4925350c02248a5ecfaea1b5bd9941b58e66b1871c48a4870ea6b784d838dfa2172be48d22645eb80d7011",
+        "dest-filename": "prebuild-install-7.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/prebuild/-/prebuild-13.0.1.tgz#6e554d9e1b232044d4a26115ef8c8e088ad85d25",
+        "sha512": "011f99a057c6daa40ce620ad34d05696e7aece505641d7a253e7c117b6706d6db0e69ff6129d7edc6e00b40ca6acc7d99f4ca0dc3a05fb10a8ae1e611ce258fd",
+        "dest-filename": "prebuild-13.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54",
+        "sha1": "21932a549f5e52ffd9a827f570e04be62a97da54",
+        "dest-filename": "prelude-ls-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54",
+        "sha256": "fafd8fe4dcc778c2711cdd371f8fd46418b39b90e30a1d4ae5860f4513e65b57",
+        "dest-filename": "prelude-ls-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396",
         "sha512": "be47033eb459a354192db9f944b18fa60fd698843ae6aa165a170629ffdbe5ea659246ab5f49bdcfca6909ab789a53aa52c5a9c8db9880edd5472ad81d2cd7e6",
         "dest-filename": "prelude-ls-1.2.1.tgz",
@@ -8458,9 +18594,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc",
+        "sha1": "d4f4562b0ce3696e41ac52d0e002e57a635dc6dc",
+        "dest-filename": "prepend-http-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897",
+        "sha1": "e92434bfa5ea8c19f41cdfd401d741a3c819d897",
+        "dest-filename": "prepend-http-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b",
+        "sha256": "294f5aa92d40d6a7049bafd6e29b81fbd8aa3a5b9b3e26a4816b75155a309382",
+        "dest-filename": "preserve-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b",
         "sha512": "19b2b670ff67ada492505f4dd97c14c2a7f394016530d61897e4a113f57e1fc6bdb8d97fa14a81d70d842f9e098743a5c9149df117d6609ddca154b84d138fdb",
         "dest-filename": "prettier-linter-helpers-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a",
+        "sha512": "bc165c3d1511e4c649c28ca2dd9a32425735ad7784724f0a81e0bd030c0e9fe7b1bb12f1ab9b684d10d349a56b5c7c5e943307cbdce589cc3cbbaeb2c6849416",
+        "dest-filename": "prettier-2.5.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8475,6 +18639,13 @@
         "url": "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643",
         "sha512": "2ffe2950333170d6bc47f12d855d3c66de365813b8875adaad5b4ad0af90246d17d7cece2e8ee5ebdf635b0d062aec3390f43ffe330503ff179ba161dc9fc302",
         "dest-filename": "prettier-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-1.0.4.tgz#0a22e8210609ad35542f8c8d5d2159aff0751c84",
+        "sha256": "b10e09e975fa6a9f416bcb26628650306305f843a1198f2dae680d068761af9f",
+        "dest-filename": "pretty-bytes-1.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8500,6 +18671,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.0.tgz#71e1af7a4b587d259fa4668dcd3e94af077767cb",
+        "sha512": "c448ba0513d9f89d40212e0102d142ffeae1e635e55ce6c6663c79f8e4a933de6f47f3c695aefc6c5547332e467598cff7093700700c1d1397abfafaf735e5b7",
+        "dest-filename": "pretty-format-27.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812",
         "sha512": "3dd970fe83f137e69776633d474d09542f56545a022d3289bc354b82627ea807df04cc6c57ce65fcbbbbb0dc78cd2ccfca82f67ae226b84c0784e5dd12034565",
         "dest-filename": "pretty-format-29.7.0.tgz",
@@ -8507,9 +18685,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1",
+        "sha256": "fe1acd5c3d4039669a1516ea12d9f99b187ff5fc55128e151b375d7fb9dc38b2",
+        "dest-filename": "pretty-hrtime-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-5.1.0.tgz#b906bdd1ec9e9799995c372e2b1c34f073f95384",
+        "sha512": "e2068ad6c903da0c2c7027e4b3061046675d51bd86259b730c64631d669d547b4afc320a16e7dad7632f112ebfc6ed6d55b5187a26b96e62dcc09b5925052a9f",
+        "dest-filename": "pretty-ms-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/primer-support/-/primer-support-4.3.0.tgz#c470fef8c0bff2ec8a771a0749783c2b388118fe",
         "sha1": "c470fef8c0bff2ec8a771a0749783c2b388118fe",
         "dest-filename": "primer-support-4.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff",
+        "sha256": "22ba10fa69b6ff5f28c3697594ac19b2540d9ae15b686869cfc533c3c9f23c1b",
+        "dest-filename": "private-0.1.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/proc-log/-/proc-log-3.0.0.tgz#fb05ef83ccd64fd7b20bbe9c8c1070fc08338dd8",
+        "sha512": "fbe567ecd4b85dff4d69c694f57ab751152ea991133ec7fc2f88f9fdc92169162c7cf791cb31b0fa20e316157f26bdee3664efbdd7442455a1e51d60460507f0",
+        "dest-filename": "proc-log-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/proc-log/-/proc-log-4.2.0.tgz#b6f461e4026e75fdfe228b265e9f7a00779d7034",
+        "sha512": "83cf8e9d4fcbdaffb0ca254af83e5f037e09ec41fc8d9f030e5bf085108cc66323ed4081bf188ed6619e37edfa25720a178cdebd4e2444177c955806f6f2de94",
+        "dest-filename": "proc-log-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3",
+        "sha256": "674cb3ba253e3b6ba221d0558ee9e0814799e121f4df8bec1a91fbb270b550ae",
+        "dest-filename": "process-nextick-args-1.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa",
+        "sha256": "8eec271b7af29443e9bc816d5645a1cf8dd744e4ce9d7d929bbcdc2bd49e9c4e",
+        "dest-filename": "process-nextick-args-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8522,8 +18749,22 @@
     {
         "type": "file",
         "url": "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182",
+        "sha256": "7c10569b3c9cb056152ad630d40f9f4fcc321a0013c2bb8384f036aaa674e6bb",
+        "dest-filename": "process-0.11.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182",
         "sha512": "71d19e7ff76b585a32743d49b0ccee15ff35d349d997e193fb269c7366c471e7797fd463938cfe5ad1544c1bbd3e13a2f63fe37e604fbb498c118e3021d005f0",
         "dest-filename": "process-0.11.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be",
+        "sha256": "38ff07cb281d9982640832562f730bf087699bdb0411d1fbd89243ccfad6d1b2",
+        "dest-filename": "progress-1.1.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8549,6 +18790,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/prompt/-/prompt-0.1.12.tgz#d3114e4fb985ac66eaa35586dcb7b3fb3b27bfc6",
+        "sha256": "e20b83d35e33b9ae7742c32e693b6d46c209398ad82d86dc8198fea7a3f1b81d",
+        "dest-filename": "prompt-0.1.12.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/prompts/-/prompts-2.3.2.tgz#480572d89ecf39566d2bd3fe2c9fccb7c4c0b068",
+        "sha512": "434eae2acd8290d615203d15ab07c097d9a2a68f7dce406ffe7d89b5663cf58c5add969b592aecd1ed8a4ee74a55ade978b52f61731e7c3a8895e2cf55405930",
+        "dest-filename": "prompts-2.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/prompts/-/prompts-2.4.0.tgz#4aa5de0723a231d1ee9121c40fdf663df73f61d7",
         "sha512": "6b06402ab937bcde82ae842e9012fe47dd39d5ae11df3099065266fc705fad267c893a588b1dd55f5bd4e26bde88ba62c263894f8c2891317d9ba1d49382aa59",
         "dest-filename": "prompts-2.4.0.tgz",
@@ -8563,9 +18818,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.3.tgz#355f262505a621646b3130a728eb647e22055341",
+        "sha256": "95050796c66fb5f4595b3873f3405ad175adaf351bf7a41deb694d59facfff81",
+        "dest-filename": "proxy-addr-2.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025",
         "sha512": "96542c30b4940d43d3e388ddad4fcedfbaa59e27e2b433fe670ae699972848ac8b2afb59c69c95d27dbf6c3fcde2d040019fe024475953b28cadaa0ad7e5d802",
         "dest-filename": "proxy-addr-2.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2",
+        "sha512": "0fece439109b03d7f5b5d5912b445a091dc63efe7470cc5caf3e17f24e4b4d2503d43930e3b98a24465036e9c8b514e45b082d6944a8d515454481bd65788562",
+        "dest-filename": "proxy-from-env-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8577,9 +18846,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476",
+        "sha256": "2b8e3e77385e7f4e938e8e5f37cbe12a384adb9d95cac13f81f98a6e9b4c6752",
+        "dest-filename": "prr-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3",
         "sha1": "f052a28da70e618917ef0a8ac34c1ae5a68286b3",
         "dest-filename": "pseudomap-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3",
+        "sha256": "07e9563487c9b0161412ec9d1dd2c3ae13c7b125040bbac4e0a99a38790b5b8e",
+        "dest-filename": "pseudomap-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24",
+        "sha512": "44874ecf2a1abcafa1035f0e186583a944ec08b86d03b21c67fe8d0ace1f14968704369bfa90c3983201c96151409ab609deebd4ea10c4118a39acedabe86321",
+        "dest-filename": "psl-1.8.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8598,9 +18888,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d",
+        "sha256": "550d28760d30dfb4ec9283b6a9d9a03317ae810953508ef588e0a55afa01219c",
+        "dest-filename": "punycode-1.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e",
+        "sha256": "452bca7369ca14bc47711c79063f5f0f3939095918508ca7400f5859448ded89",
+        "dest-filename": "punycode-1.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d",
         "sha1": "5f863edc89b96db09074bad7947bf09056ca4e7d",
         "dest-filename": "punycode-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d",
+        "sha256": "1bf719e58dfed9efbde40cde25e5c9a00868b09b8e8eb7d97484ea4ca0a0c4bf",
+        "dest-filename": "punycode-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec",
+        "sha256": "e5ccd079bf02390e34cbb51b75f73a8be42795146a2e2e23cbb204dddb04ff3c",
+        "dest-filename": "punycode-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec",
+        "sha512": "5d1b118dd7fe8f99a5fb2ffa18a1cf65bac5ffca766206b424fb5da93218d977b9a2124f0fdb1a0c924b3efa7df8d481a6b56f7af7576726e78f672ff0e11dd0",
+        "dest-filename": "punycode-2.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8619,6 +18944,48 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/q/-/q-1.4.1.tgz#55705bcd93c5f3673530c2c2cbc0c2b3addc286e",
+        "sha256": "545b428eb6dbb457148564b3c033b5e7f3f8495b785cd7f1ddc4813926e84115",
+        "dest-filename": "q-1.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7",
+        "sha256": "757b4915ac02f13b4c450a517892518bd84e170d52f627798b5577af00cd15f2",
+        "dest-filename": "q-1.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/qs/-/qs-0.5.1.tgz#9f6bf5d9ac6c76384e95d36d15b48980e5e4add0",
+        "sha256": "85bf27180b586499902d4e2bea83974b337924c870f6b790a23e6bfeb982c2e5",
+        "dest-filename": "qs-0.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/qs/-/qs-2.4.2.tgz#f7ce788e5777df0b5010da7f7c4e73ba32470f5a",
+        "sha256": "b629204c05912a6f88ecd5f4b582491192aef343263d9951e98d7b4c6e0e7457",
+        "dest-filename": "qs-2.4.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/qs/-/qs-5.1.0.tgz#4d932e5c7ea411cca76a312d39a606200fd50cd9",
+        "sha256": "f64ad829ad011fc65800c564cb2413d84828cfa8f32a15bdd4e355f458c1e533",
+        "dest-filename": "qs-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/qs/-/qs-5.2.0.tgz#a9f31142af468cb72b25b30136ba2456834916be",
+        "sha256": "0863a62b64a28790a055c1415e321b7386f641862155121523fd4ce2b655e135",
+        "dest-filename": "qs-5.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a",
         "sha512": "32f8e830227011aad26d4624e4efa79a84b34aeb52b13c05f39cdc1cf43d3ab945a193982236aa040248a885e3a6dc83e6f4e1c46ab9d97bbf31a273464224e1",
         "dest-filename": "qs-6.11.0.tgz",
@@ -8626,9 +18993,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c",
+        "sha256": "4cb137ebb7d435d7cae8ba1899da1f154409d85f9857c4d575813221866e8d02",
+        "dest-filename": "qs-6.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233",
+        "sha256": "a166db939dbf2e14b115b1fb3c9406fea7fe582c27b64011db1f41235814c19d",
+        "dest-filename": "qs-6.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8",
+        "sha256": "14b2a3cdd0df4fd37784b4bfc60a586969e8d5a180877c0a9f0923d628cded01",
+        "dest-filename": "qs-6.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36",
+        "sha256": "539349384f28c64d970ee897379839967dcc2a9c5b03a4db49cb1c0e5e2e16f0",
+        "dest-filename": "qs-6.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73",
+        "sha256": "e5a389fe3a87b47ab022d6c1aa77688aa4fd0496e636de9f573c45db256f283e",
+        "dest-filename": "querystring-es3-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620",
         "sha1": "b209849203bb25df820da756e747005878521620",
         "dest-filename": "querystring-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620",
+        "sha256": "79485dacb8b7be756ad05a9e3fc8ec61c2c3701827d2d294c5be0f995797f06b",
+        "dest-filename": "querystring-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/querystringify/-/querystringify-0.0.4.tgz#0cf7f84f9463ff0ae51c4c4b142d95be37724d9c",
+        "sha256": "90312f738f0ea1124d19dec6b8eb05496ea52c4d3ab40084f79ea5f142060f6a",
+        "dest-filename": "querystringify-0.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb",
+        "sha256": "ced40860e4a33ccb6290ff2908566f53b5f2e0570c657f3b0e3806049b265928",
+        "dest-filename": "querystringify-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8643,6 +19066,20 @@
         "url": "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243",
         "sha512": "36e68d49ae9f94a4f925a498433268934e09cd32f5080e9a1a1bf9adf2d6dcf82a03e3360a1a59427002f21f22e19164052f17e51aa40c11c0eebe217a3dcaf4",
         "dest-filename": "queue-microtask-1.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/queue-tick/-/queue-tick-1.0.1.tgz#f6f07ac82c1fd60f82e098b417a80e52f1f4c142",
+        "sha512": "909b79aa1331a2cce053feb63cb3f5089cadcddd8d29eb634919f2ba3df57c3777465733ddfce515d14b0f5488b6e9cfc32a843a471ae866d5eb5d8159f6816a",
+        "dest-filename": "queue-tick-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8",
+        "sha1": "4360b17c61136ad38078397ff11416e186dcfbb8",
+        "dest-filename": "quick-lru-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8668,9 +19105,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb",
+        "sha256": "3eb8b6599ab368b62606d905cfd811e2e5fc851294ca63ad8a493aadb7786a74",
+        "dest-filename": "randomatic-1.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c",
+        "sha256": "ee54048289bc252c353a4b5d22ada4abc7d6791f50b6858c9a2cd48727d9bca1",
+        "dest-filename": "randomatic-1.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a",
         "sha512": "bd897788e5fee022945aec468bd5248627ba7eca97a92f4513665a89ce2d3450f637641069738c15bb8a2b84260c70b424ee81d59a78d49d0ba53d2847af1a99",
         "dest-filename": "randombytes-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/range-parser/-/range-parser-0.0.4.tgz#c0427ffef51c10acba0782a46c9602e744ff620b",
+        "sha256": "8e1bcce3544330b51644ea0cb4d25f0daa4b43008a75da27e285635f4ac4b1ce",
+        "dest-filename": "range-parser-0.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e",
+        "sha256": "80adc87883e7f01f26ec747d4bca098037469483e34c31a896d29f414f807c55",
+        "dest-filename": "range-parser-1.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8682,9 +19147,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/raw-body/-/raw-body-2.1.7.tgz#adfeace2e4fb3098058014d08c072dcc59758774",
+        "sha256": "ea7e1595b244fd9e5783051aa8333861122343b3c3ca73d5d60d0ff4e27c5cce",
+        "dest-filename": "raw-body-2.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89",
+        "sha256": "572a3826da7c43850d546282cce778a30b0ad25b7eb63bb4d29ab2754293402d",
+        "dest-filename": "raw-body-2.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.2.tgz#99febd83b90e08975087e8f1f9419a149366b68a",
         "sha512": "f331aaca97c4363088a868605d3a02f1a076afb62b057f804007c83ecfcc964f81b4f4f3b4ebd34b4d4d456ff7121eb427e6b8f25b7caac0b38ab43a9680957c",
         "dest-filename": "raw-body-2.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rc/-/rc-1.2.5.tgz#275cd687f6e3b36cc756baa26dfee80a790301fd",
+        "sha256": "619c4fa7cc5712746fd7ad93f0bf248a27d855c742a21c973a3d4618d90d83a9",
+        "dest-filename": "rc-1.2.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rc/-/rc-1.2.6.tgz#eb18989c6d4f4f162c399f79ddd29f3835568092",
+        "sha256": "a109ca32e9575b2da6e88342f4d3b5e1bc170e7837695e01e9eceb2a431d772f",
+        "dest-filename": "rc-1.2.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8745,6 +19238,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0",
+        "sha512": "c361accae90beb62099e569f7ff9d17a03d047de02fd75da9af3169921d1278cbb4ecff8a1c1919931ef3acf0f484ea90777563ab0ff9ee7ae539b1db81b10e3",
+        "dest-filename": "react-is-17.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b",
         "sha512": "c56183216eb1f76d71b733e486250bb6d8491e826f05b177ab6e9fce5a0f08ad21b2fc6d3d57a5bdfb70df38db1d64a4476926f59fb8bb16c30caffa670f41f3",
         "dest-filename": "react-is-18.2.0.tgz",
@@ -8801,6 +19301,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02",
+        "sha256": "e7058ddcb7a13ab36cf55795d6a31629e5be82f206a50d35a10b91d17c7e4726",
+        "dest-filename": "read-pkg-up-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be",
         "sha1": "6b72a8048984e0c41e79510fd5e9fa99b3b549be",
         "dest-filename": "read-pkg-up-2.0.0.tgz",
@@ -8808,9 +19315,86 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07",
+        "sha1": "3ed496685dba0f8fe118d0691dc51f4a1ff96f07",
+        "dest-filename": "read-pkg-up-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-4.0.0.tgz#1b221c6088ba7799601c808f91161c66e58f8978",
+        "sha512": "e9eb50487ee7246b0ad116c6ff64de0f36456bcb218d0d6e9be4b0410e5cc0acb476149774e9dc1216f508fa6f406e21ec5c8e57a101e98955d3226f65034090",
+        "dest-filename": "read-pkg-up-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
+        "sha256": "8ec36eb1bbfbbeafd98799818804e94528bde09db50a87a9aac0f0eaaf56eff2",
+        "dest-filename": "read-pkg-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8",
         "sha1": "8ef1c0623c6a6db0dc6713c4bfac46332b2368f8",
         "dest-filename": "read-pkg-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389",
+        "sha1": "9cbc686978fee65d16c00e2b19c237fcf6e38389",
+        "dest-filename": "read-pkg-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c",
+        "sha1": "125820e34bc842d2f2aaafafe4c2916ee32c157c",
+        "dest-filename": "readable-stream-1.0.34.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c",
+        "sha256": "d1010c97201478f2d9096fed5ce1217587d5238475f4506fe09c87cdd5bc56a6",
+        "dest-filename": "readable-stream-1.0.34.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9",
+        "sha1": "7cf4c54ef648e3813084c636dd2079e166c081d9",
+        "dest-filename": "readable-stream-1.1.14.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9",
+        "sha256": "2c993fcc5a24fc1605a1dd81f52b921774990316d31dbc61a95f24d0d7d59de4",
+        "dest-filename": "readable-stream-1.1.14.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8",
+        "sha256": "7004dc0d6048ec532e5c80420494876e918d0b7fc2fede0286efceb9bd7dbe84",
+        "dest-filename": "readable-stream-2.2.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d",
+        "sha256": "b4a3e04324c0801381a8fd9aa951e0bfff9634dd8a8d27c53bd717c342de6f10",
+        "dest-filename": "readable-stream-2.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf",
+        "sha256": "0f205b60dc0fb300f05bbbf1d1583b3f87cca8cecc0b6a8673910c9519c45c77",
+        "dest-filename": "readable-stream-2.3.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8829,9 +19413,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967",
+        "sha512": "f6efec9e20ab6370f959db04447cc71381b66025eaa06e454c7522082e1221bafa5dc2d9058d39c9af442a361e93d3b9c4e0308c6abed497460404bb43d49ca0",
+        "dest-filename": "readable-stream-3.6.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747",
         "sha1": "9fafa37d286be5d92cbaebdee030dc9b5f406747",
         "dest-filename": "readdir-scoped-modules-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78",
+        "sha256": "49e447571188062c466e4e556136dd92bf2e4faf8751e5d23148a69bea41ffeb",
+        "dest-filename": "readdirp-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readdirp/-/readdirp-3.2.0.tgz#c30c33352b12c96dfb4b895421a49fd5a9593839",
+        "sha512": "72b93842ede9997c20c5d4a01a1800fde5e22403d0897e0630e6593179ea2b11d7ed36a82fede0415a3f59eb808a882bd3b0e99df8c83295d76be3c022fc0f19",
+        "dest-filename": "readdirp-3.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8843,6 +19448,34 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35",
+        "sha256": "c202e193f4b140530abc94d9b96176d15310c9485fab1b65fe446ac95e2ef681",
+        "dest-filename": "readline2-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384",
+        "sha256": "141faa56cef4953ffbe236336a09af64097560338de5abbce57f990fb62ac635",
+        "dest-filename": "rechoir-0.6.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde",
+        "sha256": "48b368465df2a980b1f4e0f3f132555dbb82a69e07508f3f403e7dcb207834ad",
+        "dest-filename": "redent-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa",
+        "sha1": "c1b2007b42d57eb1389079b3c8333639d5e1ccaa",
+        "dest-filename": "redent-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz#aaccbf41aca3821b87bb71d9dcbc7ad0ba50a3f3",
         "sha512": "102913c3c4e62705bad2539347e6643832125ba450f3ed822f708eaad88928b77a326078e61379d47a6b1c5ce228b1a402e4c642105bf7557c732f8a1e56828f",
         "dest-filename": "reflect.getprototypeof-1.0.4.tgz",
@@ -8850,9 +19483,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz#ef51e0f0ea4ad424b77bf7cb41f3e015c70a3f0e",
+        "sha512": "2c6673920b4b63bf467972e6f03a740552dd4255880b3067273fe2a56520a39f6a05a67e047b6ae753f6ab5b95665a6932e5004f7ed20e4dfda946e34d607b6c",
+        "dest-filename": "regenerate-unicode-properties-8.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f",
+        "sha256": "e6657be589fb26101c71759e6c2fdcdb88c09f776d40fda9e189abcd624a6557",
+        "dest-filename": "regenerate-1.3.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11",
+        "sha512": "d46ea32550d6aedd2b2bdf64063bc4b7389934220202ebc83e44a2505210c553f4e91095a6addd983a36a22e8006961a0d869346bebb04484bf2bd708046592a",
+        "dest-filename": "regenerate-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658",
+        "sha256": "f8d0fdf16aac76d45f3024905d1d57238df46e9f2ec11f7da0525ab2ea0c794c",
+        "dest-filename": "regenerator-runtime-0.10.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1",
         "sha512": "fda03490b7916f937d2b47787f0ee8a046c8fb10def83283e3df4442aca01aa792f0ddf1b68d79a74f6e636c63ee2c4ff35b0d3d7bd12e701022a7554ad81bd4",
         "dest-filename": "regenerator-runtime-0.11.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9",
+        "sha256": "cdd8985b84b3b6b08fe5dcb39b9506d70ddddffda9f9d703dd33534c60bc373b",
+        "dest-filename": "regenerator-runtime-0.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8874,6 +19542,27 @@
         "url": "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45",
         "sha512": "b2bc35ecd2344d4587b866b90851869a17cd21e8dadf458c05f6ec94f3617fa26ba9094b37981caef8a0d68a8fc6255a5dbd285b45d12ad1fa36782ce6528220",
         "dest-filename": "regenerator-runtime-0.14.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd",
+        "sha256": "b6fb60950898c5d1b5f491a71cb7f1397f24e0a557f865f197b996191fb45dde",
+        "dest-filename": "regenerator-transform-0.10.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145",
+        "sha256": "b4318a2d5781641235715466dd01a05d8d2423a384353c33560d8940b806b102",
+        "dest-filename": "regex-cache-0.4.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd",
+        "sha256": "66d49d35e7e084cba2f0841cc794cdfe63870b17c79e43d119124c39c6791480",
+        "dest-filename": "regex-cache-0.4.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8913,6 +19602,48 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f",
+        "sha512": "96fd0cebe4e40d59e2037683d448340d5a5f53f6e8a12bbb11ebf74c33bf99928705f563802193578b786eea691121180ed900ad814ec53256bfa4b90be89a37",
+        "dest-filename": "regexpp-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regexpp/-/regexpp-3.0.0.tgz#dd63982ee3300e67b41c1956f850aa680d9d330e",
+        "sha512": "67e84dafb440556c739cb3ee03b0c887c50d5f58fd083ad4431b24c3d22b044d43c6e7b69725d3fac86a10878b523ae893120ff02332d56923806deb4ec779fe",
+        "dest-filename": "regexpp-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240",
+        "sha256": "ea28b108b285a8c4e8e9495c835d2b7a38d08baed79ca0ac31adf1e14fbc40b2",
+        "dest-filename": "regexpu-core-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.6.0.tgz#2037c18b327cfce8a6fea2a4ec441f2432afb8b6",
+        "sha512": "62555a79f97c3f90671583884d33730ef6a7d6e94b3a25c9cc2359c5db93228b0dd7b6fcee1ddbbc6f721cca07691ba8f3c1f8990d3a028763e55b581861a24e",
+        "dest-filename": "regexpu-core-4.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.4.0.tgz#d7446815433f5d5ed6431cd5dca21048f66b397e",
+        "sha512": "e0b33a170f1e0507703187044b8c939e7d93a886ac6d7bb00f1dee9be411b3b4b9e5a30a081281c6f3d79764625231f0b892d3c987f14a999f4808d0a5cb8ff8",
+        "dest-filename": "registry-auth-token-3.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.0.0.tgz#30e55961eec77379da551ea5c4cf43cbf03522be",
+        "sha512": "9694241f177d50bead6f793f6870157e756d9fe05cb3da1be489ee14b2c40ea4aa7aaf8096307c1995bdc58d31ec5fb163011c8ca7b4ee7ca8c73118cfacaf93",
+        "dest-filename": "registry-auth-token-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/registry-js/-/registry-js-1.16.0.tgz#951444f10c0e39c7669e4bde166f9237472a7c7e",
         "sha512": "85c3277ca86608f4c0fbeef4a841b046a72d2c174183ec6f1b765f00fb74ca68dd4d414ab554e895e9692032b6aacf03548babca59df33a04cf6e5a955b26bfa",
         "dest-filename": "registry-js-1.16.0.tgz",
@@ -8920,9 +19651,72 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942",
+        "sha1": "3d4ef870f73dde1d77f0cf9a381432444e174942",
+        "dest-filename": "registry-url-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/registry-url/-/registry-url-5.1.0.tgz#e98334b50d5434b81136b44ec638d9c2009c5009",
+        "sha512": "f1a7185d74c8d00910bfa4403a3137bce6885d9913f70a382ce15b04a6101049e730d0692aa754ac8e92e0d4f428f228fd656f279b44fd7e4b17f4d051fd1e93",
+        "dest-filename": "registry-url-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7",
+        "sha256": "c3ef01d4c06a3de88c027238d42df152b461d6c4bb40776c20a6f2b33a3f2938",
+        "dest-filename": "regjsgen-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.1.tgz#48f0bf1a5ea205196929c0d9798b42d1ed98443c",
+        "sha512": "e6ac731998c3b3dc38b734f74cf84226a59d09cdd12d8c32f49d8d0749e6e4bcfe4b6ef796f59ca63693187b13d5d73a1e17eae35b9210ec3cc019b1aca3aeca",
+        "dest-filename": "regjsgen-0.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c",
+        "sha256": "aaeb398fd9fcb47773f837a91cd0f8173296ede0c00dd7a93f1521fb32ee3944",
+        "dest-filename": "regjsparser-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.0.tgz#f1e6ae8b7da2bae96c99399b868cd6c933a2ba9c",
+        "sha512": "450ed8ca890b89006899426e506f22195be480e2f1c3264cf24e9ddeae52017a60e2be5364966280a16f0ba3e90fea90f7c6c20c2e587a53de03712e703a0d79",
+        "dest-filename": "regjsparser-0.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9",
         "sha1": "54dbf377e51440aca90a4cd274600d3ff2d888a9",
         "dest-filename": "relateurl-0.2.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/release-zalgo/-/release-zalgo-1.0.0.tgz#09700b7e5074329739330e535c5a90fb67851730",
+        "sha1": "09700b7e5074329739330e535c5a90fb67851730",
+        "dest-filename": "release-zalgo-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz#615ebb96af559552d4bf4057c8436d486ab63cc4",
+        "sha256": "1e8724f794c3d03b95500d4ed2fe9bbbef4af7ba08b494f4cd98115b31f384e2",
+        "dest-filename": "remove-trailing-separator-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef",
+        "sha256": "4e1340d198749dbcf0986dde8b657e0470f395d2c9be1da90a7c169dbeae6321",
+        "dest-filename": "remove-trailing-separator-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8941,9 +19735,100 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a",
+        "sha256": "aa0e5c12fccb4fa26936d541f86b3780505781c03f98807eb2aef0629bf67b06",
+        "dest-filename": "repeat-element-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce",
+        "sha512": "6a11aad199d5e66e57b592cc6febcfefa91c00ce6790baa4d25a6a02ea2348a1a042d9f87918b86591a6da8968db32851feb0cb166aa3825b576a0273abbbbda",
+        "dest-filename": "repeat-element-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/repeat-string/-/repeat-string-0.2.2.tgz#c7a8d3236068362059a7e4651fc6884e8b1fb4ae",
+        "sha256": "f7edb7a29c84816bb406d14c88934534f5428ac46233909be33bbfeb06eabcfe",
+        "dest-filename": "repeat-string-0.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637",
         "sha1": "8dcae470e1c88abc2d600fff4a776286da75e637",
         "dest-filename": "repeat-string-1.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637",
+        "sha256": "0be1cb94d6cb3c063946f502d39eb59ffe837a846951dc9d2ff1a49b8598b4fe",
+        "dest-filename": "repeat-string-1.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda",
+        "sha256": "2b686da5dedfd4fc6a1368690df313213e801a5d8b320b786082bf6facb28097",
+        "dest-filename": "repeating-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924",
+        "sha256": "5b722acc9da9c022bb833d205ddee9ee04e4d172b51e6a17d3b46d8fa98bb07b",
+        "dest-filename": "replace-ext-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/request-progress/-/request-progress-2.0.1.tgz#5d36bb57961c673aa5b788dbc8141fdf23b44e08",
+        "sha256": "f085e3936a12d9661bcb065cdfa836664446cb913bdd4a41b4b8186397dfd2c3",
+        "dest-filename": "request-progress-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/request/-/request-2.55.0.tgz#d75c1cdf679d76bb100f9bffe1fe551b5c24e93d",
+        "sha256": "304085c58d20d156ebc7aa6f3e85805c33b13246fd8a53250a0e9ac48c6b6d27",
+        "dest-filename": "request-2.55.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de",
+        "sha256": "5af6002330c7e2ae1e5e3938c64b8391c15ea5c6711a1a6aa7da3e2ee93585fe",
+        "dest-filename": "request-2.79.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0",
+        "sha256": "bc392db88ba9386af1f4dd86aea46dfbe35441d3fea891cc008ccea4b669adcf",
+        "dest-filename": "request-2.81.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356",
+        "sha256": "a1ad0fbbf5f49ab0b7ee917e47d11b86326ee44d2f630dd3e0b9d4f61298148e",
+        "dest-filename": "request-2.83.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3",
+        "sha512": "32cbed3ab7c6f5972b3b0016f908be17a1db0f40965c487da2eefbb8e6fb14cd963e1c13eec98cf37dcfcda9e124bb205e337cf48afa5763dccd7367329c0a87",
+        "dest-filename": "request-2.88.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/request/-/request-2.9.203.tgz#6c1711a5407fb94a114219563e44145bcbf4723a",
+        "sha256": "2af8f83a63c7227383fbdd6114e470e0921af86a037c4e82f42883120f35f836",
+        "dest-filename": "request-2.9.203.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8955,9 +19840,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+        "sha256": "703bee0844360383fe4a8792d4a5a562647426a053e7597a1d272ac554f386c8",
+        "dest-filename": "require-directory-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909",
         "sha512": "5dfd2759ee91b1ece214cbbe029f5b8a251b9a996ae92f7fa7eef0ed85cffc904786b5030d48706bebc0372b9bbaa7d9593bde53ffc36151ac0c6ed128bfef13",
         "dest-filename": "require-from-string-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1",
+        "sha256": "63a72dd24ef77958d01bcf2797a2e5fe57e1c5d11579fbd1bdc8b784c89999c3",
+        "dest-filename": "require-main-filename-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b",
+        "sha512": "34a37990c0f294aba577160b4947eb6e8e53bb387885dfb613c34f3d7d36999b67d55b911104e861efd9765272f89dee0a97da886174e5eec1f16d225db4079a",
+        "dest-filename": "require-main-filename-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/require-precompiled/-/require-precompiled-0.1.0.tgz#5a1b52eb70ebed43eb982e974c85ab59571e56fa",
+        "sha1": "5a1b52eb70ebed43eb982e974c85ab59571e56fa",
+        "dest-filename": "require-precompiled-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de",
+        "sha256": "d3f51f15b25309fe88c7e3b88ddfc5b4d8a02b3a90bd57d6109e9c19438b4723",
+        "dest-filename": "require-relative-0.8.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3",
+        "sha256": "51926b323996f004d358d6463749f0720e3637e071ee860e76b0078c047952a4",
+        "dest-filename": "require-uncached-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff",
+        "sha256": "6150769f202060d925a510d13afa2fbf0b1154bb59ccc766935719ff1605c6e2",
+        "dest-filename": "requires-port-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8990,6 +19924,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e",
+        "sha256": "90cbe568cec76df0cd971d83ea291b226d58553e02f016297298de124ed28a22",
+        "dest-filename": "resolve-dir-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226",
+        "sha256": "f510d3501116c37ce2d3a10bb9672daaecbf45f397519b506c94c3b4c6ffe687",
+        "dest-filename": "resolve-from-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57",
+        "sha256": "5f8f9c45d91ed1ed57eff2b5156656aaf60ce71462c922d4ddc70bde3030c09a",
+        "dest-filename": "resolve-from-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6",
         "sha512": "a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2",
         "dest-filename": "resolve-from-4.0.0.tgz",
@@ -9011,9 +19966,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9",
+        "sha512": "27597e671c69e172b72d40d9f66eb42d1245fe601ee33e9ae31c9a6cf1e4ee9bcae6ddf9740095df68888c90c57966457d994edbdc3a499ebb927474b47cc9b5",
+        "dest-filename": "resolve.exports-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800",
         "sha512": "5f6516e8dc379ff68c803572fb4ad2aa01e5bf7f56640959ad709d9dbc8488a9b5ec34aa1d7e0c99031a493dc56de591e454ee45c530600ce265a8e38b463b9a",
         "dest-filename": "resolve.exports-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve/-/resolve-0.3.1.tgz#34c63447c664c70598d1c9b126fc43b2a24310a4",
+        "sha256": "2e9424747b687ff5cabd8c51e3fbd48152fe0cc89ba37f8d6a6e926ea741a092",
+        "dest-filename": "resolve-0.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b",
+        "sha256": "605726c06837d76d2da4946e25ce90c2467672f6f52293199f570dab74e0fe0b",
+        "dest-filename": "resolve-1.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18",
+        "sha512": "2ae21ee267fefad77f7856fac2468f6cc0e73fa90e6c2684b480ee1ce5040fa30d528e0aebbd0a6541eebaf60f643c4d1745952f0e3d9f4e8cda6d9d5e9844cc",
+        "dest-filename": "resolve-1.10.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve/-/resolve-1.12.2.tgz#08b12496d9aa8659c75f534a8f05f0d892fff594",
+        "sha512": "70055323654b1d662c18e8ab7de615550ed90de8ed43d7e9e1885872458312415fa9b563693d7588cf24eb14807c614c33e803a598cc9c5b2c3eef307be9aa17",
+        "dest-filename": "resolve-1.12.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444",
+        "sha512": "89cfbb258895f158b6cb34061563a48990f967dcfb3b66619bd5cc693c5d244c4a6ac89e142afec9767f5a65ec7241e22a5d766abd32e978970f1de6e111e7d7",
+        "dest-filename": "resolve-1.17.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198",
+        "sha512": "1e1b6bc349cb792ac543ba613e9e0e39c5632cf21e327465af999c9d5b8c7bb33fede067f7c0378661512e8168dc32d9922bd26308515094f23f2580939e962f",
+        "dest-filename": "resolve-1.22.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9025,9 +20029,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5",
+        "sha256": "f316de5e76b6e52868d0327b2b662651af0b9384e6f613a9dfab0b3733a371bd",
+        "dest-filename": "resolve-1.3.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve/-/resolve-1.6.0.tgz#0fbd21278b27b4004481c395349e7aba60a9ff5c",
+        "sha256": "69f40a3d7faa8f3583c6496ed63fdc3c13a8d1cc26cc2dcf15508220d8303cae",
+        "dest-filename": "resolve-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.5.tgz#6b0ec3107e671e52b68cd068ef327173b90dc03c",
         "sha512": "53b5a31951bdb07f2dbe35b94a619b42eba2ef9162ca3017ef61d7d790f0041c05f5d362419450020f679cf858cbe4d49c4d3e55caedb6ebcd23ca12c5972870",
         "dest-filename": "resolve-2.0.0-next.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7",
+        "sha1": "918720ef3b631c5642be068f15ade5a46f4ba1e7",
+        "dest-filename": "responselike-1.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9039,9 +20064,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541",
+        "sha256": "6de0a2138d132f2d8b13f10ba406b31d9b864c914e4de8ff79e677b6dca4df97",
+        "dest-filename": "restore-cursor-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf",
+        "sha1": "9f7ee287f82fd326d4fd162923d62129eee0dfaf",
+        "dest-filename": "restore-cursor-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e",
+        "sha512": "97eb1279fcc7a63e6a8a6845484e5af27b9f65800cdec05254c00fb589260bee041f66a7486684317483d22cd141bbbd9dfc90f72e49ad59a9ec4f2866b523bc",
+        "dest-filename": "restore-cursor-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759",
+        "sha1": "f1e8f461e4064ba39e82af3cdc2a8c893d076759",
+        "dest-filename": "resumer-0.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc",
         "sha512": "4d3958a5af8e2febcc30d1b6e314a5406109dc1fd1cc47d494b72dedbe46ff2b5abfec0fae9942a55305bb0cd76e479c26b6fa218a358856f44bdbf7efbe789a",
         "dest-filename": "ret-0.1.15.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b",
+        "sha1": "1b42a6266a21f07421d1b0b54b7dc167b01c013b",
+        "dest-filename": "retry-0.12.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9067,9 +20127,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef",
+        "sha256": "9430b5e7c04962bef89ea4f8c9f4b2818fe4f13e67a6bdbef77e3ba74ddf9d98",
+        "dest-filename": "right-align-0.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582",
         "sha1": "e439be2aaee327321952730f99a8929e4fc50582",
         "dest-filename": "rimraf-2.2.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582",
+        "sha256": "3f5d746a7fe4adaf3e8c8fef6f72dd57e360e6882b45d724a6b1f7c1407f79bb",
+        "dest-filename": "rimraf-2.2.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.3.tgz#e5b51c9437a4c582adb955e9f28cf8d945e272af",
+        "sha256": "5e210ab9e44f9d87045193dcd458b38c2d0e24ce89db7ce249d68f85a5440494",
+        "dest-filename": "rimraf-2.4.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d",
+        "sha256": "0597dcdf16daa619e52826fcc243d2eb4a396ad9fcb2cec02348d6bb5c69f8c1",
+        "dest-filename": "rimraf-2.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36",
+        "sha256": "e6ee2251037935e6e6734f91acee17a5cc405f1011107b8fecd0f7f9685929de",
+        "dest-filename": "rimraf-2.6.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9095,9 +20190,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ripemd160/-/ripemd160-0.2.0.tgz#2bf198bde167cacfa51c0a928e84b68bbe171fce",
+        "sha256": "1b9238f7ebf8fb9f2c49898f66df3678d77cbdb215dc2024d47b61a39fea5500",
+        "dest-filename": "ripemd160-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/roarr/-/roarr-2.15.4.tgz#f5fe795b7b838ccfe35dc608e0282b9eba2e7afd",
         "sha512": "08784f87e50d1c3d864d735884f58b9d4f0e347748fb90c8fb811820039a883eb7ac7798959bf287c3fe8a7e7df7d4d348581462e294023cd123899d87fa7ed8",
         "dest-filename": "roarr-2.15.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-2.7.1.tgz#16528197b0f938a1536f44683c7a93d573182f57",
+        "sha256": "41f7dc9878bc77361e74c3b3615b37275b1bd8c06f38e534eefe82c9e25f3dfb",
+        "dest-filename": "rollup-plugin-babel-2.7.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-2.1.1.tgz#cbb783b0d15b02794d58915350b2f0d902b8ddc8",
+        "sha256": "54d98ef810891feb17b60eade8de36011e170acdf6204a2464ee5dab945bd300",
+        "dest-filename": "rollup-plugin-node-resolve-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408",
+        "sha256": "70e6e2af627f463c647d27375be57808b67b0775661cfc506be6a3eb552b45c4",
+        "dest-filename": "rollup-pluginutils-1.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rollup/-/rollup-0.41.6.tgz#e0d05497877a398c104d816d2733a718a7a94e2a",
+        "sha256": "d2a0381c093af890ac1806498d95a6be75c9eba2997a5ad9dbfac8619222ead5",
+        "dest-filename": "rollup-0.41.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9109,9 +20239,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389",
+        "sha256": "676c5e2081c1f15d8b309dda1a1cc8b6759594905c8a8efc01cc41daee134a84",
+        "dest-filename": "run-async-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0",
+        "sha1": "0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0",
+        "dest-filename": "run-async-2.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/run-con/-/run-con-1.2.11.tgz#0014ed430bad034a60568dfe7de2235f32e3f3c4",
         "sha512": "344306b144fe72095693312be0814adb53f825c6b8e47aa201b20864805d5f9f94653076e0c6ffdb588d1a0cfdc596bcb4beaf6d6ec25e6abb305378dbe56335",
         "dest-filename": "run-con-1.2.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679",
+        "sha512": "0c4aa74914c3c3f4dcdc55dfe3dcde748eb7f19f689f0528b413225052a6acedac7452886d76a65c6437031778aa0a61c4a078930fea3f5c39913c677d4d41f5",
+        "dest-filename": "run-parallel-1.1.9.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9123,6 +20274,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/run-waterfall/-/run-waterfall-1.1.7.tgz#ae368b549b2f5171f86c2924492cab3352a6e9c5",
+        "sha512": "8853e087b49ab475ce1b50a57297701c8eb781e5771dcfe22fa72b192c81947d8f63b466ff36bece82b3e857d8fd0970e4aec9c12a25f29b1e3bc7cde8232185",
+        "dest-filename": "run-waterfall-1.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102",
+        "sha256": "5e645720c902385311f983ef2b550128d36d912845c1830b87869a55c625a6e6",
+        "dest-filename": "rx-lite-3.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a",
+        "sha512": "c2e62c0186057564c09c068fa0a18d85fa56c0a65b256f8780027e9889a9f84a65ec11bca0d581093c9133c81b6bd938964f01816768626db5328fd162185b80",
+        "dest-filename": "rxjs-6.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.0.1.tgz#91686a63ce3adbea14d61b14c99572a8ff84754c",
         "sha512": "e976d402c7981362ad3ae1ae7b27a86c2c928fd2f8fbae939fa29030e3d026b009128c18296fd847f30625997b15dc9d51d685bb82d8c83663c5fe3f366a36dd",
         "dest-filename": "safe-array-concat-1.0.1.tgz",
@@ -9130,9 +20302,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853",
+        "sha256": "0c1447202230c905a611cfbd4c6d834ffcd1f598dadcbc8d5be74826e5e3b171",
+        "dest-filename": "safe-buffer-5.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d",
+        "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22",
+        "dest-filename": "safe-buffer-5.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d",
         "sha512": "19dd94641243917958ec66c9c5fb04f3f9ef2a45045351b7f1cd6c88de903fa6bd3d3f4c98707c1a7a6c71298c252a05f0b388aedf2e77fc0fb688f2b381bafa",
         "dest-filename": "safe-buffer-5.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519",
+        "sha512": "7d91305066d597b928b99b358c274c2ddb7de61748bf465e1e0e8beea3de722319859fbf81d7ac5b8c204c0464ac5584a6ca631004c0cd418f1bc3768c98b06e",
+        "dest-filename": "safe-buffer-5.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9166,8 +20359,22 @@
     {
         "type": "file",
         "url": "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a",
+        "sha256": "78812f65ae3b98071ce1c9bacbe0666f4220d0b2753c2a11530eb27df440a3b3",
+        "dest-filename": "safer-buffer-2.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a",
         "sha512": "619a372bcd920fb462ca2d04d4440fa232f3ee4a5ea6749023d2323db1c78355d75debdbe5d248eeda72376003c467106c71bbbdcc911e4d1c6f0a9c42b894b6",
         "dest-filename": "safer-buffer-2.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sander/-/sander-0.5.1.tgz#741e245e231f07cafb6fdf0f133adfa216a502ad",
+        "sha256": "24c2d1ebf7577f2a2bc6c97c8a2b879464f1123180572ab86e0aa15b0943ddd1",
+        "dest-filename": "sander-0.5.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9193,9 +20400,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/sauce-connect-launcher/-/sauce-connect-launcher-0.13.0.tgz#25d7df9da16a5ed1caa13df424cb57cb0b6d5a22",
+        "sha256": "8f747e94297db165cca76b43ca21b18d76656a13f589e258e8502816d95eed0b",
+        "dest-filename": "sauce-connect-launcher-0.13.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/saucelabs/-/saucelabs-1.4.0.tgz#b934a9af9da2874b3f40aae1fcde50a4466f5f38",
+        "sha256": "61d4facc898a7d0cde7f2b91282090abb44f006fdb2b64b6f8f70f63ab1e4547",
+        "dest-filename": "saucelabs-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9",
         "sha512": "36a543bfd4e900d523166d0df2e3391b12f7e9480a8bdfdab59c3ec7b6059d0f1c9301462ab978c57e325adadecb75099b99cfd6451b9d880ba29a963524615b",
         "dest-filename": "sax-1.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d",
+        "sha512": "e4b061d5396cf1cf718068f0dd0accc044e64cc564d28160beb152bd6c7ada5951da1704227aca359d866420aebb2da5bd6add9798e16e97aa73985160a14e73",
+        "dest-filename": "saxes-5.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9235,9 +20463,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36",
+        "sha1": "4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36",
+        "dest-filename": "semver-diff-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/semver/-/semver-1.0.14.tgz#cac5e2d55a6fbf958cb220ae844045071c78f676",
+        "sha256": "560df522ae0e8834d8b07f6ca9c60bd8836e844642361abde108018cbe9ca82f",
+        "dest-filename": "semver-1.0.14.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da",
+        "sha256": "3db1b80506614a48cea118f6980fe63195d9ed4899823afc68d7485f247be435",
+        "dest-filename": "semver-4.3.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a",
+        "sha256": "131385bf0466cecc69e5bbf3c0a8f41174b8c832aa2e9b40f37cb4f4ad8c47f1",
+        "dest-filename": "semver-5.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f",
+        "sha1": "9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f",
+        "dest-filename": "semver-5.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab",
+        "sha256": "bd93bdd068b190bfe1deb9f68bc37458e2425b4c3e230284732b5b6dad66a36e",
+        "dest-filename": "semver-5.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7",
+        "sha512": "b1ab9a0dffcf65d560acb4cd60746da576b589188a71a79b88a435049769425587da50af7b141d5f9e6c9cf1722bb433a6e76a6c2234a9715f39ab0777234319",
+        "dest-filename": "semver-5.7.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8",
         "sha512": "701ce79d0f4a8c9a94ebb079d91302eb908c6ab2b6eb4d161676e471a8b05aadf1cbfe61685265b21827a63a2f31527e1df7f8f5df06127d1bf3b0b9a43435d2",
         "dest-filename": "semver-5.7.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d",
+        "sha512": "6f7f5305a4d27d5eb206b6a953cf69e5f29e904da6fcdc270e870e56bb90152d7fbde320773b8f72738cdf833a0b0c56f231ff97111ae6b0680de530bb91c74f",
+        "dest-filename": "semver-6.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9249,6 +20533,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938",
+        "sha512": "3ab39bdf64de79a99b1fa52b86d4a1985ec2443aa12faff95e93cda760ee447ebef502f0fe8ae1a7bda3f3bbfc41ad5270392faeb04da597037a3022ac999f5d",
+        "dest-filename": "semver-7.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7",
+        "sha512": "3e878625887c1cae014cefdaf537fa646def7a8fc0ed956c62b480e89f27cbd9dbdc1d55ae992e37ecfd384e707c4e69e87e0b721619b1e8224206c90fde1915",
+        "dest-filename": "semver-7.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e",
         "sha512": "d5b09211257a3effa2db51efa71a770f1fa9483f2520fb7cb958d1af1014b7f9dbb3061cfad2ba6366ed8942e3778f9f9ead793d7fa7a900c2ece7eded693070",
         "dest-filename": "semver-7.5.4.tgz",
@@ -9256,9 +20554,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13",
+        "sha512": "14d0080560b1f6a7118681dc81c27482f53b48dd65614d995ee49f974e1b482e4ea6f0c71722428dd347a263d7c6342508153aed85bae0fcd8eff548107ec5db",
+        "dest-filename": "semver-7.6.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/send/-/send-0.0.4.tgz#2d4cf79b189fcd09610e1302510ac9b0e4dde800",
+        "sha256": "7e028fa3760884d8103414f079dc4bcc99d0b72bc21bcaa9d66a319d59010d6c",
+        "dest-filename": "send-0.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/send/-/send-0.16.1.tgz#a70e1ca21d1382c11d0d9f6231deb281080d7ab3",
+        "sha256": "8f5bda4c3050de81498dc706409d99fa40597a45b67677b0495d7e56ea37c5fd",
+        "dest-filename": "send-0.16.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be",
         "sha512": "aaa5b3b8e8d214ebaa3e315ee0d3ac30b69f4e8410c0148e1294be17012ddc0d95def2ae6d3aae4f7be62d3429160317a7c02515616e3f5a8a68964eb4fa555e",
         "dest-filename": "send-0.18.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sequencify/-/sequencify-0.0.7.tgz#90cff19d02e07027fd767f5ead3e7b95d1e7380c",
+        "sha256": "73f5387839eddc018b86d805fe76c1a386fcc0f791f38ed23d8cd65395672237",
+        "dest-filename": "sequencify-0.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a",
+        "sha1": "50b679d5635cdf84667bdc8e59af4e5b81d5f60a",
+        "dest-filename": "serialize-error-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9277,6 +20610,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239",
+        "sha256": "37e848fc869a439a8f55b557cb1a87881cca0a76b8aac08a62ba7b7c0cd26bde",
+        "dest-filename": "serve-index-1.9.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.1.tgz#4c57d53404a761d8f2e7c1e8a18a47dbf278a719",
+        "sha256": "03fe407dddefe803b85b19ee7900782f996ec63e97e74b27d5d80e36c147d49c",
+        "dest-filename": "serve-static-1.13.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540",
         "sha512": "5c6b910cd8d75228ec50bd2f97a9d20fb730511bb31208256ce685b9933d8379300d7396553724d232f38cfcc60fe4dacd66dba1962ee76ffdfd73dd5209def6",
         "dest-filename": "serve-static-1.15.0.tgz",
@@ -9286,6 +20633,20 @@
         "type": "file",
         "url": "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7",
         "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
+        "dest-filename": "set-blocking-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7",
+        "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d",
+        "dest-filename": "set-blocking-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7",
+        "sha512": "2a22814bc0275861322f3a1f15f9af2b0a5d3f3aa2cb5e8bbd07cadf2bff7d51fb063d77ff097725247527eadf81113dabbc5424ae2abe04bcada48e78b51e87",
         "dest-filename": "set-blocking-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -9319,6 +20680,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61",
+        "sha256": "d72d78d5fa9944408bdf30d59140c0298a5673ff30b4ec8597fe2e6bf694d696",
+        "dest-filename": "set-immediate-shim-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1",
         "sha1": "7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1",
         "dest-filename": "set-value-0.4.3.tgz",
@@ -9333,6 +20701,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b",
+        "sha512": "2711dcd7078237af30458d1f842a17a722b9e66fd73c769f3a62b85160fb9b6088d7818c705ca9b78c3fd3e355e5ffd931bcb617a4b6c3003b7e0ca787d8164b",
+        "dest-filename": "set-value-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285",
+        "sha256": "5cb9fc22698364ed42c02d6aa3dc50ffeafa68452ae84699672e3dfd74922c9e",
+        "dest-filename": "setimmediate-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285",
         "sha512": "3004c9759a7cb0ba8397febc2df4266cff3328f2d0355e81219a0882bb1c14343e46cbcafc1c5e0d03a0cb128aa21d32ffc87706a5459c2a90fe077eade8885c",
         "dest-filename": "setimmediate-1.0.5.tgz",
@@ -9340,9 +20722,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04",
+        "sha256": "bbba5760a805118c7fdbae5408147ef468fdbc284bbac61066f1c5c73f6fbcaf",
+        "dest-filename": "setprototypeof-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656",
+        "sha256": "e9ca9d42c3febb8e239da76d50455584afc481894b98fe7ff99950e97da4ed64",
+        "dest-filename": "setprototypeof-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424",
         "sha512": "1392c35fb5aba7ce4a8a5e5b859bf8ea3f2339e6e82aae4932660cde05467461fcc45a4f59750cb0dae53830ab928c4c11e362fd7648c2e46f6385cdc18309a7",
         "dest-filename": "setprototypeof-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sha.js/-/sha.js-2.2.6.tgz#17ddeddc5f722fb66501658895461977867315ba",
+        "sha256": "0fb726adf0107f7c9f723c0112a947651480bcc859b9f9da6485c0f2f00a2ef4",
+        "dest-filename": "sha.js-2.2.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9356,6 +20759,13 @@
         "type": "file",
         "url": "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea",
         "sha1": "44aac65b695b03398968c39f363fee5deafdf1ea",
+        "dest-filename": "shebang-command-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea",
+        "sha256": "e56584aed67fa7855e99b63cd90231e2506e5493a37f52f53e232415f57de1f7",
         "dest-filename": "shebang-command-1.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -9375,9 +20785,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3",
+        "sha256": "676f124e8e6621c51b563d61136f9bf2becb86b0b6c4e6bfb055ace21e85c671",
+        "dest-filename": "shebang-regex-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172",
         "sha512": "efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
         "dest-filename": "shebang-regex-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/shelljs/-/shelljs-0.5.3.tgz#c54982b996c76ef0c1e6b59fbdc5825f5b713113",
+        "sha256": "1f8ea9e43673b759841dc0653896625fcd84aa76c7a035d66269c780865c43fd",
+        "dest-filename": "shelljs-0.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/shelljs/-/shelljs-0.6.1.tgz#ec6211bed1920442088fe0f70b2837232ed2c8a8",
+        "sha256": "4a7c7105ace71d0ba229b2e170938a4e90e2d7a3fe28003478cd2013f4563690",
+        "dest-filename": "shelljs-0.6.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9389,6 +20820,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590",
+        "sha256": "321438d319f77cde19451f7dd53999bbcdfa9760e840be888f1c978bfba68d3d",
+        "dest-filename": "sigmund-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d",
         "sha1": "b5fdc08f1287ea1178628e415e25132b73646c6d",
         "dest-filename": "signal-exit-3.0.2.tgz",
@@ -9396,9 +20834,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d",
+        "sha256": "d8900ed050db9f8e5c27529d43c025d0bbbb16737ca199d86bd50fdc8c5bd2d8",
+        "dest-filename": "signal-exit-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c",
+        "sha512": "554278f450bc5353b1c192f121b4d3ac3bcb9dfffa4c383165c2bcc3147ccecd77c69c7bc5b1bad2774196136b162d8432e151a1e0e824eef0b6148bab8d848c",
+        "dest-filename": "signal-exit-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9",
         "sha512": "c270f6644fa5f923c2feea12d2f5de13d2f5fb4c2e68ca8a95fcfd00c528dfc26cc8b48159215c1d1d51ae2eb62d9735daf2ebd606f78e5ee2c10860c2901b19",
         "dest-filename": "signal-exit-3.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04",
+        "sha512": "6f3c99d5ef3cc3d3b588d25b2a73a5bd84eb58f0e5e3a3b56c6d03dd7227bfef6d90faf1acdf235144e21650e4926296827d4ce827c8035dd2b86a8e6bd2a8af",
+        "dest-filename": "signal-exit-4.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9420,6 +20879,13 @@
         "url": "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543",
         "sha512": "6ebbfba795a01f48e6409af56430df2833927965a0f8e572a46f7d03fe6f6063ea27aa7189a1cbcbc9f1b458c103ba0c6b4d5e6c0f607e1d6e30216a3ae5f1bc",
         "dest-filename": "simple-get-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/simple-mime/-/simple-mime-0.1.0.tgz#95f517c4f466d7cff561a71fc9dab2596ea9ef2e",
+        "sha1": "95f517c4f466d7cff561a71fc9dab2596ea9ef2e",
+        "dest-filename": "simple-mime-0.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9459,6 +20925,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55",
+        "sha256": "b2fae45c196161d0ee126a0f4f0ef293dac6f5cd3939564f434de31fb12acd31",
+        "dest-filename": "slash-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44",
         "sha512": "6582a1dd6876cf53e91175abd0ca52059d15ea66470107d87afb6d3b5d5ce7509a5a319369a762299fb056dd4f6cc943579aa1305b25a5909e9a1c0e2bb0bcf4",
         "dest-filename": "slash-2.0.0.tgz",
@@ -9473,6 +20946,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35",
+        "sha256": "435767fe94dda9db3b0f0864abf90097fab8fd2ae0eee78469570a5005e037b6",
+        "dest-filename": "slice-ansi-0.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636",
+        "sha512": "42ef950b713060b95d29ad5f0b1baebd42ef48938a12093da62f1d65e0952bb4ea05f50d4c7e2c1649388e88fc69f5527c062026848e7ad8f1f5058e279998a1",
+        "dest-filename": "slice-ansi-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787",
         "sha512": "a52cafedb4930bb8a0f437206f0f40b913546f993957aa03b9d8d9a0c052af5deaa4b046eed07ece00a40118eaef121481dcf93f541ef2efab486768b8e388c9",
         "dest-filename": "slice-ansi-3.0.0.tgz",
@@ -9482,6 +20969,13 @@
         "type": "file",
         "url": "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707",
         "sha1": "56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707",
+        "dest-filename": "slide-1.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707",
+        "sha256": "4333b89d6f3263f223ba6b87eb7890112515576ca8161822b488a5b4b8f76b18",
         "dest-filename": "slide-1.1.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -9522,6 +21016,97 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d",
+        "sha512": "16dc8e9d637fc021d355738cc2f4afdba77e928e6f5a52030face8509ecb5bcbe1f99042f107658ef7913fe72b36bb41c22a04516cbfe1d32d6c18c0e22a0d96",
+        "dest-filename": "snapdragon-0.8.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198",
+        "sha256": "6913bd03125d36dd741d4ffac1620170b568c655a1751bfb7e2ebb3ffa3edcf0",
+        "dest-filename": "sntp-1.0.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8",
+        "sha256": "50c45334c7f8c0ce7901aa3c8783a1486af1f88801df36bae3b185f2b1a0f796",
+        "dest-filename": "sntp-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz#cb6d4bb8bec81e1078b99677f9ced0046066bb8b",
+        "sha256": "2e77cb2dba9c662727456376fca5303de916aa45c052459e9e5f103d89762628",
+        "dest-filename": "socket.io-adapter-0.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-1.7.4.tgz#ec9f820356ed99ef6d357f0756d648717bdd4281",
+        "sha256": "11649396bfeb9f84c0d429cae43ac43aebee52ae7054c8a929c36173bc00782f",
+        "dest-filename": "socket.io-client-1.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-2.3.1.tgz#dd532025103ce429697326befd64005fcfe5b4a0",
+        "sha256": "d53b9c44862932e75e4160740eda459d7ed671add3c50f5bea93034ea26e6ebf",
+        "dest-filename": "socket.io-parser-2.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/socket.io/-/socket.io-1.7.4.tgz#2f7ecedc3391bf2d5c73e291fe233e6e34d4dd00",
+        "sha256": "d303da86902f0adbf16dcfdeba19e99eecf97e0d82a37dd1ccc0cc675b3a8939",
+        "dest-filename": "socket.io-1.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.1.4.tgz#5babe386b775e4cf14e7520911452654016c8b12",
+        "sha256": "de4fcc377bac4af39dfa64b4137a969976fb87104e56501e7b108d415ecd3bc2",
+        "dest-filename": "sockjs-client-1.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.19.tgz#d976bbe800af7bd20ae08598d582393508993c0d",
+        "sha256": "7d55543b0c4dc2fc378246c6c8dd8a9f5af159b41e7b88523c39aa5e338ec0e8",
+        "dest-filename": "sockjs-0.3.19.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz#6b2da3d77364fde6292e810b496cb70440b9b89d",
+        "sha512": "54d7a04d92a1b86ab9bd20fa5cd2a56ea5a1cadff8d02828130f17c43e9d8679bc26af4811ade721ae07c2733c5cea94d02741d01c16557bacaa21577c7077f8",
+        "dest-filename": "socks-proxy-agent-8.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/socks/-/socks-2.8.3.tgz#1ebd0f09c52ba95a09750afe3f3f9f724a800cb5",
+        "sha512": "979c7b5545166e35456da7c62f13d6918b0722112f985f39b5b21e15959cf193eda0ccb26ee1212fb2727bfa280b8fdde3c1603a34895e0b05fc024f6025bc67",
+        "dest-filename": "socks-2.8.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sorcery/-/sorcery-0.10.0.tgz#8ae90ad7d7cb05fc59f1ab0c637845d5c15a52b7",
+        "sha256": "4bc1d08cd8f0a819ccdfc08666654718249a298d6f42f6a5c69481e6ae6a6723",
+        "dest-filename": "sorcery-0.10.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106",
+        "sha256": "0430758349314b7de6d9221bd4712106449a814fe8f90892d43ebe8baa9b478a",
+        "dest-filename": "source-list-map-0.1.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c",
         "sha512": "4745ef549f56bac2e2a930848860a620208ca65702908c30475d663920fd091e6ef885d8762b1e784b970950234b9e33ab090b70f367994e0e789ead52b5a10f",
         "dest-filename": "source-map-js-1.0.2.tgz",
@@ -9532,6 +21117,27 @@
         "url": "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a",
         "sha512": "d0a5b6c2fcdfc66f0d0936f7d33d0b30dc8fa9609d0c6136be2c3351ab9ca897644d15ed662498dc8fb603a9d502399d3b2d08e2053c0f09d5546b24f63bcfd8",
         "dest-filename": "source-map-resolve-0.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259",
+        "sha512": "323aacbcdc32cf5b3493cd46a33ffdbd105ef5265d074f41770fbfcd8c8efb70ae3e4e9fa2e4dac6c707920b44f232af7f4d6455f97cae21f311143f91e7da48",
+        "dest-filename": "source-map-resolve-0.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.3.3.tgz#34900977d5ba3f07c7757ee72e73bb1a9b53754f",
+        "sha256": "6c89a5f7edde84551d5807254aac27ab16c0bf6ec90584cf0e7d69eb7f110bfd",
+        "dest-filename": "source-map-support-0.3.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f",
+        "sha256": "82e7eb70bc5039b1e194e98f65eea2740bba35a4eda384eadba7d5867a60ade0",
+        "dest-filename": "source-map-support-0.4.18.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9550,6 +21156,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042",
+        "sha512": "79fc8b4490ebebc0fd84104d20f5858e1a45cd4461f8a272910c2f3325b9522673630a05ea5e1830c0c8249132156c560aa7f2c4bcf3ead49f50547e9175ec55",
+        "dest-filename": "source-map-support-0.5.16.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61",
+        "sha512": "5a89e6ef3382209cc1190741fad86c3daaf4918b8223362fc59c2505af3bca2fcc763bfb4e2a7673255b2e3e68d1c14f37811592e4f06f71830f2531d831a71b",
+        "dest-filename": "source-map-support-0.5.19.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f",
         "sha512": "b811d4dcbddccec232617297f3c7ddac6a2fc5d482a13183459e92617b524712d95331e0e4fffae87b7aba85251eef4466877e8a75e12a8dea420c17513ff2d7",
         "dest-filename": "source-map-support-0.5.21.tgz",
@@ -9564,9 +21184,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.1.32.tgz#c8b6c167797ba4740a8ea33252162ff08591b266",
+        "sha256": "5a1773319923f7b03024ddcb340c01545a17225d7343a9e27d285240fbd14b3d",
+        "dest-filename": "source-map-0.1.32.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346",
+        "sha256": "a9e6acfb560b35dce41537edf7f3b9e06f288e4f38bb19e4443957fc283c2a2b",
+        "dest-filename": "source-map-0.1.43.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d",
+        "sha256": "ea283cef95a195436930870a771a2cde087ccc9733ee7d116757427989078e07",
+        "dest-filename": "source-map-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b",
+        "sha256": "11bee89581e5e24e73450aabcd55550007e20db26c4632c5b909001fc2b5a708",
+        "dest-filename": "source-map-0.4.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412",
+        "sha256": "5b6d427a47255f75c923ceaa50b39567837a784f988fb5937b55bcfa6521e971",
+        "dest-filename": "source-map-0.5.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
         "sha1": "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
         "dest-filename": "source-map-0.5.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
+        "sha256": "e1de289bc493154f00a11cb4e363e0bb37619537d44b36b8112bba4924116b67",
+        "dest-filename": "source-map-0.5.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263",
+        "sha256": "bdbca10d17ff5a5802d5acfc7b2f22f9f9bf587632a95650d3c5f513c7092b86",
+        "dest-filename": "source-map-0.6.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9578,9 +21247,72 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383",
+        "sha512": "0a40a3ea088ddd2fa7f6aad88814d7e60cacb6510d9d15b98d978d2c7a5ee9ab9ef92ac7706e55630ba3856f6ce1d637d66106b31043ac747aa08ebd7d35ec69",
+        "dest-filename": "source-map-0.7.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz#c8fd92d91889e902a07aee392bdd2c5863958ba2",
+        "sha256": "d073dbcbe0d76d417ed2c187e45337914c97d02a58e0f7a24ab0c1f9e3e5ef7c",
+        "dest-filename": "sourcemap-codec-1.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.0.tgz#1acbbfb592436d10bbe8f785b7cc6f82815012c3",
+        "sha256": "0c26520e43d63c0e9e6aad6ee771f3a1735a2b7b5cab41f41c212a1651c26c17",
+        "dest-filename": "sparkles-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.2.tgz#cff58e73a8224617b6561abdc32586ea0c82248c",
+        "sha256": "90b9959ebaa48ee79829db94f18e437803810c6e7897a07745fa3eef7e810159",
+        "dest-filename": "spawn-wrap-1.4.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.3.tgz#81b7670e170cca247d80bf5faf0cfb713bdcf848",
+        "sha512": "22007c99dd105bffad5aa71abee16029847fa8846f26444b3c90c56a85ed2cb51a55c0832b4f877854e49901e3ddea6b71885cfa03a5d1a100d70eea66561ecf",
+        "dest-filename": "spawn-wrap-1.4.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40",
         "sha1": "4b3073d933ff51f3912f03ac5519498a4150db40",
         "dest-filename": "spdx-correct-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82",
+        "sha256": "849cfd33e675d3b21e83a7abde4ed870e9020d8da45f574ac7c62949ea3b34b1",
+        "dest-filename": "spdx-correct-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4",
+        "sha512": "96bd8464272d0b604d47b8fb5b32761690f39f1932d6c8dfc6fbd8132cf13726fa9595c7383984a09785bb826ea589647e16b5299a49ca8aa227ba60035aaaf1",
+        "dest-filename": "spdx-correct-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9",
+        "sha256": "d4b0c730872adc42b64f7b0c9d9df11f8d7c17033e460754d2780f775e63f4ae",
+        "dest-filename": "spdx-exceptions-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977",
+        "sha512": "d9740009f1252a2f529556f509869d2835efa1a8cf80154f9ff80e40bad3bc774495a561afb6446ea25a46724b54d79a23870c10081509e04c285e8c5910c244",
+        "dest-filename": "spdx-exceptions-2.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9599,6 +21331,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0",
+        "sha256": "dd8c30ca9c877df1ca37aae208bee889de1dd75b60d6dde8b3f454863f4bf214",
+        "dest-filename": "spdx-expression-parse-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0",
+        "sha512": "620e83dd7a510f89243a64e97606d48842452a08491f4ddf882d4e3e597987fd2c3ba9de8768ea443547390e28fcb31e6b4b600a46cc81e6b98a9fdef8c916ca",
+        "dest-filename": "spdx-expression-parse-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679",
         "sha512": "71ba87ba7b105a724d13a2a155232c31e1f91ff2fd129ca66f3a93437b8bc0d08b675438f35a166a87ea1fb9cee95d3bc655f063a3e141d43621e756c7f64ae1",
         "dest-filename": "spdx-expression-parse-3.0.1.tgz",
@@ -9609,6 +21355,13 @@
         "url": "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57",
         "sha1": "c9df7a3424594ade6bd11900d596696dc06bac57",
         "dest-filename": "spdx-license-ids-1.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87",
+        "sha256": "872b0605cf18a828085f369108e87c0551ee9e84f49b64aa04aca1efdcf249f8",
+        "dest-filename": "spdx-license-ids-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9627,6 +21380,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2",
+        "sha512": "3733558490d8a7071e5558a2f3f1eee8329f0f61be36b407952fd5fea82fefadc462e755c0470c40dc5dda587ed15ad40725cdfe826497982b3a1616bd05188b",
+        "dest-filename": "split-string-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f",
         "sha512": "f4d4e18e98199e27d3909a734d9ec4b9ef394b8f50c29361653aba19127039b6fa8e72c534607b426ef75791dec1344e3f2c43d02dbdc6a99a23af1b42d57e86",
         "dest-filename": "split2-3.2.2.tgz",
@@ -9634,8 +21394,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/split2/-/split2-4.1.0.tgz#101907a24370f85bb782f08adaabe4e281ecf809",
+        "sha512": "541889c459318974655087b23108bcb38860bca0928ed92726ffcb5586eb8002cfc1fe7348a984c15f4bb2ddb9024bcc0e7bf1383ba08dd97a29983028cd5661",
+        "dest-filename": "split2-4.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c",
         "sha1": "04e6926f662895354f3dd015203633b857297e2c",
+        "dest-filename": "sprintf-js-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c",
+        "sha256": "3afb26bcc328dc90f516515acf2783ad35b08dbfe9e0ada18264c3c4ddaa1a83",
         "dest-filename": "sprintf-js-1.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -9648,8 +21422,50 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a",
+        "sha512": "3a8fb4444155e7dfebcf781f24d2908819707c7692112975a5c1b200142c9e721f58e16de89363e600a883653a30b67ffc81980fe9c0f2723e9934a144445e68",
+        "dest-filename": "sprintf-js-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3",
+        "sha256": "9f32e58102bd59ea8459d25b76697d7734ded220be55f26ab7dea9b8068e8a7d",
+        "dest-filename": "sshpk-1.13.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.1.tgz#130f5975eddad963f1d56f92b9ac6c51fa9f83eb",
+        "sha256": "f977688300749453b55875dd37d1ada68d4c2d6dad06b275530c025af0da7ae4",
+        "dest-filename": "sshpk-1.14.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877",
+        "sha256": "5c4adda13e7ac814c9668bd3d495e3292f4b5d041f181bf5bbd092dd5d2b0839",
+        "dest-filename": "sshpk-1.16.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ssri/-/ssri-10.0.6.tgz#a8aade2de60ba2bce8688e3fa349bad05c7dc1e5",
+        "sha512": "306ac51fd67834ff48ca1aa7d7ab03b41a5144d27463684d6ba0fae61ef7e9f55268f087af80cce2c59436f55a4ae0bed0e046870b2bc9d4309a07e0e4b9dca9",
+        "dest-filename": "ssri-10.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0",
         "sha1": "547c70b347e8d32b4e108ea1a2a159e5fdde19c0",
+        "dest-filename": "stack-trace-0.0.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0",
+        "sha256": "71e0893a625d234c68481c334ca127ef6c5521eaa3d49d743801f8d83b775f5f",
         "dest-filename": "stack-trace-0.0.10.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -9658,6 +21474,27 @@
         "url": "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620",
         "sha1": "d4f33ab54e8e38778b0ca5cfd3b3afb12db68620",
         "dest-filename": "stack-utils-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620",
+        "sha256": "7001ef639484f4a3900116940f98f94563cfd8e79d21148f082f18c8ebed7e25",
+        "dest-filename": "stack-utils-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8",
+        "sha512": "3135fe31e1b953df7871ace48ddffd28d01aa6c1e789b8cc2e77d7a1d9645f0efa24479ad1488dcebaa2773a357a633093bc3942173d8dde019fd4c16f5305c0",
+        "dest-filename": "stack-utils-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5",
+        "sha512": "c6b41c99884eb27ff5917f95adaabeee3e281368ffe8116c719d1eb66620f35c6e33c1aad34db63f16fcf88aa03855086b11ecd0a6926fb4f5f8e7a088dacd14",
+        "dest-filename": "stack-utils-2.0.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9683,9 +21520,79 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e",
+        "sha256": "c0257c2ba7fb97985f520fe1759ee544f4c893ad51e983ad5c46993906f5b252",
+        "dest-filename": "statuses-1.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087",
+        "sha256": "81e0aef6a3eec7052cb17e440353f8428cda89b0300988b43095fc196df48c2a",
+        "dest-filename": "statuses-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63",
         "sha512": "470340f59ffb3eb2b4eab60b23314c95a17e97bde2c29ceca9120581b30b6d370b0fa70e6a8f364da59e7cf5d0bc1d9f382e008ee612127752ecdfe64c26e475",
         "dest-filename": "statuses-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db",
+        "sha256": "f176a8f8894f121850c6159c355b1b29bd0721d3d78f34b017ed5959f3cbd65f",
+        "dest-filename": "stream-browserify-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stream-cache/-/stream-cache-0.0.2.tgz#1ac5ad6832428ca55667dbdee395dad4e6db118f",
+        "sha256": "2e98637f1b945c70b82d4d537596709e558a6362a5cdd5b938293bd49071c088",
+        "dest-filename": "stream-cache-0.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stream-combiner2/-/stream-combiner2-1.1.1.tgz#fb4d8a1420ea362764e21ad4780397bebcb41cbe",
+        "sha256": "5dee4089a53bef9bba9fdf073774421c31dd82529e70c5aac57fa452cd1bca55",
+        "dest-filename": "stream-combiner2-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stream-consume/-/stream-consume-0.1.0.tgz#a41ead1a6d6081ceb79f65b061901b6d8f3d1d0f",
+        "sha256": "33fbd56f6cb65a27aaa75611d2f341b60e47349d8bfc0a47231a8d2ea18f98f3",
+        "dest-filename": "stream-consume-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.0.tgz#fd86546dac9b1c91aff8fc5d287b98fafb41bc10",
+        "sha256": "53ea6288862527d77d2ed66c2a80731be30c316536eb80cbae96cf711d366a43",
+        "dest-filename": "stream-http-2.8.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952",
+        "sha256": "d9c3a1a5159fd000e974ca9e933ca3590fc854b556b2046053c65fb061c8e785",
+        "dest-filename": "stream-shift-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/streamx/-/streamx-2.16.1.tgz#2b311bd34832f08aa6bb4d6a80297c9caef89614",
+        "sha512": "9bd4188fa5b2816c966b71f5618ebd6a6af89d5832eb5c5f8f2b3bc4eee4be22f9adf2047369da7fe7b0162380f9a1090fbcb424ede1d86a2252fe130f0106cd",
+        "dest-filename": "streamx-2.16.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6",
+        "sha512": "6aa0f6434d78e19fbf46a1b9d8d78712465ab930145893bc73ac937ed18928edd38dae6d52021f98897a904c6f86dc520cfedf5c1e83bf391f32909dfc5dc6f9",
+        "dest-filename": "string-argv-0.3.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9704,9 +21611,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
+        "sha256": "97e54ded8cca6d24a58e8d0650fcfe80fb4094894c2078136b4ad0f24059e25d",
+        "dest-filename": "string-width-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e",
+        "sha256": "b4922d20363327278e65819559d75f036d4685190d29deb3a96999347a009dd2",
+        "dest-filename": "string-width-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e",
+        "sha256": "227cdc0ce920900ba08c9c53bdfbd36ab22d78d9657dbb6108e4f9b9ae59792c",
+        "dest-filename": "string-width-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e",
         "sha512": "9cea87e7d75e0aaf52447971ab5030f39267b78c3a2af2caa9656293aa00f599255cb3483a5aa0e05db2ad3d4c55a4e302abd5c1d7de67bc3b682bc90fbba093",
         "dest-filename": "string-width-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961",
+        "sha512": "bda7dcbfa2a3559292833d3aa0cfc7e860c1ac0b73f2f76141a9068c522f36b1c0eb2dc7085d422272f2f902eaf1d4c93d0d5bf8a0d4a8315cb647515b8e1ed7",
+        "dest-filename": "string-width-3.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9721,6 +21656,13 @@
         "url": "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010",
         "sha512": "c0ac90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe",
         "dest-filename": "string-width-4.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794",
+        "sha512": "1e72ce091def8dc63c6dea0d2ed723679fe7c67d9a7e6304ea586b0eb79ba24a8c6a9f976de5bc9fd4d7a4f0cea9d18ae6a708de84f418a4d6eb00bb10c895a8",
+        "dest-filename": "string-width-5.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9753,6 +21695,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea",
+        "sha1": "d04de2c89e137f4d7d206f086b5ed2fae6be8cea",
+        "dest-filename": "string.prototype.trim-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz#f9ac6f8af4bd55ddfa8895e6aea92a96395393bd",
         "sha512": "95f8d8e07722c5f41739f6aa0af701b8e21aa726aba135e16e47c937781c0753adcaea678162b8b04113f4a9ddd1c5dddbc91352abbf907a15e0729225d9e389",
         "dest-filename": "string.prototype.trim-1.2.8.tgz",
@@ -9781,6 +21730,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634",
+        "sha512": "149e9bec481d2b1c5b0f173bf5c3a5a24e807ddfbe4d3b39b33a3ecc94d4ca8c37c9cad17c9544da9ab7bdc379dd77b1bca66efc324c0df788fea322653ae34f",
+        "dest-filename": "string.prototype.trimleft-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz#669d164be9df9b6f7559fa8e89945b168a5a6c58",
+        "sha512": "7d7653495e7974d070bf5eaec3e861e639208714a7739a07abee4afe05e08b31f002f31eb5d009947aaaa050b51520d53d858b9002a5d9cc69513e35b15ee74a",
+        "dest-filename": "string.prototype.trimright-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed",
         "sha512": "8e1e9ef7ce0e05fbf14b9d2d758da74599e80b9fe62c528e44441fc3cb79cb2b64a14b0944dc6f23f137f6abb5b03d0eb56237382d1780a4a6716c338b062e67",
         "dest-filename": "string.prototype.trimstart-1.0.4.tgz",
@@ -9802,6 +21765,41 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94",
+        "sha1": "62e203bc41766c6c28c9fc84301dab1c5310fa94",
+        "dest-filename": "string_decoder-0.10.31.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94",
+        "sha256": "3e6e6ffeafe6157eb2278a909afc0b845234b13446dca8a9518c2b79b9c22086",
+        "dest-filename": "string_decoder-0.10.31.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667",
+        "sha256": "6fdee292992b73c222819029592876be7b1217944850210cdf43a4e3a84020a1",
+        "dest-filename": "string_decoder-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab",
+        "sha256": "56c1525e1423067916604f80b89753527c1ee7b43b51373d579676b4b5e36ba8",
+        "dest-filename": "string_decoder-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+        "sha256": "af8262434508fa8292407f7fef4690d19eabb73387ca230b41f2a1155216963a",
+        "dest-filename": "string_decoder-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
         "sha512": "9ff4a19ef0e2e851db6d57ef8aba3e5a88e2173bfeb3c30f30705ccd578f7d4a4324bc282d3d21b759786300426e2f29240bde104767907c8fc933ff9b345fc2",
         "dest-filename": "string_decoder-1.1.1.tgz",
@@ -9816,8 +21814,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878",
+        "sha256": "ed686bc9c2641ff7bb002b7c3bf58e2b8193f535490de7d07669ef465b40fcf3",
+        "dest-filename": "stringstream-0.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
         "sha1": "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
+        "dest-filename": "strip-ansi-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
+        "sha256": "1c9d385a4118959514f84dce8d7bb2dafc802f0272dd00348aa18d17b95b793a",
         "dest-filename": "strip-ansi-3.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -9826,6 +21838,20 @@
         "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f",
         "sha1": "a8479022eb1ac368a871389b635262c505ee368f",
         "dest-filename": "strip-ansi-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f",
+        "sha256": "aab0a8473699e01692bac2bb83d5460e295a3dad0e6653e0dd6af57e8ff6202d",
+        "dest-filename": "strip-ansi-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae",
+        "sha512": "0ee46cd6029b06ab0c288665adf7f096e83c30791c9e98ece553e62f53c087e980df45340d3a2d7c3674776514b17a4f98f98c309e96efbdcc680dc9fa56e258",
+        "dest-filename": "strip-ansi-5.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9840,6 +21866,34 @@
         "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9",
         "sha512": "637f153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
         "dest-filename": "strip-ansi-6.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45",
+        "sha512": "8aae9e55523ae274104d162ad8ab44836776b94ecb125853270b07e18cc81d9b21c658199acff021ce15a03413946fc8bd522b04a1b4e82ad99e9d2abfb86471",
+        "dest-filename": "strip-ansi-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-bom-buf/-/strip-bom-buf-2.0.0.tgz#ff9c223937f8e7154b77e9de9bde094186885c15",
+        "sha512": "80b14d1ee71dea0cdbf2332c9794266774209d4266a7baa7e2e5121cdc045ee980a7b622ce8198c35f595157eeab868139052dca7da4f17fc2c33581ef75b695",
+        "dest-filename": "strip-bom-buf-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-bom/-/strip-bom-1.0.0.tgz#85b8862f3844b5a6d5ec8467a93598173a36f794",
+        "sha256": "e093942ea7c12af2e0236ec9e93f2759919a1bfb099c53ce6ce8961b0ef108ac",
+        "dest-filename": "strip-bom-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e",
+        "sha256": "ad9ed163db6586739e6576b48ea76349b83ad460fee5c8e6a8fb481883fd0653",
+        "dest-filename": "strip-bom-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9865,6 +21919,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf",
+        "sha256": "f2bead0b21242d44edb6d3d1852fc456fc56ea9489cd8b9a85a458055b219c5d",
+        "dest-filename": "strip-eof-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad",
         "sha512": "06ba6f7cd004ddd72fabb965df156e9b38ca8d9439b48d6c11420aaf752892cd17525e394addc595ab55a9e7fda6b9388d10f3856e96660fb76e4f77cbaa4b8c",
         "dest-filename": "strip-final-newline-2.0.0.tgz",
@@ -9879,9 +21940,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2",
+        "sha256": "bea31071c9346ea38853ad41190455d725f89c0796ea1cd7f478b2385baded00",
+        "dest-filename": "strip-indent-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68",
+        "sha1": "5ef8db295d01e6ed6cbf7aab96998d7822527b68",
+        "dest-filename": "strip-indent-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91",
+        "sha256": "9850cca91d8bcbefb99eaf250c984ea47c980d57836eeb7d3b31717497527112",
+        "dest-filename": "strip-json-comments-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a",
         "sha1": "3c531942e908c2697c0ec344858c286c7ca0a60a",
         "dest-filename": "strip-json-comments-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a",
+        "sha256": "dbe45febaf1bf7265c25733242bc0e7ac38b632db6a8e19f0341af4770425899",
+        "dest-filename": "strip-json-comments-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7",
+        "sha512": "553c8c0147dd9b4e3b9b02a5faeefd58876b671b45b67fa70711de6fce385c143db8c353b931ddc7685ce51880258ab04e3df073fc5ee472d27494a427e59f67",
+        "dest-filename": "strip-json-comments-3.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9914,6 +22010,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/supertap/-/supertap-1.0.0.tgz#bd9751c7fafd68c68cf8222a29892206a119fa9e",
+        "sha512": "1d927781e20c3e05702a4d95b263b9607aa79c9625e9b57903d256daecea578dd69a982588d1186eebee91fa2bed44696aaa71bb0dc27d9dce35d55b6630a020",
+        "dest-filename": "supertap-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e",
+        "sha256": "575916b4275b3b5d544e917433ce65651998fc878e9a1e020abe5b10fbec7ec8",
+        "dest-filename": "supports-color-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7",
         "sha1": "535d045ce6b6363fa40117084629995e9df324c7",
         "dest-filename": "supports-color-2.0.0.tgz",
@@ -9921,8 +22031,29 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7",
+        "sha256": "725d4b25d44e0f16eb986ba957c14d9c8540de2f6a4fca961bf1f60aa1659ad3",
+        "dest-filename": "supports-color-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5",
+        "sha256": "38d3e0f27fefc6ace202c5afcdc49bb06fd10ea9e078fcc36ee7af603e9c9665",
+        "dest-filename": "supports-color-3.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6",
         "sha1": "65ac0504b3954171d8a64946b2ae3cbb8a5f54f6",
+        "dest-filename": "supports-color-3.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6",
+        "sha256": "b8538096cce414fe297eb5d4469939a8890f4c21f75a9b74b43c0ff0f34b99ee",
         "dest-filename": "supports-color-3.2.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -9935,9 +22066,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0",
+        "sha256": "b6c531585c477493de12ae11eabf89bb87c1fb209a256668e83e1d696d033514",
+        "dest-filename": "supports-color-5.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
         "sha512": "423563c1d5c8b78d3c308880a825f8a142ac814d84a801b3b363e9926e1a4186e39be644584716e127c5353af8b8c35999ad1ecb87f99602eb901d1a5f440ca3",
         "dest-filename": "supports-color-5.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3",
+        "sha512": "a9ed637e6d4c83b36afcd4a1e97136e203d744e115b161f10b52c8c7ffd73650fd8b0ed86501a364d8d837bc466841ba88a740f04b4d156e91d208e7557a7ec1",
+        "dest-filename": "supports-color-6.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1",
+        "sha512": "a11488a51f29c53d56af616ab9336719eb7bf5bdc15a58ea3aea16fe1e28061c49fc751b5f99d7e894abb9392f5c30853300cfbec6934dbbcc2ca6564b2d11e6",
+        "dest-filename": "supports-color-7.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9956,6 +22108,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz#f663df252af5f37c5d49bbd7eeefa9e0b9e59e47",
+        "sha512": "ce8139fdef9d9c48a393a01207afeaacafa861d9b6768d618e82d6aea502ffc584216d606f115c2ae0687fbb16f00acde9ef8062fb04f070468954562ff17908",
+        "dest-filename": "supports-hyperlinks-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09",
         "sha512": "a2dd169d74bd7e076480871e3dee911cd935580f3e9ae3dae9c4a3791dd5f0adbbabd041d6b4c4dd1d69ec7bf4cf567201cf2ce95beff0323259febcd4c02dd3",
         "dest-filename": "supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -9966,6 +22125,13 @@
         "url": "https://registry.yarnpkg.com/svg-element-attributes/-/svg-element-attributes-1.3.1.tgz#0c55afac6284291ab563d0913c062cf78a8c0ddb",
         "sha512": "061d397523a72417f79a234caa9b28ae67cdb5f89d03f1b14156a486d9f44f80c409629e5d045051c7988c9f8ec588a22dd19ee09a3d88557cc080856a915e20",
         "dest-filename": "svg-element-attributes-1.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804",
+        "sha512": "7bdd349ccf1146d1a1955dfa286114f64eb92b798f6f5595ef439d8dfc651b6100b8cd67a22fc4fc1696fee3212fb6cf12cb0af10579eef3777ac8b18d4bdc5d",
+        "dest-filename": "symbol-observable-1.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9998,9 +22164,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f",
+        "sha256": "f19282cba5059dd103eef1cb5743eea52f45348a0b224b9f783a04a96cd563c0",
+        "dest-filename": "table-3.8.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e",
+        "sha512": "c2611cf26e1f8e7a1be20b79ae2151b53bbfebee2b49ed764e90042cd4aa1cc7c5dc8aa703e087dfb51233afd8477a9166fedee7a900100b5dea72996b17b452",
+        "dest-filename": "table-5.4.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tap-mocha-reporter/-/tap-mocha-reporter-3.0.6.tgz#12abe97ff409a5a6ecc3d70b6dba34d82184a770",
+        "sha256": "fc4cb7bf0dd1e0ebddc8635da9e2a7a6e5a4fc6c5bb1b30646d35612a801a416",
+        "dest-filename": "tap-mocha-reporter-3.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tap-parser/-/tap-parser-5.4.0.tgz#6907e89725d7b7fa6ae41ee2c464c3db43188aec",
+        "sha256": "6fd4b98896f7e39508e5ecb9bf2c54cbd611de40f1649126c69ead97d050fbb4",
+        "dest-filename": "tap-parser-5.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tap-parser/-/tap-parser-7.0.0.tgz#54db35302fda2c2ccc21954ad3be22b2cba42721",
+        "sha256": "24dfc5ee0537382ff27cd8f3bd810b81cdf88c438f88221229acea67d1eb5043",
+        "dest-filename": "tap-parser-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tap/-/tap-11.1.1.tgz#6dbd23c487127f621a95c793f7a247fa7e2c053a",
+        "sha256": "9a57c8abc0ddf4db74a89120a55c1ba1c99abeabaf4276bf9c470e33fddbd041",
+        "dest-filename": "tap-11.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tapable/-/tapable-0.1.10.tgz#29c35707c2b70e50d07482b5d202e8ed446dafd4",
+        "sha256": "5931834d6d865f4cefeb097975be3ca349a4d4481abca65041f713f790a952c1",
+        "dest-filename": "tapable-0.1.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0",
         "sha512": "18dcd0bd04ce20fe91c937c4d90c5bf19565366c349fcf2fa75b33c1646298fd369a74ecc775ad9f9a9176a63dc365ddb8535482f3b084d9d0b23c02a7e92a69",
         "dest-filename": "tapable-2.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tape/-/tape-4.10.2.tgz#129fcf62f86df92687036a52cce7b8ddcaffd7a6",
+        "sha512": "9a0976de1ed6db2ba4dcdf3914e62b8a7d8ebd38536167706e4e97435a6bd8f30989ec96d8533fe01bbffa40ffc1e71bdda6741279be4b28a7caae3aece3eadb",
+        "dest-filename": "tape-4.10.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10012,9 +22234,65 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784",
+        "sha512": "574af663db1c99b0d12c235ec7ffa1633be9ff3c988ef15b1cf36055329f42f56b6fa82e884fdfc4ff976e50cd474d75bada296e47b1da7338747355e860ec9e",
+        "dest-filename": "tar-fs-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f",
+        "sha256": "ed8e0f05894021c7bfda1a17e5de5ab0eff196f164b2398128c79d51f2b31647",
+        "dest-filename": "tar-pack-3.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.1.5.tgz#be9218c130c20029e107b0f967fb23de0579d13c",
+        "sha256": "9838172d61c0b51472be126f379cd872673df9b309e9b329f5cac4f467b052fd",
+        "dest-filename": "tar-stream-1.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.0.tgz#d1aaa3661f05b38b5acc9b7020efdca5179a2cc3",
         "sha512": "f83027e0d6f8fa0cfa5998a0473284665d50b8954e2ed030c05f96531cb57c9e97eb709a19a500c49443d8a127d4e31f71b0a3c924d8a4d0ba5a67d0a0810e77",
         "dest-filename": "tar-stream-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287",
+        "sha512": "ba37aa6dc780060c0c6711099e4d870d8d83967519fbda0471bd4acd355f6078a8d1413a746ef59fad1df03d88e2a36f95e5abad7a668e9b7bbd9785d4b9cc65",
+        "dest-filename": "tar-stream-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.1.7.tgz#24b3fb5eabada19fe7338ed6d26e5f7c482e792b",
+        "sha512": "a898fad025edec853515fc9cdcd24c8e1e8492e0857a3e3acd4a89e09ee9a9895387277d6ced1705399c388852cd925559fb0b92cd3e9e57bf8f9dfc6005bd45",
+        "dest-filename": "tar-stream-3.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1",
+        "sha256": "1f187a298c96f42a825117e9e40a986749133ce1f7fd05d9aa70ba581c131f37",
+        "dest-filename": "tar-2.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40",
+        "sha512": "14212143fe2b135cd8bfdad85c9c3f9ac46ab279a58dee631cfea1b9678167bd388d44f2d36739019c96ba3a4c4756b1ea6570f4dc8931fb8ad8230359521f80",
+        "dest-filename": "tar-2.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621",
+        "sha512": "6a7fca650cd052464292ea0003ae2133dd97d14adbe95a51840165943cf3e3853699c0f9b1c993df305ce15815a64ba0179f34f83427f1e0054b2a10b74b739c",
+        "dest-filename": "tar-6.1.11.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10029,6 +22307,13 @@
         "url": "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a",
         "sha512": "0d9e323914f0adb4e3ffb31962adb0fbf645748e8e67f7fd4851d1fbbd6021551984e40f1f35422e9bd19cf83268ca5f5b1c64ff838dbdadc6412c8d20a46fe8",
         "dest-filename": "tar-6.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/teeny-request/-/teeny-request-3.11.3.tgz#335c629f7645e5d6599362df2f3230c4cbc23a55",
+        "sha512": "08a9dca9217bb07ea9e2bcc28246ffcff3dca2ce5e7e5d039a8973be5a9141435ca5122bb8e858f7e4f516c225c846df59deccb05a6875138ec07621d81697cf",
+        "dest-filename": "teeny-request-3.11.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10054,6 +22339,34 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/temporary/-/temporary-0.0.8.tgz#a18a981d28ba8ca36027fb3c30538c3ecb740ac0",
+        "sha256": "6b2f5543c0bb158434827a582f8108412b5801d0724dbb8742c031238ee5703b",
+        "dest-filename": "temporary-0.0.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69",
+        "sha1": "458b83887f288fc56d6fffbfad262e26638efa69",
+        "dest-filename": "term-size-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994",
+        "sha512": "ba7d059a245440daf93c9ab2f643fb738d05e4139fa469584ebc689c30a111907ba7367144da7f6edfb29a2cbdfe7a705f26bd287f7d9c9fc65c522252460615",
+        "dest-filename": "terminal-link-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ternary-stream/-/ternary-stream-2.0.1.tgz#064e489b4b5bf60ba6a6b7bc7f2f5c274ecf8269",
+        "sha256": "98f4464713c8c5a66a4d6425e22e4ad460e62e6aa29df563e28cce4988b72f00",
+        "dest-filename": "ternary-stream-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz#0320dcc270ad5372c1e8993fabbd927929773e54",
         "sha512": "1af959753eb03d029b0cd5bf18343364583f8f8bca53deb2976aba99c524cca3a05b88307f567c7194e8502af3df55c794f587f0c55bd6bdad16d743b53189ee",
         "dest-filename": "terser-webpack-plugin-5.3.1.tgz",
@@ -10064,6 +22377,20 @@
         "url": "https://registry.yarnpkg.com/terser/-/terser-5.14.2.tgz#9ac9f22b06994d736174f4091aa368db896f1c10",
         "sha512": "a0bd2b19e33f58540251dd32d90ad6c589eaeed7d2b8a062a938d13d6ad1801e3a583fe48b01f017c4f6df3efc1fa43a9060aeb8770f07e2942c745dc6f54640",
         "dest-filename": "terser-5.14.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.0.tgz#07e3613609a362c74516a717515e13322ab45b3c",
+        "sha256": "b2fd178972f73d13e27c7556ca5212e72fc5e414547590bac96af28434df9769",
+        "dest-filename": "test-exclude-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.3.tgz#c3d3e1e311eb7ee405e092dac10aefd09091eac0",
+        "sha512": "33ea31b6c78214edc40ed01a187ee289e8f70819335ea14c6f3a9800009dccaba2e1e640fa9ab7b591300a1bce74d7daef1c72f017db9a025222be37702ffeda",
+        "dest-filename": "test-exclude-5.2.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10089,9 +22416,114 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4",
+        "sha256": "d883f6704c060373991701894931dd859f73938dd159c66092247a403f88c772",
+        "dest-filename": "text-table-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/textarea-caret/-/textarea-caret-3.0.2.tgz#f360c48699aa1abf718680a43a31a850665c2caf",
         "sha1": "f360c48699aa1abf718680a43a31a850665c2caf",
         "dest-filename": "textarea-caret-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375",
+        "sha512": "f219a218824c0e5c2383b765278c8a18b2bc12c62a2a03d66c6ddbe308c975d28dc1cecdec3a67d3c0dfe2ccebfec65d31578eb2dadd612b2acd7e8161b701fb",
+        "dest-filename": "throat-6.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c",
+        "sha256": "a2d63351f01f2f40b62d605ec6a98340e2962b0a717cff13bbfcfa707b622924",
+        "dest-filename": "throttleit-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5",
+        "sha1": "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5",
+        "dest-filename": "through-2.3.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5",
+        "sha256": "16b27a8c0fb13e5727356b328d72dbbc5f20bd909252f14d19da344e9354573e",
+        "dest-filename": "through-2.3.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48",
+        "sha1": "41ab9c67b29d57209071410e1d7a7a968cd3ad48",
+        "dest-filename": "through2-0.6.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48",
+        "sha256": "c7b3907c8ac9d4786f6aeff8d09380267e76369e00a3811b97492668f556112e",
+        "dest-filename": "through2-0.6.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be",
+        "sha256": "ecb86efbc1e5b4cf0bb0d7d63923099257f3e2b100f9e4f54bf1a46ca0de6aeb",
+        "dest-filename": "through2-2.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tildify/-/tildify-1.2.0.tgz#dcec03f55dca9b7aa3e5b04f21817eb56e63588a",
+        "sha256": "42bcd445fc0cf3a222debdddece10aa61114cb49a9d40970d3cb07645de650bf",
+        "dest-filename": "tildify-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.0.1.tgz#9f4bd23559c9365966f3302dbba2b07c6b99b151",
+        "sha256": "045b91a499b25ceb2819a6f358fe8456be23294939d79390473a20623b56d29e",
+        "dest-filename": "time-stamp-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/time-stamp/-/time-stamp-2.0.0.tgz#95c6a44530e15ba8d6f4a3ecb8c3a3fac46da357",
+        "sha256": "e42c66d55e5753e3c4898f18f11b58a3c12525f4803e85c9114639fbbf677e29",
+        "dest-filename": "time-stamp-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d",
+        "sha1": "99c5bf55958966af6d06d83bdf3800dc82faec5d",
+        "dest-filename": "time-zone-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f",
+        "sha1": "f32eacac5a175bea25d7fab565ab3ed8741ef56f",
+        "dest-filename": "timed-out-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.6.tgz#241e76927d9ca05f4d959819022f5b3664b64bae",
+        "sha256": "3bbd75f745341a9ace6745e9b4da175f32a02db239d8d68cd7afc04ec3bd90a7",
+        "dest-filename": "timers-browserify-2.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/timespan/-/timespan-2.3.0.tgz#4902ce040bd13d845c8f59b27e9d59bad6f39929",
+        "sha256": "6c8de4e470069f910b92f743b97623f0baf6300eb197a951b3dfebdb6aa64026",
+        "dest-filename": "timespan-2.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10103,9 +22535,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/tiny-lr/-/tiny-lr-0.2.1.tgz#b3fdba802e5d56a33c2f6f10794b32e477ac729d",
+        "sha256": "0ebe2d0299741005fed102ff45cd96b551eeceb0e18ac9cc179d80f271538d8b",
+        "dest-filename": "tiny-lr-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/titleize/-/titleize-3.0.0.tgz#71c12eb7fdd2558aa8a44b0be83b8a76694acd53",
         "sha512": "2b156ef046070cf05d51874a65d2ad5366a3d977c4c7d01f8d7c44fc08f4bd3d3ac3689c034f55bacd6b87a792bb5cb4d5a91883a06320afe1c722c920da0c2d",
         "dest-filename": "titleize-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tmatch/-/tmatch-3.1.0.tgz#701264fd7582d0144a80c85af3358cca269c71e3",
+        "sha256": "07ae2b8e3dfa35d691783d560755865ba7e688f41622032902197f801965cd06",
+        "dest-filename": "tmatch-3.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10120,6 +22566,13 @@
         "url": "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7",
         "sha512": "47033b3283e88cfc6c381627c9dda1cb46f1b48955ae284db3da63e5252f63c673d6c41c406dad1b5852afc3c3c5f80407c44d28386a6c896ba086ab48d0cdb1",
         "dest-filename": "tmp-promise-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9",
+        "sha256": "d23b215e6ce454f076e163a3feb7a1b548ddf44be3a41353f74837722b11d6c5",
+        "dest-filename": "tmp-0.0.33.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10145,6 +22598,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890",
+        "sha256": "4dc6972e7a55b2fa84d2717c6b8eb62bb5568ef8d14080836fc3d7859024f3a5",
+        "dest-filename": "to-array-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43",
+        "sha256": "49ae8edfcdadc33714f9a4c8fe66f8d2b827f004d7a5b10aafb4d085287b4aa2",
+        "dest-filename": "to-arraybuffer-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/to-camel-case/-/to-camel-case-1.0.0.tgz#1a56054b2f9d696298ce66a60897322b6f423e46",
         "sha1": "1a56054b2f9d696298ce66a60897322b6f423e46",
         "dest-filename": "to-camel-case-1.0.0.tgz",
@@ -10152,9 +22619,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47",
+        "sha256": "31a6db330b363a97276cea9605fdd5a0c7211af71bcb549a94f4b59bf9028c21",
+        "dest-filename": "to-fast-properties-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e",
         "sha1": "dc5e698cbd079265bc73e0377681a4e4e83f616e",
         "dest-filename": "to-fast-properties-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1",
+        "sha256": "55a3b5d0120765b9033262b20e79375d088b7f2ea2d2f6bb0cedb2421a98600d",
+        "dest-filename": "to-iso-string-0.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10169,6 +22650,13 @@
         "url": "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af",
         "sha1": "297588b7b0e7e0ac08e04e672f85c1f4999e17af",
         "dest-filename": "to-object-path-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771",
+        "sha512": "22adb95c1b7acc3e67a4f8652d55c614ddff832476fea38370a34dc9331de2f6e6dfd1d468e8803383ccab478c542fd3931cfe66376c739e60f72cb3f98ab4d1",
+        "dest-filename": "to-readable-stream-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10222,6 +22710,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655",
+        "sha256": "910b8acbe1ae08f9598b331ac952860aef61618d603620ca24a0b1df0df78683",
+        "dest-filename": "tough-cookie-2.3.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2",
+        "sha512": "9e52ec533826d647cb5d25df45931cd4a2c0ba077886a2470d3bdcda10c8c12de66407cc12e31b734dd2ba3305f8611ca5a5ffa9ba1ec9cc3a88ef09c15bf6fa",
+        "dest-filename": "tough-cookie-2.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4",
+        "sha512": "b4776d12940232b73560bacc6aa5d7723e80c61622ff1822b7a999bb5f840d6527faa8547fcc0c428148cbd357baadb7cc0c2d701d2dfcc8c0086475f297116e",
+        "dest-filename": "tough-cookie-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf",
         "sha512": "697ff2e6955191f4677e6b97f8e75b49d5ef3deea278a5ff1b6b3b7bdf1fe29a091e7a87df6f358033e6fe67ad9ba13f5916a67f1ed60b81d4aa45877d01e9af",
         "dest-filename": "tough-cookie-4.1.3.tgz",
@@ -10236,9 +22745,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/tr46/-/tr46-2.0.2.tgz#03273586def1595ae08fedb38d7733cee91d2479",
+        "sha512": "de7d6a1beff9920fa3adb4f3c00ca4079c9162d4024ea3862aae54e4f1376f46b5fe6ce8eac9c3863192d3325526e9ced0dad3dc383530bcb94e358ffd4269a6",
+        "dest-filename": "tr46-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tr46/-/tr46-2.1.0.tgz#fa87aa81ca5d5941da8cbf1f9b749dc969a4e240",
+        "sha512": "d79221ee985f71d3f9631aa207e883b4ba1a4f3e0d777e7e22202fd2443914d287cd781d5aa3e84c8a840c32665dc790b7825993a9553d3f259c394fa460e9a7",
+        "dest-filename": "tr46-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9",
         "sha512": "97b16f7c01e5726ba5a7c92bf9f969419995c2dbbb9df455ecd66e8ed3743aa112f042f83b87b4aaaccbd030b9800bf1fd90bff6593aae1714c18be406706760",
         "dest-filename": "tr46-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613",
+        "sha256": "0fb1fc939423d9068dcacbde0359a9857ad59de874a74d15e00589e480ea07f0",
+        "dest-filename": "trim-newlines-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20",
+        "sha1": "b403d0b91be50c331dfc4b82eeceb22c3de16d20",
+        "dest-filename": "trim-newlines-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3",
+        "sha1": "9f9ba9d9efa8764c387698bcbfeb2c848f11adb3",
+        "dest-filename": "trim-off-newlines-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10250,6 +22794,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003",
+        "sha1": "cb2e1203067e0c8de1f614094b9fe45704ea6003",
+        "dest-filename": "trim-right-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003",
+        "sha256": "89f3b88291843bfa6dd3aae2f154fe2e1913c4de02d821b210b7270e3cbfd985",
+        "dest-filename": "trim-right-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9",
         "sha512": "5eb1d4bd5e47a5d2e6223e2e54cc478202db152658227ec7116b2a78f65c239d29728f8c3ea279d3030663bf785fb00e3a1c4e0408db92a7c06c47bf40ca762f",
         "dest-filename": "triple-beam-1.3.0.tgz",
@@ -10257,9 +22815,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/trivial-deferred/-/trivial-deferred-1.0.1.tgz#376d4d29d951d6368a6f7a0ae85c2f4d5e0658f3",
+        "sha256": "5d5fa86e4e4975f93c83d380cd75afb20fd3a2ab15fec0907149110383f727df",
+        "dest-filename": "trivial-deferred-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b",
         "sha512": "f793eed505d0bebb86121bfad9708c3b7326f741ac70e08296fac853008cd0f60e5cade4685de5dec207c71ef54e125f71b3363b902ee923b701609211f5b899",
         "dest-filename": "truncate-utf8-bytes-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb",
+        "sha256": "ff0a7af58bd6de974b7db128637fb5744564b976344f0f5783146ccd9ac8fbfc",
+        "dest-filename": "tryit-1.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10292,6 +22864,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/tsame/-/tsame-1.1.2.tgz#5ce0002acf685942789c63018797a2aa5e6b03c5",
+        "sha256": "8f0723f35988e74a7ab72b7d7c5e0982e55935d98e972b079a3d795d57c4e57d",
+        "dest-filename": "tsame-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a",
         "sha512": "7f10e15a71522eddd5b93c2dbc9b797e9c3104783901d29632c81c3ce3888a5ca3ca6718559a02405f1fbc545ecc235f6e51179a2f8f70cd5e60778e0205c239",
         "dest-filename": "tsconfig-paths-3.14.1.tgz",
@@ -10302,6 +22881,20 @@
         "url": "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b",
         "sha512": "75172ece891685a8ed656910b0354a6d6c98fa381c2c2e6ca89860d8f4a07f86641f66873ef68e63c6161a19a36faf1be6aa937dab12b033bd93b45488499903",
         "dest-filename": "tsconfig-paths-3.9.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tsd/-/tsd-0.11.0.tgz#ede8b8e85850845b753fff7eaaf68dbd3673700b",
+        "sha512": "92528c342d0a47350868b246f17aa4bc7ffdacac185fbe31a6a24137cb295a36140e88c07ac77a01f0c24f976b6b2fb284b7d31a47a6ecede753a8b82b0ccd0f",
+        "dest-filename": "tsd-0.11.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a",
+        "sha512": "a8e79b179ddfae77bcd5c7f44bd078d41c9e9c9dff22e1fcc892a78005f7e429a2672480d24861928bec84a2be8c609a3275689a56bb81594871cdc4bca3db4d",
+        "dest-filename": "tslib-1.10.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10355,8 +22948,29 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6",
+        "sha256": "311204c6f116e7b725c1f4fe2a0dd4dbaf633ca1a466a1b7bdcb8dd1a8181a2e",
+        "dest-filename": "tty-browserify-0.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb",
+        "sha256": "13f903ff89080a44aab03e92666890dfb3ce4a7bae5b2562b0348b46737ed4e2",
+        "dest-filename": "tunnel-agent-0.4.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd",
         "sha1": "27a5dea06b36b04a0a9966774b290868f0fc40fd",
+        "dest-filename": "tunnel-agent-0.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd",
+        "sha256": "d3e3c04a50d6d2fa40654bf764fa1792f797bd5a62c69d03dceaa7d4a85c5012",
         "dest-filename": "tunnel-agent-0.6.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -10376,9 +22990,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64",
+        "sha256": "6cea33d67a9bd83f8bd250655c78a2c89ea912bcc6be91c8e65807ce69cfdfd6",
+        "dest-filename": "tweetnacl-0.14.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72",
+        "sha1": "5884cab512cf1d355e3fb784f30804b2b520db72",
+        "dest-filename": "type-check-0.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72",
+        "sha256": "d414efefe0eb03f174a507af6ff09e7537d6d66cb94f5a2eef76352d24ef3c16",
+        "dest-filename": "type-check-0.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1",
         "sha512": "5e5794a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b",
         "dest-filename": "type-check-0.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822",
+        "sha256": "d7664ad90968b11cd0a7dbf1745621bfdf131b0a90bdb0129d0edf3894b3ff74",
+        "dest-filename": "type-detect-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2",
+        "sha256": "7dd934365d1c46b6feb0ddcecd3a1fcb0aa8814cda542a5da9fe1b01fd7b49d9",
+        "dest-filename": "type-detect-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10411,9 +23060,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1",
+        "sha512": "7141899c276be124db78f0a0a8d15ba553427a96be900568849b35b0b871cdd1fe82712839df1585b61aee90f7cd9606894456336c731082377d07118b30e461",
+        "dest-filename": "type-fest-0.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d",
+        "sha512": "e1d6f3233aaf8ed822339af0d64e6b107b4100d2a676e7611b20446a3374d5f13285a00886ca0a372eb2efe20df7721fa45b7063d8aa8bb903fb1c0a850b0d24",
+        "dest-filename": "type-fest-0.8.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194",
+        "sha256": "023206c4383a0befa929b380b9bf3a1552a14430a161ec595deb54edd357c4b0",
+        "dest-filename": "type-is-1.6.16.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131",
         "sha512": "4e444aafdb144f1107f0c75fb8248fed58b3272cd134c8e3d89d9da3626bdcaca6e7df0955d124b2eccf4029e514f5b8932f50fa203e99af411a6d3a5d0072f2",
         "dest-filename": "type-is-1.6.18.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0",
+        "sha512": "fb99ede400278aab029eed9c11041da73080877de4571f27d15a0589d2a907575554b00dfc5f9b8153aa389a8e9c49eb869db6d9c941e69def5250fed500277e",
+        "dest-filename": "type-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/type/-/type-2.1.0.tgz#9bdc22c648cf8cf86dd23d32336a41cfb6475e3f",
+        "sha512": "1bd69bb035af840582576826175ccab9ddcec82eb59d90f05af04bd83029695168808d3b0a9ae082240038e8efa763518d8585ccfcaeeefc2d0eb405abc8de48",
+        "dest-filename": "type-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10446,6 +23130,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080",
+        "sha512": "cddbbc5cc3440dea4a291f9760e5c054fb56ba2d25cb436da2152c730f9499a1e20164fc86b575aebfff1fa57ed03bc9dce435f52f7bf4cd2568b7d7f2b9bcd9",
+        "dest-filename": "typedarray-to-buffer-3.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777",
+        "sha256": "3f324b75a9581c4c85cec25e8cd30831ccaa3c87770cee2ff4b9167055004108",
+        "dest-filename": "typedarray-0.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624",
+        "sha256": "9b32bd684e935101f00bea2e290879b2a0600c12d068751b8f9c92daddb42224",
+        "dest-filename": "typescript-2.8.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a",
         "sha512": "d455e4f44d879be433650ef3f8c7098872f8356d45d84cccbbd36af62df301a1aa89b69fa98c02554e96c9602ec90451cce971a2ef31652c972c437ca0a8f6e2",
         "dest-filename": "typescript-4.9.5.tgz",
@@ -10460,9 +23165,79 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611",
+        "sha512": "bdc23852946083cd68211505c11d164881cab75d6727b48056560d22ef90a6a7b25cffa0a50272fd9e3e174686c5213832ac23c97bd6fd3ce090b031d80187c1",
+        "dest-filename": "typescript-5.4.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac",
         "sha512": "f18ef9a6f4d890b256da15901d7c68a91815eea6fd07ef6f144b6274c2feee4a075056a99d524067a70ab3e423cf9030dda6561cc0babb4c0913702dfa7486c0",
         "dest-filename": "uc.micro-1.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uglify-js/-/uglify-js-1.3.5.tgz#4b5bfff9186effbaa888e4c9e94bd9fc4c94929d",
+        "sha256": "df282243ed7839aead494e20c2289a14009dbcc79110f7087e5ff96475cadd8b",
+        "dest-filename": "uglify-js-1.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.6.4.tgz#65ea2fb3059c9394692f15fed87c2b36c16b9adf",
+        "sha256": "c10036b5fcdac9d34b8f17359b3f9626ea44890040bd7b398baabaaee78695a6",
+        "dest-filename": "uglify-js-2.6.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.5.tgz#4612c0c7baaee2ba7c487de4904ae122079f2ca8",
+        "sha256": "720a171a0e743a00ab012900c208942b6b84bfd57775df54d513b6d844eaea1e",
+        "dest-filename": "uglify-js-2.7.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd",
+        "sha256": "dfb27e7004eafe33ec1b228785ff73a197e68c183749ec5e32f55254a9a7e021",
+        "dest-filename": "uglify-js-2.8.29.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.0.tgz#14b854003386b7a7c045910f43afbc96d2aa5307",
+        "sha512": "3c2fde7b8e7c3443084ded4eb9f0236a5eb98ba941e7c4751d6311731c2f773d54a295b40d8aa544bdf176edc8713bd35ec074d82447ca489d91344bf80de140",
+        "dest-filename": "uglify-js-3.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7",
+        "sha256": "e78538eb306ac63a5d42145d91e21e40c921487157afacecf7310cd9a9e025c2",
+        "dest-filename": "uglify-to-browserify-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81",
+        "sha256": "409e8ad409e79122539f440ae0bb2e494453e7584edeb5907d2c64d3a8eb8544",
+        "dest-filename": "uid-number-0.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uid2/-/uid2-0.0.3.tgz#483126e11774df2f71b8b639dcd799c376162b82",
+        "sha1": "483126e11774df2f71b8b639dcd799c376162b82",
+        "dest-filename": "uid2-0.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa",
+        "sha256": "c7d0a71ce1a07165dda424fabaf5efb151c86dc4d9d7619892310e817137d414",
+        "dest-filename": "ultron-1.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10481,6 +23256,55 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa",
+        "sha256": "6bbaa9a0f445290ffceac14be915b25526732cd782ff27a4bed93984c35590f1",
+        "dest-filename": "unc-path-regex-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.1.1.tgz#458397799114b9b67f6030bb527b0afae689c061",
+        "sha256": "86b4045eee6e04e8ffb100a8aaa5d4c195e936ccf9d34cef5b48c4a26e47e8d7",
+        "dest-filename": "underscore.string-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.2.1.tgz#d7c0fa2af5d5a1a67f4253daee98132e733f0f19",
+        "sha256": "2013a0849f07d495e9ccfbebc84ccd5f04561c0f32347ba83eac99539967429c",
+        "dest-filename": "underscore.string-2.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.3.3.tgz#71c08bf6b428b1133f37e78fa3a21c82f7329b0d",
+        "sha256": "7a62d2f69a2214b8be5482950bd96c2794e890cf480823943c69537af01fe71d",
+        "dest-filename": "underscore.string-2.3.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b",
+        "sha256": "bef71ecb4ccab2bd38ee46fa6463b11de6f4dea89e41c5bc2f6adb59b0ed59b9",
+        "dest-filename": "underscore.string-2.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.0.3.tgz#4617b8c1a250cf6e5064fbbb363d0fa96cf14552",
+        "sha256": "1ce6cb6bed5f5f4612bbc6e00991ecfb023f533811de9fb07ef482a061d0e174",
+        "dest-filename": "underscore.string-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/underscore/-/underscore-1.2.4.tgz#e8da6241aa06f64df2473bb2590b8c17c84c3c7e",
+        "sha256": "da204be1206f72d0ed1e63fdc63460c0b20a5274a18e4d213ecef2bc9eddad9b",
+        "dest-filename": "underscore-1.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8",
         "sha1": "8b38b10cacdef63337b8b24e4ff86d45aea529a8",
         "dest-filename": "underscore-1.6.0.tgz",
@@ -10488,9 +23312,100 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209",
+        "sha256": "f31eb2e0351d4e2439c038ad040498fdb948a513b0d6f1f9bbe32b28b7b2c275",
+        "dest-filename": "underscore-1.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617",
+        "sha512": "26508c3be7a174420aaa517193a21f568014566833edc53bcc3fe1f57674ab37a8b121e650954ecd242fbd84985979055c2f887cb29221f7e1bf4b1566ea7aa4",
+        "dest-filename": "undici-types-5.26.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818",
+        "sha512": "8c3acd9d7587778a07893667c7f646ee0b544d5a7e8027134caafc2f41e3970a6144e116dfe1e29be229bc2fb17091057a06a988c67265ed360b2b8e9d199b9d",
+        "dest-filename": "unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unicode-length/-/unicode-length-1.0.3.tgz#5ada7a7fed51841a418a328cf149478ac8358abb",
+        "sha256": "5669dbad94eced784a1c9e7b9fa20212fae4cdb8da5cf2a05be6af9b90c629e4",
+        "dest-filename": "unicode-length-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz#8ed2a32569961bce9227d09cd3ffbb8fed5f020c",
+        "sha512": "2f8428875e6f4df9edb27e0fd73aa71ee946d0b75782348ed37e5f12976da7a6315e1313e7543abe0339958746ff95f73234be93f63d5f0e1214263d224474ae",
+        "dest-filename": "unicode-match-property-ecmascript-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz#5b4b426e08d13a80365e0d657ac7a6c1ec46a277",
+        "sha512": "8434c7bda064dd1985cef4a5d1456b5260b73ee5bdc0a567a68503607d090e4488a2fcf0f89e6f89099e607c55481a6db9b9ebecf6c7d9ed1f9e90d1427425e6",
+        "dest-filename": "unicode-match-property-value-ecmascript-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57",
+        "sha512": "2f9440a827d7a80c11dd1ae217ca4cd25534c384727ff1a0cce3708ba2a72f5b5a2506bbc754c2c5d26720b5f9f562063b0479ec85719fb35e8f47f3d4dcba7f",
+        "dest-filename": "unicode-property-aliases-ecmascript-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4",
         "sha1": "5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4",
         "dest-filename": "union-value-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847",
+        "sha512": "b497d79b131e5989dccc256ced7004bc857b89ea6900b7727a958c90793072246966b686ff1c13facd8937cfa9af5fbc8c245ff34145cefafe32941e7a81785e",
+        "dest-filename": "union-value-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unique-filename/-/unique-filename-3.0.0.tgz#48ba7a5a16849f5080d26c760c86cf5cf05770ea",
+        "sha512": "69f5e1b82e79c240266743f5f10b1513a929f096b1ac4a243761c6228215bf68a31d0778d7d1f4fba12280015c2335de30891c224341a41dcbfc35c1ddc4d2fe",
+        "dest-filename": "unique-filename-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unique-slug/-/unique-slug-4.0.0.tgz#6bae6bb16be91351badd24cdce741f892a6532e3",
+        "sha512": "5ab700e80c847ea0d7e5b5a281eff83507cf64cb4048d571766591efa584498415000092816711e9ef62d26a1faaa071605b4be280313c8a6d63bdffd181350d",
+        "dest-filename": "unique-slug-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unique-stream/-/unique-stream-1.0.0.tgz#d59a4a75427447d9aa6c91e70263f8d26a4b104b",
+        "sha256": "db6c9d91735ea7753568284a5ecbc96f32d76d676ff3b27c62c8880c1dd20e6d",
+        "dest-filename": "unique-stream-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a",
+        "sha1": "9e1057cca851abb93398f8b33ae187b99caec11a",
+        "dest-filename": "unique-string-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz#6dce95b2681ca003eebfb304a415f9cbabcc5385",
+        "sha1": "6dce95b2681ca003eebfb304a415f9cbabcc5385",
+        "dest-filename": "unique-temp-dir-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10523,8 +23438,22 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d",
+        "sha512": "829b4735082120d9dcfef4c6224d12385185357c3b255ae5454b42a2725196f6b0e83b97d303b925e928f6c5ab301861f8fb18019ee85c088e9dffd42a88328b",
+        "dest-filename": "universalify-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec",
         "sha1": "b2bf4ee8514aae6165b4817829d21b2ef49904ec",
+        "dest-filename": "unpipe-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec",
+        "sha256": "2dfb5e06d1d4bf1fe9f0fa7f633c4a2fde04d8b41cf0b9bd249a42561d5edfb6",
         "dest-filename": "unpipe-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
@@ -10558,6 +23487,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97",
+        "sha1": "d2f0f737d16b0615e72a6935ed04214572d56f97",
+        "dest-filename": "unzip-response-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz#3c5e4f5c083661bd38ef64b6328c26ed6c8248c4",
         "sha512": "c5e6cff3548d70fb8da4f3f7bb3796d4d617c48debc72273177a43eac1f88c4ee8fc85fe5ad4a9c27554faa22c0cfca4d1dde198543b9a3a9ce80b55eb4e216e",
         "dest-filename": "update-browserslist-db-1.0.13.tgz",
@@ -10572,9 +23508,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6",
+        "sha512": "83031d8602471ae8fffb01c926cf5ee8f702b33a714756f6dfa8a0ace914a1f1a1a89b86f9a9a520ac00a47d485b559697ba2f671b17e3d94c0562f149d9b90f",
+        "dest-filename": "update-notifier-2.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/update-notifier/-/update-notifier-3.0.1.tgz#78ecb68b915e2fd1be9f767f6e298ce87b736250",
+        "sha512": "82bae6ac1e996fc0d48b20c869e4530429202126148044cd7bb3609446d5b2b2d65de1129e50923f9d167d14a3fc69b330f97a51c863db84bfa7cd273ff650ad",
+        "dest-filename": "update-notifier-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0",
+        "sha256": "fa2e3a0fdbe0ab9dc82cefdb424370fac52ded8d412bbd51d655aa24716df7ae",
+        "dest-filename": "uri-js-4.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0",
         "sha512": "298f45ae68abaa5f755f64208ebcb459de18f984ddadd661792f13170be46cb59ffc6e4a3490c287aa4a2f939972d116e3ed0169ae6274ad9942e10b4703f39d",
         "dest-filename": "uri-js-4.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uri-path/-/uri-path-1.0.0.tgz#9747f018358933c31de0fccfd82d138e67262e32",
+        "sha256": "6d02c481a1278d06c724ae060b86beb9a323e22fb2235d982becfdb6a76d4450",
+        "dest-filename": "uri-path-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10586,6 +23550,41 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7",
+        "sha512": "8e4d7e40fe9926ac8e8ae108f4011641f8eefe70763f0e3aea46c0d0b1199631f029e32077d5ab0048041b18cf0c3dbe4cd6db6f7eeb4f28447eb0977ee2979c",
+        "dest-filename": "url-join-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73",
+        "sha1": "7af8f303645e9bd79a272e7a14ac68bc0609da73",
+        "dest-filename": "url-parse-lax-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c",
+        "sha1": "16b5cafc07dbe3676c1b1999177823d6503acb0c",
+        "dest-filename": "url-parse-lax-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/url-parse/-/url-parse-1.0.5.tgz#0854860422afdcfefeb6c965c662d4800169927b",
+        "sha256": "5e9630074c9d93e40a49ad4356a1310eea5e6c893afa02126015eac51437b723",
+        "dest-filename": "url-parse-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/url-parse/-/url-parse-1.2.0.tgz#3a19e8aaa6d023ddd27dcc44cb4fc8f7fec23986",
+        "sha256": "69d4c22895a7c733371989ecb81ae2cfa10819e93e056f636ba8a695b034cdc2",
+        "dest-filename": "url-parse-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1",
         "sha512": "5b2a5c7e24617de50ff6fbc5d23eabc3427786b5abc3a899bf7fb6da1ea244c27ff33d538fa5df2cfe03b148b1e4c84c3e75e98870e82b2a19fdb74293004289",
         "dest-filename": "url-parse-1.5.10.tgz",
@@ -10593,9 +23592,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21",
+        "sha1": "fc565a3cccbff7730c775f5641f9555791439f21",
+        "dest-filename": "url-template-2.0.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1",
+        "sha256": "bc4e2a3ad68ea88e1ad619bd475152f9ae972eaadae94912a729d867dc9356e6",
+        "dest-filename": "url-0.11.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f",
+        "sha1": "892fe95960805e85519f1cd4389f2cb4cbb7652f",
+        "dest-filename": "urlgrey-0.4.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/use/-/use-2.0.2.tgz#ae28a0d72f93bf22422a18a2e379993112dec8e8",
         "sha1": "ae28a0d72f93bf22422a18a2e379993112dec8e8",
         "dest-filename": "use-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f",
+        "sha512": "73011255794edeeae5f585a5156fd303d72c842121b6eec8289fe9e6ca09fe01a98fbbdbbc5ac063f7888a843a0f0db72a3661620888a3c1ceb359d0dafaffa1",
+        "dest-filename": "use-3.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190",
+        "sha256": "8e2428d84ca5211864ad9ac4b91756570fa5be90f56e2b0e2dbb67d535e78d92",
+        "dest-filename": "user-home-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f",
+        "sha256": "256ad7d378093fde4a115d4ac7777b6b062be45cd8b428a93e222b10a564f713",
+        "dest-filename": "user-home-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/useragent/-/useragent-2.3.0.tgz#217f943ad540cb2128658ab23fc960f6a88c9972",
+        "sha256": "ba2de49984a91ff248066b67f9386558f861cf1ce62c4ff873e1274d0fd8f010",
+        "dest-filename": "useragent-2.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10622,6 +23670,13 @@
     {
         "type": "file",
         "url": "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+        "sha256": "79a1de983c1b393180c47456d6b73caab278a00ea6e37d5c6675f2dcdec2a3e5",
+        "dest-filename": "util-deprecate-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf",
         "sha512": "10f0f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73",
         "dest-filename": "util-deprecate-1.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
@@ -10631,6 +23686,13 @@
         "url": "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz#a7c216d267545169637b3b6edc6ca9119e2ff93f",
         "sha1": "a7c216d267545169637b3b6edc6ca9119e2ff93f",
         "dest-filename": "util-extend-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9",
+        "sha256": "88033ac0a981b3c3919d7bf21e9808d0a2903c331688e4122bdd32eeea3dd6d0",
+        "dest-filename": "util-0.10.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10649,9 +23711,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713",
+        "sha256": "ded95d8fedda75712b7282073ee7e5b7359646d3f6cd4b1ed3b0ddfe5dae5036",
+        "dest-filename": "utils-merge-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04",
         "sha512": "0c85adcd4930d383389376dfd487294b6b6781710bdba6140f6334b4c0d4a6752bcf6860cd40650f9e5ae058dd2c63ef7c7c52eae96e196bda544aa005c55afa",
         "dest-filename": "uuid-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14",
+        "sha256": "917d0c22a3268506a2b5061722916aa3982497ee5e879ade8f726e14324f0664",
+        "dest-filename": "uuid-3.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131",
+        "sha256": "505f8ff9b83df6853deaf3b04852a48e9845963be04d4605313c6cabf8b4ee68",
+        "dest-filename": "uuid-3.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866",
+        "sha512": "a56d0da354461e0ce5a4724ed67b15ac72a9384231906835c41fafd1999d347e4e01e030cc056b0a7236ffa32dc7e532b3a89aca5c5af83de0e23eb720a2a349",
+        "dest-filename": "uuid-3.3.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10663,9 +23753,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e",
+        "sha512": "bac6414f73d6f8b3a3336e706ea2256703de255fb7392cf73359355acf2c9e55b7f5d67260bf653860b91603d51df9348ca9a388357c6749886d540f8b016cee",
+        "dest-filename": "v8-compile-cache-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz#77b752fd3975e31bbcef938f85e9bd1c7a8d60ed",
+        "sha512": "146b4ab6fdf122947a05886f807f0c23fcbbf284fb77c02edf0c38408c729ab0ad6448796fc802c36b22cb013ea6e8449ae58a0ed99faef179525076f7cbaddf",
+        "dest-filename": "v8-to-istanbul-8.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz#2ed7644a245cddd83d4e087b9b33b3e62dfd10ad",
         "sha512": "fc41ffb03831536786c5a8ca7702c20e6438156abe9298b7b829811a9c35c49b67031123943f23f0f122196a4220c22cddc88d0201f47774d3262524633c998c",
         "dest-filename": "v8-to-istanbul-9.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4",
+        "sha256": "363990d5b6b3d92d8b73551c44b3ca3b278662d60216a3b27a1a182b9c3c9d44",
+        "dest-filename": "v8flags-2.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10677,6 +23788,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338",
+        "sha256": "b5a756da95e66bc26a5788d4369fcda2eca411e3e14bf10792372e2c8f3f542b",
+        "dest-filename": "validate-npm-package-license-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a",
+        "sha512": "0e92a6d948bfc4deff1d0282b69671a11581859f59d24aadca01bc5c280d43c6650e7c6e4265a18f9eba8fc7cde02bb7fc999b86c0e8edf70026ae2cf61dbb13",
+        "dest-filename": "validate-npm-package-license-3.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/vargs/-/vargs-0.1.0.tgz#6b6184da6520cc3204ce1b407cac26d92609ebff",
+        "sha256": "201532a1242f43cfc6b73068cc97fc743f432fd5af1b78e6bf209a7da4a52cdf",
+        "dest-filename": "vargs-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc",
         "sha1": "2299f02c6ded30d4a5961b0b9f74524a18f634fc",
         "dest-filename": "vary-1.1.2.tgz",
@@ -10684,9 +23816,58 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc",
+        "sha256": "7378860671377a35e7a443ecfdca0745cfd066f595c90d581b827defea246e71",
+        "dest-filename": "vary-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400",
+        "sha256": "019b4544dc60b21b7f325205967d0aafb72c618570499933ed25e16d0d799e6b",
+        "dest-filename": "verror-1.10.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/verror/-/verror-1.10.1.tgz#4bf09eeccf4563b109ed4b3d458380c972b0cdeb",
         "sha512": "bdeb9f726c6b8b87b75d2ad3d31c1f511ee482e2246b105ea2c0e0d34c835a1938f7077091252bbefb26ee773be5ed4f532bc87998fa9d2f15411633dbf4b85e",
         "dest-filename": "verror-1.10.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-0.3.14.tgz#9a6851ce1cac1c1cea5fe86c0931d620c2cfa9e6",
+        "sha256": "8719f1625e98dae791a04a872a4eef75fa24f5edbc6efe29990863705ad38376",
+        "dest-filename": "vinyl-fs-0.3.14.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/vinyl/-/vinyl-0.4.6.tgz#2f356c87a550a255461f36bbeb2a5ba8bf784847",
+        "sha256": "de776d9bda3f8066469a16164dfbcf60e4fd5e7b326ae8ecf15c2332f8d82d5f",
+        "dest-filename": "vinyl-0.4.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/vinyl/-/vinyl-0.5.3.tgz#b0455b38fc5e0cf30d4325132e461970c2091cde",
+        "sha256": "2a518effa84f0a747a7d62c45c4f6311ed34549206fc2741cfd7275a9a5b16da",
+        "dest-filename": "vinyl-0.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73",
+        "sha256": "a9b1f579eb4096ec3535cceae251f24c26a122c82844e98551b57c634d1b1e73",
+        "dest-filename": "vm-browserify-0.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec",
+        "sha256": "ac0f8137b7d1bc397ee427dcccf24b10a9b29dc79abda6e3927ad3242c5c9932",
+        "dest-filename": "void-elements-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10726,9 +23907,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd",
+        "sha512": "cfc3f90ef0cd8ca0e81481caeeaf2bf2569c913ea5fa3a3f61edc73a57bb97d9c808ff657f50a2db97f2f6f1ddd093967b09081735c81228374dd293ec94397d",
+        "dest-filename": "w3c-hr-time-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz#3e7104a05b75146cc60f564380b7f683acf1020a",
+        "sha512": "e2dcc3d2617c89288c88db37d0188b3b71297c62d9513d8c497fc6fa8ed9cb00f3962590dce3ed4d9d0f4c2dc1ddc6b55007f870930707ed817f9e84ae226e44",
+        "dest-filename": "w3c-xmlserializer-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz#aebdc84920d806222936e3cdce408e32488a3073",
         "sha512": "77e0451f36e20b1eb319fcf41f243a460ebdc3d935f67be226ca5a8f8c8db1c1a3ac7bbde2c54ff9a466ef9c846c287eaf6ff247eeeaea1bb1f4b56d6ee4c607",
         "dest-filename": "w3c-xmlserializer-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb",
+        "sha1": "2f7f9b8fd10d677262b18a884e28d19618e028fb",
+        "dest-filename": "walker-1.0.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10747,6 +23949,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/watchpack/-/watchpack-0.2.9.tgz#62eaa4ab5e5ba35fdfc018275626e3c0f5e3fb0b",
+        "sha256": "7474bb55f8daed80881d84601e762a82105b5e1eb72d760cddc6f80f6154cee0",
+        "dest-filename": "watchpack-0.2.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d",
         "sha512": "2dcbe6ecc1924ffe1fba9fa27f22a2da18f2200c1c748e07460b6f4e9214c4146107e445b5487c5ed0cec547dcb550a78558be4108f8f62f753b2bf390997a72",
         "dest-filename": "watchpack-2.4.0.tgz",
@@ -10754,9 +23963,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8",
+        "sha1": "f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8",
+        "dest-filename": "wcwidth-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wd/-/wd-0.3.12.tgz#3fb4f1d759f8c85dde5393d17334ffe03e9bb329",
+        "sha256": "0d38209cf0cc354dd5b1b81ee13cf4b9c5724685d821d22d6331af1097cadabd",
+        "dest-filename": "wd-0.3.12.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871",
         "sha512": "d89027df3f0047aae32bc4a6f28ad10b487f6dc97f0ea2fbb513dd199e08d428dd17e11a30b998c411f25ee28bf38f5eb9c3c586f068c4cb1f95f39bf24c5a79",
         "dest-filename": "webidl-conversions-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff",
+        "sha512": "56567028f0a460ac5081e49b1f91329e03a6469ed6c3b23dad02c44444ed7f9a1f77da467acc1688eb6882910ef39d23ce23d16abade1b19f9408893aa96f6c0",
+        "dest-filename": "webidl-conversions-5.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514",
+        "sha512": "a8122f14b1a20692e37f099801a1cf5ec9fe868e716671afc86bec6abcb018d73c57240950c1c9f0e04a186acf111d2890178c0da6a7e263419600513b1b88f3",
+        "dest-filename": "webidl-conversions-6.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10775,9 +24012,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack-core/-/webpack-core-0.6.9.tgz#fc571588c8558da77be9efb6debdc5a3b172bdc2",
+        "sha256": "7952b65e25d3b308f1328ec9ba2cee301673fc2a3a33438a5e48be515afa642f",
+        "dest-filename": "webpack-core-0.6.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz#f8fc1120ce3b4fc5680ceecb43d777966b21105e",
+        "sha256": "3baf21035f0a3315ecae8b637138dcb2896773a11058a6f1224ae620a9155b1a",
+        "dest-filename": "webpack-dev-middleware-1.12.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz#eb7b39281cbce10e104eb2b8bf2b63fce49a3517",
         "sha512": "055753aa186cfb421fa1e01fec4a07e5613e7b10a6a867ab1df0ccd082f4f7a3f1eb44ead8c9fd3006e768651ee8788c6b8d4a302605d7d832cd998172afe8e1",
         "dest-filename": "webpack-dev-middleware-5.3.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz#0cbd5f2d2ac8d4e593aacd5c9702e7bbd5e59892",
+        "sha256": "1aa52da4d32ddbd0842cb8280f59a9e9fda7058153441317a73d52990625da3c",
+        "dest-filename": "webpack-dev-server-1.16.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10810,6 +24068,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack/-/webpack-1.15.0.tgz#4ff31f53db03339e55164a9d468ee0324968fe98",
+        "sha256": "7c180abb39a97678b3ef150d77c1d9f32b48ef11b9dc29f7bc4f5c2b81230bd6",
+        "dest-filename": "webpack-1.15.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/webpack/-/webpack-5.76.0.tgz#f9fb9fb8c4a7dbdcd0d56a98e56b8a942ee2692c",
         "sha512": "979b0e758043ba7c9fef61d6f1d176deb16d5aaffb660bedffd7ed3287fbd44ff251bd582ce0664e00362b8bd0b61077928b4cad28fad3db71544d1d9ebd9f8c",
         "dest-filename": "webpack-5.76.0.tgz",
@@ -10817,9 +24082,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.0.tgz#0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb",
+        "sha256": "fa885b10ec14538471c1cf043ade6eab2dc5f5992d9523a860fc10dfdc6ae194",
+        "dest-filename": "websocket-driver-0.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29",
+        "sha256": "45116a661447dd0ff1730e5e443cef2b0af89e1d702add5df2a3d311411705b5",
+        "dest-filename": "websocket-extensions-0.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/well-known-symbols/-/well-known-symbols-2.0.0.tgz#e9c7c07dbd132b7b84212c8174391ec1f9871ba5",
+        "sha512": "64c8c2de1a3e297a3405f25bec982d439201baf9d285d94008d90a91db2a066630ddb3c06897cf798528ead2d4693e6d1bf1a487bc64a4184a450f5eee9ca0f5",
+        "dest-filename": "well-known-symbols-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0",
+        "sha512": "6f99629b9e0938f37d1edcef2bd1c55ef0666bfae77c57aab22734852a63b436d5c51ddd24a2dcf8a07857a1a08863af97b098fca361f2bc52a3d0ca42b9d413",
+        "dest-filename": "whatwg-encoding-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53",
         "sha512": "a78d6883278c52bc378d67251d64d0835934e434955cf2dc57145362c5d493e668a0e0992dca1880f67f1cbfc3fcdfae40f3ad729d667b55a1044697d369a15a",
         "dest-filename": "whatwg-encoding-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf",
+        "sha512": "338c8cc2bea6027433efa4db266f75e3e80fa41fe70b0bd96c9536f1c503e9d474d38480c432ce39251a07524346a2ed68e57fbe2d080b9944006160ae31affe",
+        "dest-filename": "whatwg-mimetype-2.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10845,6 +24145,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.2.2.tgz#85e7f9795108b53d554cec640b2e8aee2a0d4bfd",
+        "sha512": "3dc5673ba3627b08649b3574aa7ec0f9467d5f1e2668d4c8f8ef934a199f138a6a8e808cc1432392fa0d84d1cf4ef811ed01fd5eddd1d77887b96cb6b13a05c5",
+        "dest-filename": "whatwg-url-8.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.7.0.tgz#656a78e510ff8f3937bc0bcbe9f5c0ac35941b77",
+        "sha512": "800a23a9bfe6f50f1ae4857de84ddf1c933bd00cc2920b78b97617d8eec49aec8e9cbad5882425b0406617d51022edff69e008a76535eebb5ba5958d9ed42a76",
+        "dest-filename": "whatwg-url-8.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6",
         "sha512": "6f065dbf400a2e9a65158d8a6515fa4efcae37ba238ebee5c2483a9a5d2ba08cbd61eb92afb252dfbdaa94d5b5f14418ce060af7388671ead6a993a6127f5536",
         "dest-filename": "which-boxed-primitive-1.0.2.tgz",
@@ -10862,6 +24176,20 @@
         "url": "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.1.tgz#70eab71ebbbd2aefaf32f917082fc62cdcb70906",
         "sha512": "5bcc5e4d4c1a967f22dcafdc6359c65f376755996274171a832345b41743e64c676f84ef18a47b15f4884b7998a70592d50502bad7cacfc218f118dfb41d3ed4",
         "dest-filename": "which-collection-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
+        "sha1": "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
+        "dest-filename": "which-module-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
+        "sha256": "4fbf12fbe1ebf9360acf140231a7ee2156298058b8166f53df1302109f1028ea",
+        "dest-filename": "which-module-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10887,6 +24215,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/which/-/which-1.0.9.tgz#460c1da0f810103d0321a9b633af9e575e64486f",
+        "sha256": "008a7368f5531859a4d6aab74e24d6f539253edcd673ae0274414264be7bb818",
+        "dest-filename": "which-1.0.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5",
+        "sha256": "77ab19c8038c33c0db183de0b97e8c706cde24c26b8740376ace45e6148aece7",
+        "dest-filename": "which-1.2.14.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a",
+        "sha256": "87a8ce7e58c6a00b6440c2539a4e1da82f247990c546a93478a900a79fa30512",
+        "dest-filename": "which-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a",
         "sha512": "1f125d616ab53132106c9de7c3472ab2c1e84cd536ebb2a5ac3b866755989710d2b54b4a52139a266875d76fd36661f1c547ee26a3d748e9bbb43c9ab3439221",
         "dest-filename": "which-1.3.1.tgz",
@@ -10901,9 +24250,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/which/-/which-4.0.0.tgz#cd60b5e74503a3fbcfbf6cd6b4138a8bae644c1a",
+        "sha512": "1a5698c846f4ec33f16022a12b3a65096049b6fc5971932b2fee1492b4d22471cfc99538998613bf7a9a39eefb1fb10e0cb492a2901414073a5bc538caabec72",
+        "dest-filename": "which-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710",
+        "sha256": "e1538f1c765d5151940c93196b6d151300805666fd5e8eaaba65fa7747e47615",
+        "dest-filename": "wide-align-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457",
+        "sha256": "7da7041b2b221dd750e17f2c01c92d24439c5792876d672875d6412130dbb0f5",
+        "dest-filename": "wide-align-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457",
         "sha512": "40690e41cf172fa06de4fc27b04c4a04fb8c281c671b15965b77d4e795ede1f787a3331485d50c6810a4dbdd2aa66ff01b9bbf4522b3c1d002e22e7562282284",
         "dest-filename": "wide-align-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3",
+        "sha512": "78330e45868f359e2c408bae60f0c7750bdfe20c8217dac4115ff23f119fc0f911a1dc048223145174f1fdd7b1f8c7b4c31c79dd2f8d8141da3fbcb73069439a",
+        "dest-filename": "wide-align-1.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz#7438764730ec7ef4381ce4df82fb98a53142a3fc",
+        "sha512": "05ae66f7f15ae17b7d79bd842d7b7bec9c550d5f30eea42b1f4cd2fd359225d2f20304235a83b3a738f997055fb43cfa9ff10ebb7b4d0024bce2fe74f6ac2724",
+        "dest-filename": "widest-line-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10922,9 +24306,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d",
+        "sha256": "8399b671dd219a0a3ae828db810ed9d5ba7454731d91700b2afb4311813322e9",
+        "dest-filename": "window-size-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.5.0.tgz#6e7b0dd04d393171ed5e4e4905db265f7ab384fa",
         "sha512": "629673714cc179d8654c07c983abc90e5c846a2fc814c21571a119672977517225e209aa46953b004f3d0072e46f32d4b2fd0d566c3bb6cfa2ceda8ac713d6d5",
         "dest-filename": "winston-transport-4.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/winston/-/winston-0.5.11.tgz#9d84ead981a497a92ddf76616137abef661c414f",
+        "sha256": "7a2ca76f21d7abd7a39789b7b32587366378a3d28e861eb7f1a182c644934cec",
+        "dest-filename": "winston-0.5.11.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10936,9 +24334,44 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c",
+        "sha512": "1f3fe6acdc22b4d461fc7500b4cfd54ffe551feca00fa0d5ee660a640b473ab6ecf14ee5bcf4bac5fec424a305d2e5b52890a5d07ef4d60dd91aeb3e9ae139bd",
+        "dest-filename": "word-wrap-1.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34",
         "sha512": "04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970",
         "dest-filename": "word-wrap-1.2.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f",
+        "sha256": "66a2fa688509738922c3ad62a6159fe3c93268bd3bca2bff24df4bc02cc31582",
+        "dest-filename": "wordwrap-0.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107",
+        "sha1": "a3d5da6cd5c0bc0008d37234bbaf1bed63059107",
+        "dest-filename": "wordwrap-0.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107",
+        "sha256": "419fcd999c644377c678ea8315aacf9bda442cd75bdfa50aee3918dd917ae274",
+        "dest-filename": "wordwrap-0.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb",
+        "sha256": "c381f669202164c6495d22e7c2ed92f04ce4742c2770e5043c296ab3de780838",
+        "dest-filename": "wordwrap-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10950,9 +24383,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85",
+        "sha256": "4e9c683a8ddd125984393f2c2cc014037483458a863c00bfcba7429dd8123490",
+        "dest-filename": "wrap-ansi-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09",
+        "sha512": "402d7f88dff6fd13d52798d82bc046b6d8f9cfcdcb9922a6bdbbeb5cf3422d94846f7d8a2950c90e5fcc3add8dd35a94d87fc593311af4f2ada3506a0e3b5ded",
+        "dest-filename": "wrap-ansi-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43",
         "sha512": "6151888f691a98b493c70e8db198e80717d2c2c9f4c9c75eb26738a7e436d5ce733ee675a65f8d7f155dc4fb5d1ef98d54e43a5d2606e0052dcadfc58bb0f5e9",
         "dest-filename": "wrap-ansi-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214",
+        "sha512": "b22ed0588eb350cab9e9b11216f6a0b66ccc7463ada317d1f927b3d753286df73bb66f9591472493d6d6d9479f7d319551b3a4b31992c34000da0b3c83bd4d09",
+        "dest-filename": "wrap-ansi-8.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10964,6 +24418,48 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+        "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb",
+        "dest-filename": "wrappy-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f",
+        "sha256": "b160197ef3743c2316c5d1f89096d686902d17bb83c577ee04a684f59f45bb56",
+        "dest-filename": "write-file-atomic-1.3.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab",
+        "sha256": "5ab6c1266e42778270afded2a32d959295c32cb13a4b98609dcb4c99d4db1be5",
+        "dest-filename": "write-file-atomic-2.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481",
+        "sha512": "19a1131f9c30b17f86727ce13e029c2a327a3360aadff899a755b263f5f5092aab5be8d534cf58ec3f040b6b0ce191bf57cc199529e226708a58f981600b9c45",
+        "dest-filename": "write-file-atomic-2.4.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.1.tgz#558328352e673b5bb192cf86500d60b230667d4b",
+        "sha512": "24f4adac8cb2549ea8092cffebdd5f02316d79f67aabe7cfead9be392e10c3aa3e4c6431369d73898d8f812f97fe6d15f0e5a16623bf9b8c528fe3ebe11ad9bf",
+        "dest-filename": "write-file-atomic-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8",
+        "sha512": "02f1dcc99e499d27eade2a12ca3ac1907f725b89bb03293cffd332fc30fda2729ebbff787f0acca1c7a63b64002450259e70cdf990d2f998c0479b9ad7f3d5fd",
+        "dest-filename": "write-file-atomic-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-4.0.2.tgz#a9df01ae5b77858a027fd2e80768ee433555fcfd",
         "sha512": "ecac5ab947419927569e6a5a18583ea69363285f2e34baf2f0bcb38dab900ce54e35f14b34aacabd03b167f56e4c8712fe081efd835a85fe512084164d26ab96",
         "dest-filename": "write-file-atomic-4.0.2.tgz",
@@ -10971,16 +24467,72 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ws/-/ws-7.5.8.tgz#ac2729881ab9e7cbaf8787fe3469a48c5c7f636a",
-        "sha512": "ae2d487755a29c05f926a9fd1de8e219bf1cadf462a34420bbcf8cb4bdfaae54c0e912ec31d5add40cffd7d0364228fab921d432984415a4ca6b8586f9434737",
-        "dest-filename": "ws-7.5.8.tgz",
+        "url": "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757",
+        "sha256": "864b20c94a532803a8616564fbb4caeace38197f7e87d66156a65f47a2e45a25",
+        "dest-filename": "write-0.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ws/-/ws-8.14.2.tgz#6c249a806eb2db7a20d26d51e7709eab7b2e6c7f",
-        "sha512": "c04046d5fb57e2372094fc60142309999d8f2ed49b2763de83a4e6a491536def466583900833dd318bbf4e6d3f6c6664c3ca5a667258e392782b63d9acb62af2",
-        "dest-filename": "ws-8.14.2.tgz",
+        "url": "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3",
+        "sha512": "fe583bd07023b6452058f559859726f93e2190bf196eda759c534e9f7951af19e5bf9d12441bfb711ed1a91f8632c7778545f2f61581a380874db15370e6308a",
+        "dest-filename": "write-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ws/-/ws-1.1.5.tgz#cbd9e6e75e09fc5d2c90015f21f0c40875e0dd51",
+        "sha256": "a1d42fb461fddced5dd130da7590493da0fbcf6ab2b33f897a2ed13ba97b06ee",
+        "dest-filename": "ws-1.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9",
+        "sha512": "f9d6c5d6d1f06695dc6ce25d54e9332c3c593f56a296f4b133a6707974de83294f9f2f34ddb16103ebea058c38b37d4d4809384b6433f802972bd6b8c2476371",
+        "dest-filename": "ws-7.5.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67",
+        "sha512": "28cbd5b85ce9281ba22175b7138bb79b24913b6fe60874b2643250339350f50f4a1d61d687434781f6d130b2eb71e50ae6a00be32b402c96e944c8e2c45661f0",
+        "dest-filename": "ws-7.5.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b",
+        "sha512": "e97405bd74e46df50e64e28a20b146d4f0cad8d0d0b386b3290976e93d184b90b1a962e05da8db3d9fa1e2065e909c91a8553ca6f9db01b6ecff74e044fcbe19",
+        "dest-filename": "ws-8.17.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a",
+        "sha256": "a9a483cc41fe701b8bb2075f7cfdab24f09b4b658ab828317c849552cd6e12ed",
+        "dest-filename": "wtf-8-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4",
+        "sha1": "496b2cc109eca8dbacfe2dc72b603c17c5870ad4",
+        "dest-filename": "xdg-basedir-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xml-escape/-/xml-escape-1.0.0.tgz#00963d697b2adf0c185c4e04e73174ba9b288eb2",
+        "sha256": "24e6bfa4f16827f5f28d5e366be797d950e215be07ca2f5f3a25fc4f22913cdf",
+        "dest-filename": "xml-escape-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a",
+        "sha512": "039094a6dc43b2fc4a244537c8ee83b96052273fea8b3ab324a38c21f5091c44db070fec15a0f181de9fc66d5ec1468cd23678e3815ce6f0b944e62eae0ff83f",
+        "dest-filename": "xml-name-validator-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11020,6 +24572,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz#185a888c04eca46c3e4070d99f7b49de3528992d",
+        "sha256": "61c6f024b1a96d4deac5a170ad2454ee73861a6013ea9ea84d65e917f6002ddf",
+        "dest-filename": "xmlhttprequest-ssl-1.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af",
         "sha1": "a5c6d532be656e23db820efb943a1f04998d63af",
         "dest-filename": "xtend-4.0.1.tgz",
@@ -11027,9 +24586,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af",
+        "sha256": "e8cf61040c95fcc1b6b707d76d54365fb646e8e7ac9bdf6e1f794e8790dfa872",
+        "dest-filename": "xtend-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54",
+        "sha512": "2ca614d620172575200179fd5118e2bbe3168725171ecbdfa7b99cb989bd75250a2b4fc28edad4c050310fcdbf98259bb4bb068c521a774c08b28778ceb4c011",
+        "dest-filename": "xtend-4.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/xvfb-maybe/-/xvfb-maybe-0.2.1.tgz#ed8cb132957b7848b439984c66f010ea7f24361b",
         "sha1": "ed8cb132957b7848b439984c66f010ea7f24361b",
         "dest-filename": "xvfb-maybe-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41",
+        "sha256": "4d7412e72d642106847b3caa8597a54b24178e3baaf406748d519d8b51462741",
+        "dest-filename": "y18n-3.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b",
+        "sha512": "afd4bf6725eefd7bbdab5b58969b0b22c6b711e2d75e4d15c25c6a4dc1517e0f4484c5bed7b91bb7d1b436b8029a119be6f4f687284964b7c31b1fbbfb9523ff",
+        "dest-filename": "y18n-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11055,6 +24642,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52",
+        "sha256": "c7b31084d3525e17314b46c28e58ceb6cd8f10a9ff926daf48303976f8acb0b2",
+        "dest-filename": "yallist-2.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9",
+        "sha256": "8a2159b63d07b3c5e2a1973f49abb49d1013c2e640f6e730c4ba9f8f2537e37d",
+        "dest-filename": "yallist-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd",
         "sha512": "6b850641a58f1f9f663975189c01b67b09dc412e22e05e374efdc9a0033eb365430264bd36c2bc1a90cc2eb0873e4b054fb8772ba4cea14367da96fb4685f1e2",
         "dest-filename": "yallist-3.1.1.tgz",
@@ -11069,9 +24670,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/yaml/-/yaml-2.4.2.tgz#7a2b30f2243a5fc299e1f14ca58d475ed4bc5362",
-        "sha512": "07756a0d9f89020d67669684996b535d49419dea06c7a08f33d6f44c434ae9aa12bb9b7bddd22db9dc1d8268bab4794865921de1d67db2470043651b73201e54",
-        "dest-filename": "yaml-2.4.2.tgz",
+        "url": "https://registry.yarnpkg.com/yaml/-/yaml-2.4.5.tgz#60630b206dd6d84df97003d33fc1ddf6296cca5e",
+        "sha512": "681c766e7a83cd53b234a7eccac8c0da6b396659e34805b6786dff2f91bf092ba37e32c94c9b04c356c6c3c9027f4e0aa1d416935a719469d9e7a091c626b09a",
+        "dest-filename": "yaml-2.4.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yapool/-/yapool-1.0.0.tgz#f693f29a315b50d9a9da2646a7a6645c96985b6a",
+        "sha256": "b058e3b0a76c38443354e369a558b1e24d061d4b9014ad3e0ddceba6595f48be",
+        "dest-filename": "yapool-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8",
+        "sha512": "542232475c09a0405952a9393c0fa838117aca96f087968d077239d20bb100bfeaba081d7ece13b4d1d0ad26b3140ddf619fad12a7ecd3320696fd1cfeb8236d",
+        "dest-filename": "yargs-parser-10.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0",
+        "sha512": "a15015b07cfab85ae0dd7421785208f0448edacb007fd96e5ae01de967b1b2ee05dceb485b4a3c22b89b3d762b0f8582db82d6b4fac9946cbcef2e6e74af9dc5",
+        "dest-filename": "yargs-parser-13.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11090,6 +24712,27 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950",
+        "sha256": "4f480401590bfddae52363966a24d885c0bd284585b8bc77f7b72ea8bdadb24a",
+        "dest-filename": "yargs-parser-8.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5",
+        "sha256": "c0c0a18eec2c0a730bebcc20ac3ecd01087a62f040882d11fbea7e79f0ea146a",
+        "dest-filename": "yargs-10.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83",
+        "sha512": "d9e7a1ba7ffc00b5bc4cba0897b31569152b83ec829de9eef01e240654718f7189183294d4e83bb0c5cf366d416323350ce2664d9e1878dfcdc31bfef1726c50",
+        "dest-filename": "yargs-13.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66",
         "sha512": "0f59afbed0c6d0be5fb7f8c65a42e91b5fa6d1e43139f681bd33442eb6968f6db049550c5b1654bd880961c2a1ea3186224245847e0864f4214784caa5cf2607",
         "dest-filename": "yargs-16.2.0.tgz",
@@ -11104,9 +24747,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1",
+        "sha256": "e9bd679ff3bdfd44206e4922cfad37a32eff796a201e814aa2da13ecb54fc37c",
+        "dest-filename": "yargs-3.10.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9",
         "sha1": "c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9",
         "dest-filename": "yauzl-2.10.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005",
+        "sha256": "d96661710bd6404d226e78e29d5595fe31ecdbfa1c2d4185f722b921edeca554",
+        "dest-filename": "yauzl-2.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419",
+        "sha256": "56b7a3ac8f6585bdd88e703fcb916b2be3d63d70eb4a25cd4592c50035908f3c",
+        "dest-filename": "yeast-0.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11124,10 +24788,17 @@
         "dest": "flatpak-node/yarn-mirror"
     },
     {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/zip-stream/-/zip-stream-0.5.2.tgz#32dcbc506d0dab4d21372625bd7ebaac3c2fff56",
+        "sha256": "ed41c79ac1cd22699dccf7d81d5471f20a4427b74dd89ec15d7ae5f4a6809332",
+        "dest-filename": "zip-stream-0.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
         "type": "inline",
         "contents": "9",
         "dest-filename": "installVersion",
-        "dest": "flatpak-node/cache/node-gyp/28.3.3"
+        "dest": "flatpak-node/cache/node-gyp/30.0.8"
     },
     {
         "type": "script",
@@ -11171,10 +24842,16 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv28.3.3electron-v28.3.3-linux-arm64.zip\"",
-            "ln -s \"../electron-v28.3.3-linux-arm64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv28.3.3electron-v28.3.3-linux-arm64.zip/electron-v28.3.3-linux-arm64.zip\"",
-            "mkdir -p \"ef33c1c1407eeea89775ef92a07226a7f3301c3466e8ffe69e5ee2998f876d40\"",
-            "ln -s \"../electron-v28.3.3-linux-arm64.zip\" \"ef33c1c1407eeea89775ef92a07226a7f3301c3466e8ffe69e5ee2998f876d40/electron-v28.3.3-linux-arm64.zip\""
+            "mkdir -p \"8835f4c1c633a224dbe42ed5e41c45971a828de023a26b63030f454d77d21c2f\"",
+            "ln -s \"../SHASUMS256.txt-30.0.8\" \"8835f4c1c633a224dbe42ed5e41c45971a828de023a26b63030f454d77d21c2f/SHASUMS256.txt\""
+        ],
+        "dest": "flatpak-node/cache/electron"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"8835f4c1c633a224dbe42ed5e41c45971a828de023a26b63030f454d77d21c2f\"",
+            "ln -s \"../electron-v30.0.8-linux-arm64.zip\" \"8835f4c1c633a224dbe42ed5e41c45971a828de023a26b63030f454d77d21c2f/electron-v30.0.8-linux-arm64.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -11184,10 +24861,8 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv28.3.3electron-v28.3.3-linux-armv7l.zip\"",
-            "ln -s \"../electron-v28.3.3-linux-armv7l.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv28.3.3electron-v28.3.3-linux-armv7l.zip/electron-v28.3.3-linux-armv7l.zip\"",
-            "mkdir -p \"ef33c1c1407eeea89775ef92a07226a7f3301c3466e8ffe69e5ee2998f876d40\"",
-            "ln -s \"../electron-v28.3.3-linux-armv7l.zip\" \"ef33c1c1407eeea89775ef92a07226a7f3301c3466e8ffe69e5ee2998f876d40/electron-v28.3.3-linux-armv7l.zip\""
+            "mkdir -p \"8835f4c1c633a224dbe42ed5e41c45971a828de023a26b63030f454d77d21c2f\"",
+            "ln -s \"../electron-v30.0.8-linux-armv7l.zip\" \"8835f4c1c633a224dbe42ed5e41c45971a828de023a26b63030f454d77d21c2f/electron-v30.0.8-linux-armv7l.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -11197,10 +24872,41 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv28.3.3electron-v28.3.3-linux-x64.zip\"",
-            "ln -s \"../electron-v28.3.3-linux-x64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv28.3.3electron-v28.3.3-linux-x64.zip/electron-v28.3.3-linux-x64.zip\"",
-            "mkdir -p \"ef33c1c1407eeea89775ef92a07226a7f3301c3466e8ffe69e5ee2998f876d40\"",
-            "ln -s \"../electron-v28.3.3-linux-x64.zip\" \"ef33c1c1407eeea89775ef92a07226a7f3301c3466e8ffe69e5ee2998f876d40/electron-v28.3.3-linux-x64.zip\""
+            "mkdir -p \"8835f4c1c633a224dbe42ed5e41c45971a828de023a26b63030f454d77d21c2f\"",
+            "ln -s \"../electron-v30.0.8-linux-x64.zip\" \"8835f4c1c633a224dbe42ed5e41c45971a828de023a26b63030f454d77d21c2f/electron-v30.0.8-linux-x64.zip\""
+        ],
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "x86_64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv30.0.8electron-v30.0.8-linux-arm64.zip\"",
+            "ln -s \"../electron-v30.0.8-linux-arm64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv30.0.8electron-v30.0.8-linux-arm64.zip/electron-v30.0.8-linux-arm64.zip\""
+        ],
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "aarch64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv30.0.8electron-v30.0.8-linux-armv7l.zip\"",
+            "ln -s \"../electron-v30.0.8-linux-armv7l.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv30.0.8electron-v30.0.8-linux-armv7l.zip/electron-v30.0.8-linux-armv7l.zip\""
+        ],
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "arm"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv30.0.8electron-v30.0.8-linux-x64.zip\"",
+            "ln -s \"../electron-v30.0.8-linux-x64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv30.0.8electron-v30.0.8-linux-x64.zip/electron-v30.0.8-linux-x64.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [

--- a/io.github.shiftey.Desktop.yaml
+++ b/io.github.shiftey.Desktop.yaml
@@ -1,8 +1,8 @@
 app-id: io.github.shiftey.Desktop
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: "24.08"
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: "24.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
@@ -44,7 +44,7 @@ modules:
     build-commands:
       - install -Dm755  node-gyp /app/bin
     cleanup:
-      - '*'
+      - "*"
     sources:
       - type: script
         dest-filename: node-gyp
@@ -62,9 +62,11 @@ modules:
         # Set the Electron cache directory.
         ELECTRON_CACHE: /run/build/github-desktop/flatpak-node/electron-cache
         # Skip Electron related downloads
-        ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
-        OFFLINE: '1'
-        CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
+        ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+        OFFLINE: "1"
+        CHROMEDRIVER_SKIP_DOWNLOAD: "true"
+        CFLAGS: "-fpermissive"
+        CXXFLAGS: "-fpermissive"
         # Use predownloaded dugite-native
         TMPDIR: /run/build/github-desktop/flatpak-node/tmp
         XDG_CACHE_HOME: /run/build/github-desktop/flatpak-node/cache
@@ -92,8 +94,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/shiftkey/desktop.git
-        tag: release-3.3.18-linux1
-        commit: 016e5dfab09885f497a73871a03e3670c3d78ba8
+        tag: release-3.4.3-linux1
+        commit: d60f652a5b506c64e920b17dbb9d77ab951c607c
         x-checker-data:
           type: git
           tag-pattern: release-(\d+\.\d+\.\d+-linux\d+)


### PR DESCRIPTION
this updates the runtime version and github desktop version. We have to use `-fpermissive` in the Cflags as `node-addon-api` expects different type signatures from node-headers(despite bringing in its own node headers as a dep) this honestly insane problem has lead needing fpermissive.