### PR TITLE
Add permissions section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ Permissions
 
 By default, this Flatpak requests the `filesystem=host` permission, granting it access to all files on your device. This allows immediate access to any project folders you wish to add, as well as enabling editor integration, and access to relevant Git config files and GPG information.
 
-However, system-wide filesystem access is not required for functionality, so security-conscious users may wish to revoke this permission and selectively allow access to directories, such as only allowing a specific folder where you store projects.
+However, system-wide filesystem access is not necessarily required for basic functionality, so security-conscious users may choose to revoke this permission and selectively allow access to directories, such as only allowing a specific folder where you store projects.
 
 In such case, if you wish to allow GPG signing to work properly, you should grant the Flatpak the permissions `filesystem=~/.gitconfig` and `filesystem=xdg-run/gnupg:ro` as well. If your gitconfig file is in a different location, grant access to that instead.
 
 If you want the editor integration to work properly, you will need to grant access to the location of your preferred editor. You can find the pre-defined list of where GitHub Desktop checks here: https://github.com/shiftkey/desktop/blob/linux/app/src/lib/editors/linux.ts#L18
+
+This section is here as a courtesy to save certain users some time, but it is not a supported usecase. Please only submit bug reports if you can verify that they occur with the standard `filesystem=host` permission.

--- a/README.md
+++ b/README.md
@@ -52,3 +52,14 @@ Known Issues
     This happens because the default manager is not set in your environment. You need to add a default file manager to your `~/.config/mimeapps.list` file. If you are using nautilus, this can be done by adding `inode/directory=org.gnome.Nautilus.desktop` to the end of the `[Default Applications]` section.
 
 - Git Hooks that spawn external programs do not work. This is non-fixable without a massive rewrite inside git to make it possible to spawn git hooks outside the flatpak container.
+
+Permissions
+-----------
+
+By default, this Flatpak requests the `filesystem=host` permission, granting it access to all files on your device. This allows immediate access to any project folders you wish to add, as well as enabling editor integration, and access to relevant Git config files and GPG information.
+
+However, system-wide filesystem access is not required for functionality, so security-conscious users may wish to revoke this permission and selectively allow access to directories, such as only allowing a specific folder where you store projects.
+
+In such case, if you wish to allow GPG signing to work properly, you should grant the Flatpak the permissions `filesystem=~/.gitconfig` and `filesystem=xdg-run/gnupg:ro` as well. If your gitconfig file is in a different location, grant access to that instead.
+
+If you want the editor integration to work properly, you will need to grant access to the location of your preferred editor. You can find the pre-defined list of where GitHub Desktop checks here: https://github.com/shiftkey/desktop/blob/linux/app/src/lib/editors/linux.ts#L18


### PR DESCRIPTION
Following up on the compromise proposed in #343 :smile:

These instructions inform people how to allow functionality with `filesystem=host` revoked, such as GPG signing and editor integration.