### PR TITLE
Add explicit gitconfig and GPG permissions

### DIFF
--- a/io.github.shiftey.Desktop.yaml
+++ b/io.github.shiftey.Desktop.yaml
@@ -20,7 +20,9 @@ finish-args:
   - --filesystem=host
   - --filesystem=/opt/:ro
   - --filesystem=/var/lib/flatpak/app:ro
+  - --filesystem=~/.gitconfig
   - --filesystem=xdg-run/keyring
+  - --filesystem=xdg-run/gnupg:ro
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.freedesktop.Notifications


### PR DESCRIPTION
This allows GPG signing to work as expected even if `filesystem=host` is revoked.